### PR TITLE
Don't import agents if they are on leave and 'import absents' checkbox not checked, check 'import absents' by default

### DIFF
--- a/planning/poste/fonctions.php
+++ b/planning/poste/fonctions.php
@@ -63,7 +63,7 @@ function cellule_poste($date, $debut, $fin, $colspan, $output, $poste, $site)
                 }
 
                 if ($elem['absent'] == 2) {
-                    $class_tmp[]="red-cel";
+                    $class_tmp[] = "out-of-work-time";
                     $title = 'En dehors de ses heures de présences';
                 }
 

--- a/themes/default/default.css
+++ b/themes/default/default.css
@@ -428,10 +428,8 @@ select
   color:red;
 }
 
-.red-cel {
-  background-color: red;
-  color: white;
-  font-weight: bold;
+.out-of-work-time {
+  color:red;
 }
 
 .orange{


### PR DESCRIPTION
MT 24616 : 
- Don't import agents if they are on leave and 'import absents' checkbox not checked
- Check 'import absents' by default
- Change CSS class cel-red to out-of-work-time
- Fix wrong marking of absences in plannings
