### PR TITLE
MT 26914 [Planning]: Allow planning comments to be always displayed.

### DIFF
--- a/planning/poste/ajax.notes.php
+++ b/planning/poste/ajax.notes.php
@@ -26,15 +26,13 @@ $text=filter_input(INPUT_POST, "text", FILTER_SANITIZE_STRING);
 $text=urldecode($text);
 
 // Sécurité : droits d'accès à la page
-$required1=300+$site;		// Droits de modifier les plannings du sites N° $site
+$required1 = 300 + $site; // Droits de modifier les plannings du sites N° $site
+$required2 = 800 + $site; // Droits de modifier les commentaures
+$required3 = 1000 + $site; // Droits de modifier les plannings
 
-if ($config['Multisites-nombre']>1) {
-    $required2=800+$site;		// Droits de modifier les commentaires sites N° $site
-} else {
-    $required2=801;		// Droits de modifier les commentaires en monosite
-}
+$droits = $_SESSION['droits'];
 
-if (!in_array($required1, $_SESSION['droits']) and !in_array($required2, $_SESSION['droits'])) {
+if (!in_array($required1, $droits) and !in_array($required2, $droits) and !in_array($required3, $droits)) {
     echo json_encode(array("error"=>"Vous n'avez pas le droit de modifier les commentaires"));
     exit;
 }

--- a/planning/poste/comment.php
+++ b/planning/poste/comment.php
@@ -1,0 +1,41 @@
+<?php
+    // Notes : Affichage
+    $p=new planning();
+    $p->date=$date;
+    $p->site=$site;
+    $p->getNotes();
+    $notes=$p->notes;
+    $notesTextarea=$p->notesTextarea;
+    $notesValidation=$p->validation;
+    $notesDisplay=trim($notes)?null:"style='display:none;'";
+    $notesSuppression=($notesValidation and !trim($notes)) ? "Suppression du commentaire : ":null;
+
+    echo <<<EOD
+  <div id='pl-notes-div1' $notesDisplay >
+  $notes
+  </div>
+EOD;
+
+    // Notes : Modifications
+    if ($autorisationNotes) {
+        echo <<<EOD
+    <div id='pl-notes-div2' class='noprint'>
+    <input type='button' class='ui-button noprint' id='pl-notes-button' value='Ajouter un commentaire' />
+    </div>
+
+    <div id="pl-notes-form" title="Commentaire" class='noprint' style='display:none;'>
+      <p class="validateTips" id='pl-notes-tips'>Vous pouvez écrire ici un commentaire qui sera affich&eacute; en bas du planning.</p>
+      <form>
+      <textarea id='pl-notes-text'>$notesTextarea</textarea>
+      </form>
+    </div>
+EOD;
+    }
+
+    echo <<<EOD
+  <div id='pl-notes-div1-validation'>
+  $notesSuppression$notesValidation
+  </div>
+EOD;
+
+

--- a/planning/poste/index.php
+++ b/planning/poste/index.php
@@ -353,6 +353,9 @@ EOD;
         }
     }
     echo "</div>\n";
+    if ($config['Planning-CommentairesToujoursActifs']) {
+        include "comment.php";
+    }
     include "include/footer.php";
     exit;
 } elseif ($groupe and $autorisationN2) {	//	Si Groupe en argument
@@ -390,7 +393,10 @@ EOD;
     $tab=$db->result[0]['tableau'];
 }
 if (!$tab) {
-    echo "Le planning n'est pas pr&ecirc;t.\n";
+    echo "<p>Le planning n'est pas pr&ecirc;t.</p>";
+    if ($config['Planning-CommentairesToujoursActifs']) {
+        include "comment.php";
+    }
     include "include/footer.php";
     exit;
 }
@@ -415,6 +421,9 @@ if ($verrou) {
 
 if (!$verrou and !$autorisationN1) {
     echo "<br/><br/><font color='red'>Le planning du $dateFr n'est pas validé !</font><br/>\n";
+    if ($config['Planning-CommentairesToujoursActifs']) {
+        include "comment.php";
+    }
     include "include/footer.php";
     exit;
 } else {
@@ -651,45 +660,7 @@ if (!$verrou and !$autorisationN1) {
     echo "</table>\n";
     echo "</div>\n";
   
-    // Notes : Affichage
-    $p=new planning();
-    $p->date=$date;
-    $p->site=$site;
-    $p->getNotes();
-    $notes=$p->notes;
-    $notesTextarea=$p->notesTextarea;
-    $notesValidation=$p->validation;
-    $notesDisplay=trim($notes)?null:"style='display:none;'";
-    $notesSuppression=($notesValidation and !trim($notes)) ? "Suppression du commentaire : ":null;
-
-
-    echo <<<EOD
-  <div id='pl-notes-div1' $notesDisplay >
-  $notes
-  </div>
-EOD;
-
-    // Notes : Modifications
-    if ($autorisationNotes) {
-        echo <<<EOD
-    <div id='pl-notes-div2' class='noprint'>
-    <input type='button' class='ui-button noprint' id='pl-notes-button' value='Ajouter un commentaire' />
-    </div>
-
-    <div id="pl-notes-form" title="Commentaire" class='noprint' style='display:none;'>
-      <p class="validateTips" id='pl-notes-tips'>Vous pouvez écrire ici un commentaire qui sera affich&eacute; en bas du planning.</p>
-      <form>
-      <textarea id='pl-notes-text'>$notesTextarea</textarea>
-      </form>
-    </div>
-EOD;
-    }
-
-    echo <<<EOD
-  <div id='pl-notes-div1-validation'>
-  $notesSuppression$notesValidation
-  </div>  
-EOD;
+    include "comment.php";
 
     // Appel à disponibilités : envoi d'un mail aux agents disponibles pour occuper le poste choisi depuis le menu des agents
     if ($config['Planning-AppelDispo']) {

--- a/planning/poste/index.php
+++ b/planning/poste/index.php
@@ -96,7 +96,7 @@ $idCellule=0;
 //		------------------		Vérification des droits de modification (Autorisation)	------------------//
 $autorisationN1 = (in_array((300+$site), $droits) or in_array((1000+$site), $droits));
 $autorisationN2 = in_array((300+$site), $droits);
-$autorisationNotes = (in_array((300+$site), $droits) or in_array((800+$site), $droits));
+$autorisationNotes = (in_array((300+$site), $droits) or in_array((800+$site), $droits) or in_array(1000+$site, $droits));
 
 //		-----------------		FIN Vérification des droits de modification (Autorisation)	----------//
 

--- a/setup/atomicupdate/20191021_add_config_planning_always_comment.php
+++ b/setup/atomicupdate/20191021_add_config_planning_always_comment.php
@@ -1,0 +1,4 @@
+<?php
+
+$sql[] = "INSERT INTO `{$dbprefix}config` (`nom`, `type`, `valeur`, `categorie`, `ordre`, `commentaires`) VALUES 
+      ('Planning-CommentairesToujoursActifs', 'boolean', '0', 'Planning','100', 'Afficher la zone de commentaire même si le planning n\'est pas encore commencé.');";

--- a/setup/db_data.php
+++ b/setup/db_data.php
@@ -222,6 +222,8 @@ $sql[]="INSERT INTO `{$dbprefix}config` (`nom`, `type`, `valeur`, `commentaires`
   ('Planning-dejaPlace','boolean','1','Afficher une notification pour les agents d&eacute;j&agrave; plac&eacute; sur un poste dans le menu d&eacute;roulant du planning','Planning','20');";
 $sql[] = "INSERT INTO `{$dbprefix}config` (`nom`, `type`, `valeur`, `valeurs`, `categorie`, `commentaires`, `ordre` ) VALUES
   ('Planning-Heures','boolean', '1', '', 'Planning', 'Afficher les heures &agrave; c&ocirc;t&eacute; du nom des agents dans le menu du planning','25');";
+$sql[] = "INSERT INTO `{$dbprefix}config` (`nom`, `type`, `valeur`, `categorie`, `ordre`, `commentaires`) VALUES 
+      ('Planning-CommentairesToujoursActifs', 'boolean', '0', 'Planning','100', 'Afficher la zone de commentaire même si le planning n\'est pas encore commencé.');";
 
 $sql[]="INSERT INTO `{$dbprefix}config` (`nom`, `type`, `valeur`, `valeurs`, `commentaires`, `categorie`, `ordre`) 
   VALUES ('Absences-notifications1','checkboxes','[0,1,2,3]','[[0,\"Agents ayant le droit de g&eacute;rer les absences\"],[1,\"Responsables directs\"],[2,\"Cellule planning\"],[3,\"Agent concern&eacute;\"]]','Destinataires des notifications de nouvelles absences','Absences','40');";

--- a/setup/db_data.php
+++ b/setup/db_data.php
@@ -223,7 +223,7 @@ $sql[]="INSERT INTO `{$dbprefix}config` (`nom`, `type`, `valeur`, `commentaires`
 $sql[] = "INSERT INTO `{$dbprefix}config` (`nom`, `type`, `valeur`, `valeurs`, `categorie`, `commentaires`, `ordre` ) VALUES
   ('Planning-Heures','boolean', '1', '', 'Planning', 'Afficher les heures &agrave; c&ocirc;t&eacute; du nom des agents dans le menu du planning','25');";
 $sql[] = "INSERT INTO `{$dbprefix}config` (`nom`, `type`, `valeur`, `categorie`, `ordre`, `commentaires`) VALUES 
-      ('Planning-CommentairesToujoursActifs', 'boolean', '0', 'Planning','100', 'Afficher la zone de commentaire même si le planning n\'est pas encore commencé.');";
+      ('Planning-CommentairesToujoursActifs', 'boolean', '0', 'Planning','100', 'Afficher la zone de commentaire m&ecirc;me si le planning n\'est pas encore commenc&eacute;.');";
 
 $sql[]="INSERT INTO `{$dbprefix}config` (`nom`, `type`, `valeur`, `valeurs`, `commentaires`, `categorie`, `ordre`) 
   VALUES ('Absences-notifications1','checkboxes','[0,1,2,3]','[[0,\"Agents ayant le droit de g&eacute;rer les absences\"],[1,\"Responsables directs\"],[2,\"Cellule planning\"],[3,\"Agent concern&eacute;\"]]','Destinataires des notifications de nouvelles absences','Absences','40');";


### PR DESCRIPTION
 Currently, the planning comments are only displayed if said planning is started
 or validated.

 A new configuration option has been introduced:
 "Planning-CommentairesToujoursActifs" (disabled by default)

 When enabled, planning comments are always displayed, regardless of said
 planning status.

 Test plan:

  - Disable Planning-CommentairesToujoursActifs
  - Check that the planning comments are not displayed when said planning
    is not started or is not validated
  - Enable Planning-CommentairesToujoursActifs
  - Check that the planning comments are displayed even when said planning
    is not started or is not validated