### PR TITLE
update installer.sh : change the method to generate APP_SECRET

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -146,7 +146,7 @@ fi
 
 # Set variables
 planningbdatas=data/planningb_1911_utf8.sql.gz
-planningbsecret=$(hexdump -n 16 -e '4/4 "%08X" 1 "\n"' /dev/random)
+planningbsecret=$(head /dev/urandom|tr -dc "a-f0-9"|fold -w 32|head -n 1)
 
 # Download composer
 php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"


### PR DESCRIPTION
L'ancienne méthode utilisait la commande hexdump qui n'est pas connue de tous les OS, donc la clé restait vide dans certains cas.
La nouvelle méthode est celle déjà utilisée pour générer les mots de passe.