### PR TITLE
Add HTTPS support for config[URL] setting

### DIFF
--- a/src/Controller/ConfigController.php
+++ b/src/Controller/ConfigController.php
@@ -18,6 +18,7 @@ class ConfigController extends BaseController
         // Temporary folder
         $tmp_dir=sys_get_temp_dir();
         // App URL
+        $request::setTrustedProxies(array($request->server->get('REMOTE_ADDR')));
         $url = $request->getSchemeAndHttpHost() . $request->getBaseUrl();
 
         $configParams = $this->entityManager->getRepository(ConfigParam::class)->findBy(


### PR DESCRIPTION
L'URL enregistrée dans le paramètre config['URL'] ne prenez pas en compte les connexions sécurisées et renvoyé systématiquement des URL en http://

Prise en compte des connexions HTTPS : 

Solution trouvée ici :
https://stackoverflow.com/questions/33436177/symfony2-getscheme-does-not-return-https

Appliquée sur cette PR.