### PR TITLE
Demo mode

### DIFF
--- a/admin/config.php
+++ b/admin/config.php
@@ -36,7 +36,15 @@ $configParams = $entityManager->getRepository(ConfigParam::class)->findBy(
     array(), array('ordre' => 'ASC', 'id' => 'ASC')
 );
 
-if ($params && CSRFTokenOK($params['CSRFToken'], $_SESSION)) {
+
+// Demo mode
+if ($params && !empty($config['demo'])) {
+    $warning = "La modification de la configuration n'est pas autorisée sur la version de démonstration.";
+    $warning .= "#BR#Merci de votre compréhension";
+    $templates_params['warning'] = $warning;
+}
+elseif ($params && CSRFTokenOK($params['CSRFToken'], $_SESSION)) {
+    $templates_params['post'] = 1;
 
     foreach ($configParams as $cp) {
 

--- a/authentification.php
+++ b/authentification.php
@@ -160,6 +160,14 @@ EOD;
     <td><input type='password' name='password' /></td></tr>
     <tr><td colspan='2' align='center'><br/><input type='submit' class='ui-button' value='Valider' /></td></tr>
 EOD;
+
+    // Demo mode
+    if (!empty($config['demo'])) {
+        echo "<tr><td colspan='2' align='center'><p>Pour les essais, vous pouvez utiliser les identifiants suivants :<br/>\n";
+        echo "<br/>Utilisateur : admin<br/>Mot de passe : {$config['demo-password']}<br/><br/>\n";
+        echo "Attention : cette plateforme de tests est réinitialisée tous les dimanches.</p></td></tr>\n";
+    }
+
     if ($config['Auth-Anonyme']) {
         echo "<tr><td colspan='2' align='center'><br/><a href='index.php?login=anonyme'>Accès anonyme</a></td></tr>\n";
     }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
-        "apereo/phpCAS": "^1.3",
+        "apereo/phpcas": "^1.3",
         "phpmailer/phpmailer": ">=6.0.5",
         "symfony/http-foundation": "^3.4",
         "twig/twig": "^2.0",

--- a/personnel/index.php
+++ b/personnel/index.php
@@ -110,7 +110,7 @@ foreach ($agents as $agent) {
     echo "<tr><td style='white-space:nowrap;'>\n";
     echo "<input type='checkbox' name='chk$i' value='$id' />\n";
     echo "<a href='index.php?page=personnel/modif.php&amp;id=$id'><span class='pl-icon pl-icon-edit' title='Modifier'></span></a>";
-    if (in_array(21, $droits) and $id!=$_SESSION['login_id']) {
+    if (in_array(21, $droits) and $id!=$_SESSION['login_id'] and $id >1) {
         echo "<a href='javascript:popup(\"personnel/suppression.php&amp;id=".$id."\",450,240);'><span class='pl-icon pl-icon-drop' title='Supprimer'></span></a>";
     }
     echo "</td>";

--- a/personnel/suppression-liste.php
+++ b/personnel/suppression-liste.php
@@ -24,7 +24,10 @@ $CSRFToken = filter_input(INPUT_POST, 'CSRFToken', FILTER_SANITIZE_STRING);
 
 foreach ($post as $key => $value) {
     if (substr($key, 0, 3)=="chk") {
-        $liste[]=$value;
+        // Disallow admin deletion
+        if ($value != 1) {
+            $liste[]=$value;
+        }
     }
 }
 $liste=join($liste, ",");

--- a/personnel/suppression.php
+++ b/personnel/suppression.php
@@ -81,10 +81,19 @@ function etape2()
 function etape3()
 {
     global $id;
+
+    // Disalow admin deletion
+    if ($id == 1) {
+        $msg = "Le compte admin ne peut être supprimé !";
+        $msg = urlencode($msg);
+        echo "<script type='text/Javascript'>parent.location.href='index.php?page=personnel/index.php&msg=$msg&msgType=error';</script>\n";
+        return false;
+    }
+
     $CSRFToken = filter_input(INPUT_GET, 'CSRFToken', FILTER_SANITIZE_STRING);
     $date=filter_input(INPUT_GET, "date", FILTER_CALLBACK, array("options"=>"sanitize_dateFr"));
     $date=dateSQL($date);
-  
+
     // Mise à jour de la table personnel
     $db=new db();
     $db->CSRFToken = $CSRFToken;
@@ -110,6 +119,15 @@ function etape3()
 function etape4()
 {
     global $id;
+
+    // Disalow admin deletion
+    if ($id == 1) {
+        $msg = "Le compte admin ne peut être supprimé !";
+        $msg = urlencode($msg);
+        echo "<script type='text/Javascript'>parent.location.href='index.php?page=personnel/index.php&msg=$msg&msgType=error';</script>\n";
+        return false;
+    }
+
     $CSRFToken = filter_input(INPUT_GET, 'CSRFToken', FILTER_SANITIZE_STRING);
 
     //	Mise à jour de la table personnel

--- a/personnel/valid.php
+++ b/personnel/valid.php
@@ -104,25 +104,35 @@ switch ($action) {
     $id=$db->result[0]['id']+1;
 
     $login=login($nom, $prenom);
-    $mdp=gen_trivial_password();
-    $mdp_crypt=md5($mdp);
 
-    // Envoi du mail
-    $message="Votre compte Planning Biblio a &eacute;t&eacute; cr&eacute;&eacute; :";
-    $message.="<ul><li>Login : $login</li><li>Mot de passe : $mdp</li></ul>";
-    
-    $m=new CJMail();
-    $m->subject="Création de compte";
-    $m->message=$message;
-    $m->to=$mail;
-    $m->send();
+    // Demo mode
+    if (!empty($config['demo'])) {
+        $mdp_crypt = md5("password");
+        $msg = "Vous utilisez une version de démonstration : l'agent a été créé avec les identifiants $login / password";
+        $msg .= "#BR#Sur une version standard, les identifiants de l'agent lui auraient été envoyés par e-mail.";
+        $msg = urlencode($msg);
+        $msgType = "success";
+    } else {
+        $mdp=gen_trivial_password();
+        $mdp_crypt=md5($mdp);
 
-    // Si erreur d'envoi de mail, affichage de l'erreur
-    $msg=null;
-    $msgType=null;
-    if ($m->error) {
-        $msg=urlencode($m->error_CJInfo);
-        $msgType="error";
+        // Envoi du mail
+        $message="Votre compte Planning Biblio a &eacute;t&eacute; cr&eacute;&eacute; :";
+        $message.="<ul><li>Login : $login</li><li>Mot de passe : $mdp</li></ul>";
+
+        $m=new CJMail();
+        $m->subject="Création de compte";
+        $m->message=$message;
+        $m->to=$mail;
+        $m->send();
+
+        // Si erreur d'envoi de mail, affichage de l'erreur
+        $msg=null;
+        $msgType=null;
+        if ($m->error) {
+            $msg=urlencode($m->error_CJInfo);
+            $msgType="error";
+        }
     }
 
     // Enregistrement des infos dans la base de données
@@ -147,6 +157,14 @@ switch ($action) {
     break;
   
   case "mdp":
+
+    // Demo mode
+    if (!empty($config['demo'])) {
+        $msg = urlencode("Le mot de passe n'a pas été modifié car vous utilisez une version de démonstration");
+        echo "<script type='text/JavaScript'>document.location.href='index.php?page=personnel/index.php&msg=$msg&msgType=success';</script>";
+        break;
+    }
+
     $mdp=gen_trivial_password();
     $mdp_crypt=md5($mdp);
     $db=new db();

--- a/templates/admin/config.html.twig
+++ b/templates/admin/config.html.twig
@@ -4,6 +4,11 @@
 
 {% block page %}
   <script type="text/JavaScript" src="admin/js/config.js?version=2.8.04"></script>
+  {% if warning %}
+    <script type='text/JavaScript'>
+      CJInfo('{{ warning }}','error');
+    </script>
+  {% endif %}
   {% if post %}
     {% if erreur %}
       <script type='text/JavaScript'>


### PR DESCRIPTION
Allows to turn planningBiblio into demo mode. Simply add this lines in include/config.php

$config['demo'] = true;
$config['demo-password'] = "<yourpassword>";

Also:
  - lower case the phpcas library in composer.json
  - get error/success messages back in admin/config page