### PR TITLE
fix bug on position edit

### DIFF
--- a/src/Controller/PositionController.php
+++ b/src/Controller/PositionController.php
@@ -231,7 +231,7 @@ class PositionController extends BaseController
 
         if ($response) {
             foreach ($response as $elem) {
-                $etages_utilises[] = $elem->etage;
+                $etages_utilises[] = $elem['etage'];
             }
         }
 
@@ -254,7 +254,7 @@ class PositionController extends BaseController
         $response = $query->getResult();
         if ($response) {
             foreach ($response as $elem) {
-                $groupes_utilises[] = $elem->groupe;
+                $groupes_utilises[] = $elem['groupe'];
             }
         }
 


### PR DESCRIPTION
I noticed on master the following bug : accessing to a position's editing page returns an notice to get the group and the floor to display. 