### PR TITLE
Fix agent template, select service hours (20.04.xx)

### DIFF
--- a/templates/agents/agent_table_edit.html.twig
+++ b/templates/agents/agent_table_edit.html.twig
@@ -81,7 +81,7 @@
       <select name='heuresHebdo' style='width:405px'  title='Choisissez un nombre d&apos;heures ou un pourcentage. Si vous Choisissez un pourcentage, le nombre d&apos;heures sera calculé à partir des plannings de pr&eacute;sence'>
         <option value='0'>&nbsp;</option>
         {% for i in 1..100 %}
-          {% if i == heures_hebdo %}
+          {% if i == heures_hebdo and '%' in heures_hebdo %}
             <option selected="selected" value='{{ i }}%'>{{ i }}%</option>
           {% else %}
             <option value='{{ i }}%'>{{ i }}%</option>
@@ -89,7 +89,7 @@
         {% endfor %}
 
         {% for time in times %}
-          {% if time[0] == heures_hebdo %}
+          {% if time[0] == heures_hebdo and '%' not in heures_hebdo %}
             <option selected="selected" value='{{ time[0] }}'>{{ time[1] }}</option>
           {% else %}
             <option value='{{ time[0] }}'>{{ time[1] }}</option>


### PR DESCRIPTION
Si l'heure de service public sélectionnée dans la fiche des agents est un pourcentage, le select se positionne sur la même valeur en heure lors de l'édition de la fiche.
Ex:

sélection de 22% dans le menu déroulant "Heures de service public".
validation
édition : la valeur sélectionnée dans le menu déroulant est 22 heures (et non 22%).
Corrigé par ce fix