### PR TITLE
Fix broken links on absences/edit pages

### DIFF
--- a/templates/absences/edit.html.twig
+++ b/templates/absences/edit.html.twig
@@ -18,7 +18,7 @@
   <h3>Modification de l'absence</h3>
   {% if not access %}
       Vous n'êtes pas autorisé(e) à modifier cette absence.<br/><br/>
-      <a href='index.php?page=absences/voir.php'>Retour à la liste des absences</a><br/><br/>
+      <a href='{{ asset("index.php?page=absences/voir.php") }}'>Retour à la liste des absences</a><br/><br/>
   {% else %}
     <form name='form' id='form' method='get' action='/index.php' onsubmit='return verif_absences(\"debut=date1;fin=date2;motif\");'>
       <input type='hidden' name='CSRFToken' value='{{ CSRFToken }}' />
@@ -455,7 +455,7 @@
               <td>
                 <ul id='documentsList'>
                   {% for document in documents %}
-                    <li id="document_{{ document.id}}"><a href="/absences/document/{{ document.id }}">{{ document.filename }}</a> <a href="javascript:deleteAbsenceDocument({{ document.id }});">supprimer</a></li>
+                    <li id="document_{{ document.id}}"><a href="{{ asset('absences/document/') }}{{ document.id }}">{{ document.filename }}</a> <a href="javascript:deleteAbsenceDocument({{ document.id }});">supprimer</a></li>
                   {% endfor %}
                 </ul>
               </td>
@@ -527,7 +527,7 @@
                 <input type='button' class='ui-button' value='Annuler' onclick="annuler(1);"/> 
                 <input type='submit' class='ui-button' value='Valider'/>
               {% else %}
-                <a href='index.php?page=absences/voir.php' class='ui-button'>Retour</a>
+                <a href='{{ asset("index.php?page=absences/voir.php") }}' class='ui-button'>Retour</a>
               {% endif %}
 
             </td>


### PR DESCRIPTION
2 liens de retour étaient cassés : dans le cas d'un accès refusé ou dans le cas d'une absence non modifiable (ex: absence importée depuis un calendrier extérieur) :
ex : depuis /absences/123 --> index.php donnait absences/index.php au lieu de /index.php

+ j'ai ajouté la fonction asset sur ces 2 liens + les liens pour voir les fichiers joints