### PR TITLE
Mt28476 jc

### DIFF
--- a/src/Controller/HolidayController.php
+++ b/src/Controller/HolidayController.php
@@ -380,7 +380,7 @@ class HolidayController extends BaseController
             'adminN2'               => $adminN2,
             'show_allday'           => $show_allday,
             'debit'                 => $data['debit'],
-            'valide'                => $valide,
+            'valide'                => $data['valide'],
             'valide_n1'             => $data['valide_n1'],
             'balance_date'          => dateFr($balance[0]),
             'balance_before'        => heure4($balance[1]),

--- a/src/Controller/HolidayController.php
+++ b/src/Controller/HolidayController.php
@@ -115,6 +115,23 @@ class HolidayController extends BaseController
             $p->fetch();
             $agents_menu=$p->elements;
 
+            // If config Multi-sites : keep only users that we can manage.
+            if ($this->config('Multisites-nombre') > 1) {
+                $tmp = array();
+
+                foreach ($agents_menu as $elem) {
+                    if (is_array($elem['sites'])) {
+                        foreach ($elem['sites'] as $site_agent) {
+                            if (in_array((400+$site_agent), $droits) or in_array((600+$site_agent), $droits)) {
+                                $tmp[$elem['id']] = $elem;
+                                continue 2;
+                            }
+                        }
+                    }   
+                }
+                $agents_menu = $tmp;
+            }
+
             // Filtre pour n'afficher que les agents gérés si l'option "Absences-notifications-agent-par-agent" est cochée
             if ($this->config('Absences-notifications-agent-par-agent') and !$adminN2) {
                 $tmp = array();

--- a/templates/conges/edit.html.twig
+++ b/templates/conges/edit.html.twig
@@ -534,7 +534,7 @@
               </td>
             </tr>
 
-            {% if adminN1 and not adminN2 %}
+            {% if adminN2 and not adminN1 %}
               <tr>
                 <td>Validation niveau 1</td>
                 <td>{{ validation_n1 }}</td>


### PR DESCRIPTION
Filtre la liste des congés selon les droits de gestion multi-sites :
Les éléments filtrés sont le menu déroulant en haut de la liste et le résultat.

Corrige 2 bugs au niveau de l'affichage des validations dans le formulaire. 