### PR TITLE
MT27842: Having "Full day" checked by default in absences is configurable.

### DIFF
--- a/public/setup/atomicupdate/20200420_MT27842_Full_Day_switch.php
+++ b/public/setup/atomicupdate/20200420_MT27842_Full_Day_switch.php
@@ -1,4 +1,4 @@
 <?php
-$sql[] = "INSERT INTO `{$dbprefix}config` (`nom`, `type`, `valeur`, `categorie`, `ordre`, `commentaires`, `valeurs`) VALUES ('Absences-journeeEntiere', 'boolean', '0', 'Absences','38', 'Le paramètre \"Journée(s) entière(s)\" est coché par défaut lors de la saisie d\'une absence.', '');";
+$sql[] = "INSERT INTO `{$dbprefix}config` (`nom`, `type`, `valeur`, `categorie`, `ordre`, `commentaires`, `valeurs`) VALUES ('Absences-journeeEntiere', 'boolean', '1', 'Absences','38', 'Le paramètre \"Journée(s) entière(s)\" est coché par défaut lors de la saisie d\'une absence.', '');";
 
 

--- a/public/setup/atomicupdate/20200420_MT27842_Full_Day_switch.php
+++ b/public/setup/atomicupdate/20200420_MT27842_Full_Day_switch.php
@@ -1,4 +1,4 @@
 <?php
-$sql[] = "INSERT INTO `{$dbprefix}config` (`nom`, `type`, `valeur`, `categorie`, `ordre`, `commentaires`) VALUES ('Absences-journeeEntiere', 'boolean', '0', 'Absences','38', 'Le paramètre \"Journée(s) entière(s)\" est coché par défaut lors de la saisie d\'une absence.');";
+$sql[] = "INSERT INTO `{$dbprefix}config` (`nom`, `type`, `valeur`, `categorie`, `ordre`, `commentaires`, `valeurs`) VALUES ('Absences-journeeEntiere', 'boolean', '0', 'Absences','38', 'Le paramètre \"Journée(s) entière(s)\" est coché par défaut lors de la saisie d\'une absence.', '');";
 
 

--- a/public/setup/atomicupdate/20200420_MT27842_Full_Day_switch.php
+++ b/public/setup/atomicupdate/20200420_MT27842_Full_Day_switch.php
@@ -1,0 +1,4 @@
+<?php
+$sql[] = "INSERT INTO `{$dbprefix}config` (`nom`, `type`, `valeur`, `categorie`, `ordre`, `commentaires`) VALUES ('Absences-journeeEntiere', 'boolean', '0', 'Absences','38', 'Le paramètre \"Journée(s) entière(s)\" est coché par défaut lors de la saisie d\'une absence.');";
+
+

--- a/public/setup/db_data.php
+++ b/public/setup/db_data.php
@@ -210,6 +210,7 @@ $sql[]="INSERT INTO `{$dbprefix}config` (`nom`, `type`, `valeur`, `categorie`, `
   ('Absences-non-validees','boolean','1','Absences', 'Dans les plannings, afficher en rouge les agents pour lesquels une absence non-valid&eacute;e est enregistr&eacute;e','35');";
 $sql[]="INSERT INTO `{$dbprefix}config` (`nom`, `type`, `valeur`, `commentaires`, `categorie`, `ordre`) 
   VALUES ('Absences-agent-preselection', 'boolean', '1', 'Présélectionner l&apos;agent connecté lors de l&apos;ajout d&apos;une nouvelle absence.','Absences','36');";
+$sql[] = "INSERT INTO `{$dbprefix}config` (`nom`, `type`, `valeur`, `categorie`, `ordre`, `commentaires`) VALUES ('Absences-journeeEntiere', 'boolean', '0', 'Absences','38', 'Le paramètre \"Journée(s) entière(s)\" est coché par défaut lors de la saisie d\'une absence.');";
 $sql[]="INSERT INTO `{$dbprefix}config` (`nom`, `type`, `valeur`, `commentaires`, `categorie`, `ordre`) 
   VALUES ('Absences-tous', 'boolean', '0', 'Autoriser l&apos;enregistrement d&apos;absences pour tous les agents en une fois','Absences','37');";
 $sql[]="INSERT INTO `{$dbprefix}config` (`nom`, `type`, `valeur`, `commentaires`, `categorie`, `ordre`) 

--- a/public/setup/db_data.php
+++ b/public/setup/db_data.php
@@ -210,7 +210,7 @@ $sql[]="INSERT INTO `{$dbprefix}config` (`nom`, `type`, `valeur`, `categorie`, `
   ('Absences-non-validees','boolean','1','Absences', 'Dans les plannings, afficher en rouge les agents pour lesquels une absence non-valid&eacute;e est enregistr&eacute;e','35');";
 $sql[]="INSERT INTO `{$dbprefix}config` (`nom`, `type`, `valeur`, `commentaires`, `categorie`, `ordre`) 
   VALUES ('Absences-agent-preselection', 'boolean', '1', 'Présélectionner l&apos;agent connecté lors de l&apos;ajout d&apos;une nouvelle absence.','Absences','36');";
-$sql[] = "INSERT INTO `{$dbprefix}config` (`nom`, `type`, `valeur`, `valeurs`, `categorie`, `ordre`, `commentaires`) VALUES ('Absences-journeeEntiere', 'boolean', '0', '', 'Absences','38', 'Le paramètre \"Journée(s) entière(s)\" est coché par défaut lors de la saisie d\'une absence.');";
+$sql[] = "INSERT INTO `{$dbprefix}config` (`nom`, `type`, `valeur`, `valeurs`, `categorie`, `ordre`, `commentaires`) VALUES ('Absences-journeeEntiere', 'boolean', '1', '', 'Absences','38', 'Le paramètre \"Journée(s) entière(s)\" est coché par défaut lors de la saisie d\'une absence.');";
 $sql[]="INSERT INTO `{$dbprefix}config` (`nom`, `type`, `valeur`, `commentaires`, `categorie`, `ordre`) 
   VALUES ('Absences-tous', 'boolean', '0', 'Autoriser l&apos;enregistrement d&apos;absences pour tous les agents en une fois','Absences','37');";
 $sql[]="INSERT INTO `{$dbprefix}config` (`nom`, `type`, `valeur`, `commentaires`, `categorie`, `ordre`) 

--- a/public/setup/db_data.php
+++ b/public/setup/db_data.php
@@ -210,7 +210,7 @@ $sql[]="INSERT INTO `{$dbprefix}config` (`nom`, `type`, `valeur`, `categorie`, `
   ('Absences-non-validees','boolean','1','Absences', 'Dans les plannings, afficher en rouge les agents pour lesquels une absence non-valid&eacute;e est enregistr&eacute;e','35');";
 $sql[]="INSERT INTO `{$dbprefix}config` (`nom`, `type`, `valeur`, `commentaires`, `categorie`, `ordre`) 
   VALUES ('Absences-agent-preselection', 'boolean', '1', 'Présélectionner l&apos;agent connecté lors de l&apos;ajout d&apos;une nouvelle absence.','Absences','36');";
-$sql[] = "INSERT INTO `{$dbprefix}config` (`nom`, `type`, `valeur`, `categorie`, `ordre`, `commentaires`) VALUES ('Absences-journeeEntiere', 'boolean', '0', 'Absences','38', 'Le paramètre \"Journée(s) entière(s)\" est coché par défaut lors de la saisie d\'une absence.');";
+$sql[] = "INSERT INTO `{$dbprefix}config` (`nom`, `type`, `valeur`, `valeurs`, `categorie`, `ordre`, `commentaires`) VALUES ('Absences-journeeEntiere', 'boolean', '0', '', 'Absences','38', 'Le paramètre \"Journée(s) entière(s)\" est coché par défaut lors de la saisie d\'une absence.');";
 $sql[]="INSERT INTO `{$dbprefix}config` (`nom`, `type`, `valeur`, `commentaires`, `categorie`, `ordre`) 
   VALUES ('Absences-tous', 'boolean', '0', 'Autoriser l&apos;enregistrement d&apos;absences pour tous les agents en une fois','Absences','37');";
 $sql[]="INSERT INTO `{$dbprefix}config` (`nom`, `type`, `valeur`, `commentaires`, `categorie`, `ordre`) 

--- a/src/Controller/AbsenceController.php
+++ b/src/Controller/AbsenceController.php
@@ -72,6 +72,7 @@ class AbsenceController extends BaseController
             'reasons'               => $this->availablesReasons(),
             'reason_types'          => $this->reasonTypes(),
             'agents'                => $this->getAgents(),
+            'fullday_checked'       => $this->config('Absences-journeeEntiere'),
         ));
 
         return $this->output('absences/add.html.twig');

--- a/templates/absences/add.html.twig
+++ b/templates/absences/add.html.twig
@@ -98,7 +98,7 @@
               </td>
 
               <td>
-                <input type='checkbox' name='allday' checked='checked' onclick='all_day();'/>
+                <input type='checkbox' name='allday' {% if fullday_checked %} checked="checked" {% endif %} onclick='all_day();'/>
               </td>
             </tr>
 
@@ -112,7 +112,7 @@
               </td>
             </tr>
 
-            <tr id='hre_debut' style='display:none;'>
+            <tr id='hre_debut' {% if fullday_checked %} style='display:none;' {% endif %}>
               <td>
                 <label class='intitule'>Heure de début </label>
               </td>
@@ -151,7 +151,7 @@
               </td>
             </tr>
 
-            <tr id='hre_fin' style='display:none;'>
+            <tr id='hre_fin' {% if fullday_checked %} style='display:none;' {% endif %}>
               <td>
                 <label class='intitule'>Heure de fin </label>
               </td>


### PR DESCRIPTION
Test plan:
    
     1) apply the patch and the database update
     2) Check that "Full day" is unchecked when adding an absence
     3) Set "Absences-journeeEntiere" configuration option to true
     4) Check that "Full day" is checked when adding an absence