### PR TITLE
19.10.bugfix2

### DIFF
--- a/absences/ajouter.php
+++ b/absences/ajouter.php
@@ -1,3 +1,4 @@
+
 <?php
 /**
 Planning Biblio
@@ -7,7 +8,6 @@ Voir les fichiers README.md et LICENSE
 
 Fichier : absences/ajouter.php
 Création : mai 2011
-Dernière modification : 12 septembre 2018
 @author Jérôme Combes <jerome@planningbiblio.fr>
 @author Farid Goara <farid.goara@u-pem.fr>
 
@@ -385,6 +385,10 @@ $db->query("SELECT * FROM `{$dbprefix}absences_infos` WHERE `fin`>='$date' ORDER
 if ($db->result) {
     echo "<b>Informations congés / absences :</b><br/><br/>\n";
     foreach ($db->result as $elem) {
+        if($admin){
+            echo "<a href='index.php?page=absences/infos.php&amp;id={$elem['id']}'>\n";
+            echo "<span class='pl-icon pl-icon-edit' title='Modifier'></span></a>\n";
+        }
         echo "Du ".dateFr($elem['debut'])." au ".dateFr($elem['fin'])." : {$elem['texte']}<br/>\n";
     }
 }
@@ -466,9 +470,9 @@ if ($db->result) {
   </td><td>
     <span id='recurrence-summary-form'>&nbsp;</span>
   </td></tr>
-    
+
   </table>
-    
-    
+
+
   </form>
 </div>

--- a/absences/infos.php
+++ b/absences/infos.php
@@ -1,13 +1,12 @@
 <?php
 /**
-Planning Biblio, Version 2.7
+Planning Biblio
 Licence GNU/GPL (version 2 et au dela)
 Voir les fichiers README.md et LICENSE
 @copyright 2011-2018 Jérôme Combes
 
 Fichier : absences/infos.php
 Création : mai 2011
-Dernière modification : 3 août 2017
 @author Jérôme Combes <jerome@planningbiblio.fr>
 
 Description :
@@ -76,7 +75,7 @@ else {
         $db->select2("absences_infos", "*", array("id"=>$id));
         $debut=dateFr3($db->result[0]['debut']);
         $fin=dateFr3($db->result[0]['fin']);
-        $texte=$db->result[0]['texte'];
+        $texte = html_entity_decode($db->result[0]['texte'], ENT_QUOTES|ENT_IGNORE, 'UTF-8');
     } else {
         $debut=null;
         $fin=null;

--- a/agenda/index.php
+++ b/agenda/index.php
@@ -1,13 +1,12 @@
 <?php
 /**
-Planning Biblio, Version 2.8.1
+Planning Biblio
 Licence GNU/GPL (version 2 et au dela)
 Voir les fichiers README.md et LICENSE
 @copyright 2011-2018 Jérôme Combes
 
 Fichier : agenda/index.php
 Création : mai 2011
-Dernière modification : 24 mai 2018
 @author Jérôme Combes <jerome@planningbiblio.fr>
 @author Farid Goara <farid.goara@u-pem.fr>
 
@@ -367,10 +366,13 @@ EOD;
             $tmp=array();
             $j=0;
             for ($i=0; $i<count($current_postes);$i++) {
+                $current_postes[$i]['absent'] = $current_postes[$i]['absent'] == 1 ? 1 : 0;
                 if ($i==0) {
                     $tmp[$j]=$current_postes[$i];
-                } elseif ($current_postes[$i]['site']==$tmp[$j]['site'] and $current_postes[$i]['poste']==$tmp[$j]['poste']
-         and $current_postes[$i]['absent']==$tmp[$j]['absent']and $current_postes[$i]['debut']==$tmp[$j]['fin']) {
+                } elseif ($current_postes[$i]['site']==$tmp[$j]['site']
+                    and $current_postes[$i]['poste']==$tmp[$j]['poste']
+                    and $current_postes[$i]['absent']==$tmp[$j]['absent']
+                    and $current_postes[$i]['debut']==$tmp[$j]['fin']) {
                     $tmp[$j]['fin']=$current_postes[$i]['fin'];
                 } else {
                     $j++;

--- a/conges/modif.php
+++ b/conges/modif.php
@@ -1,13 +1,12 @@
 <?php
 /**
-Planning Biblio, Plugin Congés
+Planning Biblio
 Licence GNU/GPL (version 2 et au dela)
 Voir les fichiers README.md et LICENSE
 @copyright 2013-2018 Jérôme Combes
 
 Fichier : conges/modif.php
 Création : 1er août 2013
-Dernière modification : 12 septembre 2018
 @author Jérôme Combes <jerome@planningbiblio.fr>
 @author Etienne Cavalié <etienne.cavalie@unice.fr>
 
@@ -229,7 +228,7 @@ if ($confirm) {
     echo "</td><td>\n";
     if ($adminN1 or $adminN2) {
         $db_perso=new db();
-        $db_perso->query("select * from {$dbprefix}personnel where actif='Actif' order by nom,prenom;");
+        $db_perso->query("select * from {$dbprefix}personnel order by nom,prenom;");
         echo "<select name='perso_id' id='perso_id' style='width:98%;' class='googleCalendarTrigger'>\n";
         foreach ($db_perso->result as $elem) {
             if ($perso_id==$elem['id']) {

--- a/js/script.js
+++ b/js/script.js
@@ -1,12 +1,11 @@
 /**
-Planning Biblio, Version 2.8.1
+Planning Biblio
 Licence GNU/GPL (version 2 et au dela)
 Voir les fichiers README.md et LICENSE
 @copyright 2011-2018 Jérôme Combes
 
 Fichier : js/script.js
 Création : mai 2011
-Dernière modification : 23 mai 2018
 @author Jérôme Combes <jerome@planningbiblio.fr>
 @author Farid Goara <farid.goara@u-pem.fr>
 @author Etienne Cavalié
@@ -758,6 +757,7 @@ $(function(){
     $(".ui-button").button();
     $(".datepicker").datepicker({
       showOtherMonths: true,
+      selectOtherMonths: true,
     });
 
     $(".datepicker").addClass("center ui-widget-content ui-corner-all");

--- a/planning/poste/class.planning.php
+++ b/planning/poste/class.planning.php
@@ -1,13 +1,12 @@
 <?php
 /**
-Planning Biblio, Version 2.8
+Planning Biblio
 Licence GNU/GPL (version 2 et au dela)
 Voir les fichiers README.md et LICENSE
 @copyright 2011-2018 Jérôme Combes
 
 Fichier : planning/poste/class.planning.php
 Création : 16 janvier 2013
-Dernière modification : 4 avril 2018
 @author Jérôme Combes <jerome@planningbiblio.fr>
 
 Description :
@@ -677,6 +676,9 @@ class planning
                 $result = array();
                 // On classe les résultats par agent
                 foreach ($db->result as $elem) {
+                    if ($elem['perso_id'] == 0) {
+                        continue;
+                    }
                     // On commence par ajouter la plage interrogée à chaque agent
                     if (!array_key_exists($elem['perso_id'], $result)) {
                         $result[$elem['perso_id']] = array(array('debut'=>$debut, 'fin'=>$fin));


### PR DESCRIPTION
Corrige quelques bugs constatés sur la version 19.10.xx
Ces bugs ne sont pas liés aux nouveautés de la 19.10 et existaient sur les versions précédentes

1./ Correction de l'agenda. Étaient marquées en rouge barré les plages de SP importées en dehors des heures de présences. Elles doivent être affichées normalement dans l'agenda (en noir), car ces plages sont bien occupées. Le marquage de couleur des plages importées en dehors des heures de présence ne concerne que le planning principal.
Bug depuis version 19.04
Correction : 0da86a0

2./ Les agents ayant le statut "administratif" (dans le champ "service public / administratif") pouvaient demander des congés mais ceux-ci ne pouvaient pas être validés car les agents admin étaient exclus de la liste. Lors de la validation, leur nom était remplacé par le premier nom de la liste.
Bug depuis plusieurs versions
Correction eaa588d

3./ Autorise la sélection des jours des autres mois dans les calendrier JQuery-UI Datepicker.
Bug depuis plusieurs versions
Correction : 472ca19

4./ Les cellules grisées depuis le menu du planning pendant la pause déjeuner étaient marquées SR (Sans Repas).
Bug depuis la version 2.7
Correction ad02b2d

5./ La modification et suppression des messages d'information sur les absences étaient impossibles depuis la version 2.7.04, à cause de l'affichage direct de la liste des absences via le menu absences. Auparavant, la page absences/index.php était affichée et permettait la modification de ces messages.
Correction : permettre l'édition des messages depuis le menu "Ajouter une absence" où sont affichés les messages d'information.
Correction : 32aea00