### PR TITLE
Add the name planningbiblio/planningbiblio to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,19 @@
 {
+    "name": "planningbiblio/planningbiblio",
+    "description": "Planning Biblio",
+    "authors": [
+        {
+            "name": "Jerome Combes",
+            "email": "jerome@planningbiblio.fr"
+        },
+        {
+            "name": "Alex Arnaud",
+            "email": "alex.arnaud@biblibre.com"
+        }
+    ],
+    "license": "GPL-2.0-or-later",
     "require": {
+        "php": ">=7.0",
         "apereo/phpcas": "^1.3",
         "phpmailer/phpmailer": ">=6.0.5",
         "symfony/http-foundation": "^3.4",


### PR DESCRIPTION
Add the name planningbiblio/planningbiblio to composer.json

in order to register the project on https://packagist.org
in order to use `composer create-project planningbiblio/planningbiblio`