### PR TITLE
MT28753 Remove doctrine/orm and twig/twig from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
     "require": {
         "php": ">=7.0",
         "apereo/phpcas": "^1.3",
-        "doctrine/orm": "^2.5",
         "phpmailer/phpmailer": ">=6.0.5",
         "sensio/framework-extra-bundle": "^5.2",
         "symfony/asset": "*",
@@ -37,8 +36,7 @@
         "symfony/twig-bundle": "*",
         "symfony/validator": "*",
         "symfony/web-link": "*",
-        "symfony/yaml": "*",
-        "twig/twig": "^2.0"
+        "symfony/yaml": "*"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.13",


### PR DESCRIPTION
Remove doctrine/orm and twig/twig from composer.json, already loaded by symfony/orm-pack and symfony/twig-bundle

doctrine/orm and twig/twig were necessary before integrating the symfony framework. They are no longer.
doctrine/orm is problematic with php versions lower than 7.4