### PR TITLE
POC: add i18n capabilities

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -26,9 +26,9 @@ services:
         resource: '../src/Controller'
         tags: ['controller.service_arguments']
 
-    App\Listener\ControllerAuthorizationListener:
+    App\Listener\KernelRequestListener:
         tags:
-            - { name: kernel.event_listener, event: kernel.request }
+            - { name: kernel.event_listener, event: kernel.request, priority: 20 }
 
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones

--- a/src/Controller/AbsenceInfoController.php
+++ b/src/Controller/AbsenceInfoController.php
@@ -17,6 +17,7 @@ class AbsenceInfoController extends BaseController
      */
     public function index(Request $request, Session $session)
     {
+        //$translated = $this->get('translator')->trans('Symfony is great');
         $today = date('Ymd');
 
         $queryBuilder = $this->entityManager->createQueryBuilder();

--- a/templates/absenceInfo/index.html.twig
+++ b/templates/absenceInfo/index.html.twig
@@ -3,10 +3,10 @@
 {% extends 'base.html.twig' %}
 
 {% block page %}
-    <h3>Informations sur les absences</h3>
+    <h3>{% trans %}Information on absences{% endtrans %}</h3>
 
     <div class='top-button-div'>
-        <a href='{{ asset("/absences/info/add") }}' class='ui-button'>Ajouter</a>
+        <a href='{{ asset("/absences/info/add") }}' class='ui-button'>{% trans %}Add{% endtrans %}</a>
     </div>
 
     {% if info %}
@@ -14,9 +14,9 @@
             <thead>
                 <tr>
                     <th class='dataTableNoSort'></th>
-                    <th>Début</th>
-                    <th>Fin</th>
-                    <th>Texte</th>
+                    <th>{% trans %}Start on{% endtrans %}</th>
+                    <th>{% trans %}End on{% endtrans %}</th>
+                    <th>{% trans %}Text{% endtrans %}</th>
                 </tr>
             </thead>
             <tbody>
@@ -35,6 +35,6 @@
             </tbody>
         </table>
     {% else %}
-        Aucune information enregistrée.
+        {% trans %}No information.{% endtrans %}
     {% endif %}
 {% endblock %}

--- a/translations/messages.fr.yaml
+++ b/translations/messages.fr.yaml
@@ -1,0 +1,7 @@
+Symfony is great: J'aime Symfony
+Information on absences: Informations sur les absences
+Add: Ajouter
+Start on: Début
+End on: Fin
+Text: Texte
+No information.: Aucune information enregistrée.


### PR DESCRIPTION
Add i18n capabilities and make /absences/info translatable.

Test plan:
  - Go to /absences/info
  - Check the language corresponds to your brower language (only fr and en supported),
  - force another language by adding a locale parameter in url: /absences/info?locale=en or  /absences/info?locale=fr
  - Refresh the page and check the language is kept in session,
  - Try a unsupported langue: /absences/info?locale=es
  - Check the language move to default: en

To do:
  - Generate a messages file with all string,
  - Translate all the string!

This works only for parts rendered by a controller.