### PR TITLE
HolidayController, refacto : get managed agents

### DIFF
--- a/public/include/footer.php
+++ b/public/include/footer.php
@@ -20,7 +20,7 @@ if (__FILE__ == $_SERVER['SCRIPT_FILENAME']) {
 ?>
 </div> <!-- content or planningPoste -->
 <div class='footer'>
-Planning Biblio (<?php echo $displayed_version; ?>) -
+Planning Biblio (<?php echo $GLOBALS['displayed_version']; ?>) -
 <a href='http://www.planningbiblio.fr' target='_blank' style='font-size:9pt;'>www.planningbiblio.fr</a>
 </div>
 </body>


### PR DESCRIPTION
1./  683049c
Lors des essais sur le workflow des congés, j'ai remarqué que la liste des agents constituée pour le menu n'était pas bonne sur 2 pages sur 3.

La bonne méthode était utilisée sur la page index, mais elle était fausse sur les pages new et edit.
J'ai déplacé la partie du code de la fonction index dans une nouvelle fonction nommée get_agents.
Et j'utilise get_agents aux 3 places (index, edit, new).

2./ 7305df9
Lorsque l'on tenait d'ouvrir une demande de congés sans en avoir le droit, la page "Access denied" affichait un undefined $displayed_version.
Cet affichage access denied n'est ni une redirection, ni un include mais simplement un affichage généré par la fonction conges::roles (public/conges/class.conges.php) avec un include de public.
J'ai corrigé l'erreur en utilisant $GLOBALS. 
Il y a d'autres problème d'affichage (pas d'entête, le thème n'est pas chargé), mais pas très grave, seulement un access denied sur une page où les utilisateurs ne sont pas censés aller (il faut taper l'URL dans la barre pour reproduire, aucun accès possible via les liens proposés par l'interface).

3./ Note
Je suis assez étonné de voir que lors de la modification d'un congés, on peut modifier l'agent.
Si M. Dupond a demandé un congé, on peut le modifier et l'attribuer à Mme Machin. Pas logique.
Mais c'était comme ça sur les versions précédentes (j'ai vérifié) donc je laisse.
On aura a travailler sur la pose de congés pour plusieurs agents en une fois (si la commande cliente est validée), donc 1. ce menu pourra être utile dans ce cas, et 2. ce sera l'occasion de revoir les conditions d'affichage de ce menu si on le juge inutile ici.

4./ Workflow de validation des congés : validé !
Les tests n'ont montré aucune faille sur ce point 