### PR TITLE
Remove warning SR on lunch positions

### DIFF
--- a/public/planning/poste/ajax.updateCell.php
+++ b/public/planning/poste/ajax.updateCell.php
@@ -190,7 +190,7 @@ foreach ($tab as $k => $v) {
 
 // Recherche des sans repas en dehors de la boucle pour optimiser les performances (juillet 2016)
 $p = new planning();
-$sansRepas = $p->sansRepas($date, $debut, $fin);
+$sansRepas = $p->sansRepas($date, $debut, $fin, $poste);
 
 // Recherche des absences
 $a=new absences();

--- a/public/planning/poste/class.planning.php
+++ b/public/planning/poste/class.planning.php
@@ -3,10 +3,8 @@
 Planning Biblio
 Licence GNU/GPL (version 2 et au dela)
 Voir les fichiers README.md et LICENSE
-@copyright 2011-2018 Jérôme Combes
 
-Fichier : planning/poste/class.planning.php
-Création : 16 janvier 2013
+@file public/planning/poste/class.planning.php
 @author Jérôme Combes <jerome@planningbiblio.fr>
 
 Description :
@@ -221,7 +219,7 @@ class planning
       
             // Recherche des sans repas en dehors de la boucle pour optimiser les performances (juillet 2016)
             $p = new planning();
-            $sansRepas = $p->sansRepas($date, $debut, $fin);
+            $sansRepas = $p->sansRepas($date, $debut, $fin, $poste);
 
             foreach ($agents as $elem) {
                 // Heures hebdomadaires (heures à faire en SP)
@@ -677,9 +675,20 @@ class planning
     * @param string $fin
     * @return array / true
     */
-    public function sansRepas($date, $debut, $fin)
+    public function sansRepas($date, $debut, $fin, $poste = null)
     {
         if ($GLOBALS['config']['Planning-sansRepas']==0) {
+            return array();
+        }
+
+        $lunch_position = null;
+        if (!empty($GLOBALS['config']['Position-Lunch'])) {
+            $lunch_position = implode(',', $GLOBALS['config']['Position-Lunch']);
+        }
+
+        if (!empty($GLOBALS['config']['Position-Lunch'])
+            and isset($poste)
+            and in_array($poste, $GLOBALS['config']['Position-Lunch'])) {
             return array();
         }
 
@@ -699,7 +708,13 @@ class planning
 
       // Recherche dans la base de données des autres plages concernées
             $db=new db();
-            $db->select2("pl_poste", "*", array("date"=>$date, "debut"=>"<$sr_fin", "fin"=>">$sr_debut"), "ORDER BY debut,fin");
+
+            if ($lunch_position) {
+                $db->select("pl_poste", "*", "date = '$date' AND debut < '$sr_fin' AND fin > '$sr_debut' AND poste NOT IN ($lunch_position)", "ORDER BY debut,fin");
+            } else {
+                $db->select2("pl_poste", "*", array("date"=>$date, "debut"=>"<$sr_fin", "fin"=>">$sr_debut"), "ORDER BY debut,fin");
+            }
+
             if ($db->result) {
                 $result = array();
                 // On classe les résultats par agent

--- a/public/planning/poste/fonctions.php
+++ b/public/planning/poste/fonctions.php
@@ -1,13 +1,10 @@
 <?php
 /**
-Planning Biblio, Version 2.8
+Planning Biblio
 Licence GNU/GPL (version 2 et au dela)
 Voir les fichiers README.md et LICENSE
-@copyright 2011-2018 Jérôme Combes
 
-Fichier : planning/poste/fonctions.php
-Création : mai 2011
-Dernière modification : 25 avril 2018
+@file public/planning/poste/fonctions.php
 @author Jérôme Combes <jerome@planningbiblio.fr>
 
 Description :
@@ -30,7 +27,7 @@ function cellule_poste($date, $debut, $fin, $colspan, $output, $poste, $site)
   
     // Recherche des sans repas en dehors de la boucle pour optimiser les performances (juillet 2016)
         $p = new planning();
-        $sansRepas = $p->sansRepas($date, $debut, $fin);
+        $sansRepas = $p->sansRepas($date, $debut, $fin, $poste);
 
         foreach ($GLOBALS['cellules'] as $elem) {
             $title=null;


### PR DESCRIPTION
Permet de définir une liste de postes sur lesquels l'alerte SR (Sans Repas) ne doit pas s'afficher.
Livré à la BSG, cette fonctionnalité pourrait intéresser d'autres établissements.

Définition des postes à ne pas contrôler dans custom_options.php (optionnel) :
<pre>$config['Position_Lunch'] = array( // liste des ID );</pre>