### PR TITLE
Fix Fatal error: Cannot declare class App\Model\Agent, classabsences.php

### DIFF
--- a/public/absences/class.absences.php
+++ b/public/absences/class.absences.php
@@ -27,7 +27,7 @@ if (!isset($version)) {
 require_once __DIR__."/../ics/class.ics.php";
 require_once __DIR__."/../personnel/class.personnel.php";
 
-use Model\Agent;
+use App\Model\Agent;
 
 
 class absences


### PR DESCRIPTION
L'erreur suivante apparaît lors de la validation de l'ajout d'une absence
Fatal error: Cannot declare class App\Model\Agent, classabsences.php

Correction : 
remplace 
use Model\Agent;
par 
use App\Model\Agent;
dans class.absences.php,