### PR TITLE
MT 30951: fix holiday hours checking

### DIFF
--- a/public/conges/class.conges.php
+++ b/public/conges/class.conges.php
@@ -71,8 +71,6 @@ class conges
         $data['debut']=dateSQL($data['debut']);
         $data['fin']=dateSQL($data['fin']);
 
-        $data = $this->applyHalfDays($data);
-
         // Enregistrement du congé
         $db=new db();
         $db->CSRFToken = $this->CSRFToken;
@@ -1070,8 +1068,6 @@ class conges
         $data['debut']=dateSQL($data['debut']);
         $data['fin']=dateSQL($data['fin']);
 
-        $data = $this->applyHalfDays($data);
-
         $update=array(
             'debut'         => $data['debut'] . ' ' . $data['hre_debut'],
             'fin'           => $data['fin'] . ' ' . $data['hre_fin'],
@@ -1266,44 +1262,4 @@ class conges
             'to'    => $db->result[0]['fin']
         );
     }
-
-    private function applyHalfDays($data)
-    {
-        // Ability to request half day.
-        $data['halfday'] = isset($data['halfday']) ? $data['halfday'] : 0;
-
-        $config = $GLOBALS['config'];
-        if ($config['Conges-Mode'] == 'jours'
-            && $config['Conges-demi-journees']
-            && $data['halfday']) {
-
-            if (!$data['fin']) {
-                $data['fin'] = $data['debut'];
-                $data['end_halfday'] = $data['start_halfday'];
-            }
-
-            if ($data['debut'] == $data['fin']) {
-                if ($data['start_halfday'] == 'morning') {
-                    $data['hre_debut'] = '00:00:00';
-                    $data['hre_fin'] = '12:00:00';
-                }
-                if ($data['start_halfday'] == 'afternoon') {
-                    $data['hre_debut'] = '12:00:00';
-                    $data['hre_fin'] = '23:59:59';
-                }
-            }
-
-            if (strtotime($data['debut']) < strtotime($data['fin'])) {
-                if ($data['start_halfday'] == 'afternoon') {
-                    $data['hre_debut'] = '12:00:00';
-                }
-                if ($data['end_halfday'] == 'morning') {
-                    $data['hre_fin'] = '12:00:00';
-                }
-            }
-        }
-
-        return $data;
-    }
-
 }

--- a/public/conges/js/script.conges.js
+++ b/public/conges/js/script.conges.js
@@ -33,6 +33,8 @@ function calculCredit(){
   conges_mode = $('#conges-mode').val();
   is_recover = $('#is-recover').val();
   conges_demi_journee = $('#conges-demi-journees')
+  start_halfday = $('select[name="start_halfday"]').val();
+  end_halfday = $('select[name="end_halfday"]').val();
 
   if(!fin){
     fin=debut;
@@ -41,52 +43,21 @@ function calculCredit(){
     return;
   }
 
-  hre_debut=hre_debut?hre_debut:"00:00:00";
-  hre_fin=hre_fin?hre_fin:"23:59:59";
-
-  if (conges_mode == 'jours' && conges_demi_journee && halfday) {
-    start_halfday = $('select[name="start_halfday"]').val();
-    end_halfday = $('select[name="end_halfday"]').val();
-
-    start = ddmmyyyy_to_date(debut);
-    end = ddmmyyyy_to_date(fin);
-
-    if (start.getTime() == end.getTime()) {
-      if (start_halfday == 'morning') {
-        hre_debut = '00:00:00';
-        hre_fin = '12:00:00';
-      }
-
-      if (start_halfday == 'afternoon') {
-        hre_debut = '12:00:00';
-        hre_fin = '23:59:59';
-      }
-
-      if (start_halfday == 'fullday') {
-        hre_debut = '00:00:00';
-        hre_fin = '23:59:59';
-      }
-    }
-
-    if (start.getTime() < end.getTime()) {
-      if (start_halfday == 'afternoon') {
-        hre_debut = '12:00:00';
-      } else {
-        hre_debut = '00:00:00';
-      }
-
-      if (end_halfday == 'morning') {
-        hre_fin = '12:00:00';
-      } else {
-        hre_fin = '23:59:59';
-      }
-    }
-
-  }
+  data = {
+    debut: debut,
+    fin: fin,
+    hre_debut: hre_debut,
+    hre_fin: hre_fin,
+    perso_id: perso_id,
+    is_recover: is_recover,
+    halfday: halfday,
+    start_halfday: start_halfday,
+    end_halfday: end_halfday
+  },
 
   $.ajax({
     url: "/ajax/holiday-credit",
-    data: {debut: debut, fin: fin, hre_debut: hre_debut, hre_fin: hre_fin, perso_id: perso_id, is_recover: is_recover},
+    data: data,
     dataType: "json",
     type: "get",
     async: false,
@@ -366,6 +337,9 @@ function verifConges(){
   var hre_fin=$("#hre_fin_select").val();
   var perso_id=$("#perso_id").val();
   var id=$("#id").val();
+  var halfday = $('input[name="halfday"]').is(':checked') ? 1 : 0;
+  var start_halfday = $('select[name="start_halfday"]').val();
+  var end_halfday = $('select[name="end_halfday"]').val();
   if(hre_fin==""){
     hre_fin="23:59:59";
   }
@@ -393,12 +367,12 @@ function verifConges(){
 
   // Vérifions si un autre congé a été demandé ou validé
   var result=$.ajax({
-    url: '/conges/ajax.verifConges.php',
+    url: '/ajax/holiday/check',
     type: "get",
-    data: "perso_id="+perso_id+"&debut="+debut+"&fin="+fin+"&hre_debut="+hre_debut+"&hre_fin="+hre_fin+"&id="+id,
+    data: "perso_id="+perso_id+"&debut="+debut+"&fin="+fin+"&hre_debut="+hre_debut+"&hre_fin="+hre_fin+"&id="+id+'&halfday='+halfday+'&start_halfday='+start_halfday+'&end_halfday='+end_halfday,
     async: false,
     success: function(data){
-      if(data != "Pas de congé"){
+      if(data != "No holiday"){
         information("Un congé a déjà été demandé " + data,"error");
       }else{
         $("#form").submit();

--- a/public/include/feries.php
+++ b/public/include/feries.php
@@ -19,7 +19,8 @@ Code source de Olravet commenté en page de cette page
 
 // Contrôle si ce script est appelé directement, dans ce cas, affiche Accès Refusé et quitte
 $version = $GLOBALS['version'] ?? null;
-if (!isset($version)) {
+
+if (!isset($version) and php_sapi_name() != 'cli') {
     include_once "accessDenied.php";
     exit;
 }

--- a/src/Controller/AjaxController.php
+++ b/src/Controller/AjaxController.php
@@ -32,11 +32,26 @@ class AjaxController extends BaseController
         $c = new \conges();
         $recover = $c->calculCreditRecup($perso_id, $debut);
 
-        $holidayHlper = new HolidayHelper(array(
+        $holidayHelper = new HolidayHelper(array(
             'start' => $debut,
             'hour_start' => $hre_debut,
             'end' => $fin,
             'hour_end' => $hre_fin,
+        ));
+
+        $params = array(
+            'halfday' => $request->get('halfday'),
+            'start_halfday' => $request->get('start_halfday'),
+            'end_halfday' => $request->get('end_halfday')
+        );
+
+        list($hour_start, $hour_end) = $holidayHelper->startEndHours($params);
+
+        $holidayHlper = new HolidayHelper(array(
+            'start' => $debut,
+            'hour_start' => $hour_start,
+            'end' => $fin,
+            'hour_end' => $hour_end,
             'perso_id' => $perso_id,
             'is_recover' => $is_recover
         ));

--- a/src/PlanningBiblio/Helper/HolidayHelper.php
+++ b/src/PlanningBiblio/Helper/HolidayHelper.php
@@ -156,6 +156,71 @@ class HolidayHelper extends BaseHelper
         return $result;
     }
 
+    public function startEndHours($params = array())
+    {
+        foreach (array('halfday', 'start_halfday', 'end_halfday') as $key) {
+            if (!array_key_exists($key, $params)) {
+                return array('', '');
+            }
+        }
+
+        $start_halfday = $params['start_halfday'];
+        $end_halfday = $params['end_halfday'];
+        $halfday = $params['halfday'];
+        $start = $this->data['start'];
+        $end = $this->data['end'];
+        $hour_start = '00:00:00';
+        $hour_end = '23:59:59';
+
+        if ($this->data['hour_start'] && $this->data['hour_start'] != '') {
+            $hour_start = $this->data['hour_start'];
+        }
+
+        if ($this->data['hour_end'] && $this->data['hour_end'] != '') {
+            $hour_end = $this->data['hour_end'];
+        }
+
+
+        if ($this->config('Conges-Mode') == 'jours'
+            && $this->config('Conges-demi-journees')
+            && $params['halfday']) {
+
+            if (strtotime($start) == strtotime($end)) {
+              if ($start_halfday == 'morning') {
+                $hour_start = '00:00:00';
+                $hour_end = '12:00:00';
+              }
+
+              if ($start_halfday == 'afternoon') {
+                $hour_start = '12:00:00';
+                $hour_end = '23:59:59';
+              }
+
+              if ($start_halfday == 'fullday') {
+                $hour_start = '00:00:00';
+                $hour_end = '23:59:59';
+              }
+            }
+
+            if (strtotime($start) < strtotime($end)) {
+              if ($start_halfday == 'afternoon') {
+                $hour_start = '12:00:00';
+              } else {
+                $hour_start = '00:00:00';
+              }
+
+              if ($end_halfday == 'morning') {
+                $hour_end = '12:00:00';
+              } else {
+                $hour_end = '23:59:59';
+              }
+            }
+        }
+
+        return array($hour_start, $hour_end);
+
+    }
+
     private function applyWeekTable($week)
     {
         if($this->config('Conges-Mode') == 'heures' || $this->data['is_recover']) {

--- a/tests/PlanningBiblio/Helper/HolidayHelperTest.php
+++ b/tests/PlanningBiblio/Helper/HolidayHelperTest.php
@@ -1,0 +1,230 @@
+<?php
+
+use App\PlanningBiblio\Helper\HolidayHelper;
+use PHPUnit\Framework\TestCase;
+
+class HolidayHelperTest extends TestCase
+{
+    public function testStartEnd() {
+        $GLOBALS['config']['Conges-Mode'] = 'jours';
+        $GLOBALS['config']['Conges-demi-journees'] = 0;
+        $GLOBALS['dispatcher'] = '';
+
+        $params = array(
+            'halfday' => 0,
+            'start_halfday' => '',
+            'end_halfday' => ''
+        );
+
+
+        $holidayHelper = new HolidayHelper(array(
+            'start' => '2020-12-24',
+            'hour_start' => '13:00:00',
+            'end' => '2020-12-24',
+            'hour_end' => '17:00:00'
+        ));
+
+        list($startHour, $endHour) = $holidayHelper->startEndHours($params);
+
+        $this->assertEquals('13:00:00', $startHour, 'start is 13:00');
+        $this->assertEquals('17:00:00', $endHour, 'halfday option disabled, end is 17:00');
+    }
+
+    public function testStartEndNoHalfdayOption() {
+        $GLOBALS['config']['Conges-Mode'] = 'jours';
+        $GLOBALS['config']['Conges-demi-journees'] = 0;
+        $GLOBALS['dispatcher'] = '';
+
+        $params = array(
+            'halfday' => 1,
+            'start_halfday' => '',
+            'end_halfday' => ''
+        );
+
+
+        $holidayHelper = new HolidayHelper(array(
+            'start' => '2020-12-24',
+            'hour_start' => '',
+            'end' => '2020-12-24',
+            'hour_end' => ''
+        ));
+
+        list($startHour, $endHour) = $holidayHelper->startEndHours($params);
+
+        $this->assertEquals('00:00:00', $startHour, 'Halfday option disabled, start is 00:00');
+        $this->assertEquals('23:59:59', $endHour, 'halfday option disabled, end is 23:59');
+    }
+
+    public function testStartEndEmptyhalday() {
+        $GLOBALS['config']['Conges-Mode'] = 'jours';
+        $GLOBALS['config']['Conges-demi-journees'] = 1;
+        $GLOBALS['dispatcher'] = '';
+
+        $params = array(
+            'halfday' => 1,
+        );
+
+
+        $holidayHelper = new HolidayHelper(array(
+            'start' => '2020-12-24',
+            'hour_start' => '',
+            'end' => '2020-12-24',
+            'hour_end' => ''
+        ));
+
+        list($startHour, $endHour) = $holidayHelper->startEndHours($params);
+
+        $this->assertEquals('', $startHour, 'wihtout start_halfday or start_halfday, start is empty');
+        $this->assertEquals('', $endHour, 'wihtout start_halfday or end_halfday, end is empty');
+    }
+
+    public function testStartEndAfternoonSameDay() {
+        $GLOBALS['config']['Conges-Mode'] = 'jours';
+        $GLOBALS['config']['Conges-demi-journees'] = 1;
+        $GLOBALS['dispatcher'] = '';
+
+        $params = array(
+            'halfday' => 1,
+            'start_halfday' => 'afternoon',
+            'end_halfday' => 'afternoon'
+        );
+
+
+        $holidayHelper = new HolidayHelper(array(
+            'start' => '2020-12-24',
+            'hour_start' => '',
+            'end' => '2020-12-24',
+            'hour_end' => ''
+        ));
+
+        list($startHour, $endHour) = $holidayHelper->startEndHours($params);
+
+        $this->assertEquals('12:00:00', $startHour, 'Afternoon holiday starts at 12:00');
+        $this->assertEquals('23:59:59', $endHour, 'Afternoon holiday ends at 23:59');
+    }
+
+    public function testStartEndMorningSameDay() {
+        $GLOBALS['config']['Conges-Mode'] = 'jours';
+        $GLOBALS['config']['Conges-demi-journees'] = 1;
+        $GLOBALS['dispatcher'] = '';
+
+        $params = array(
+            'halfday' => 1,
+            'start_halfday' => 'morning',
+            'end_halfday' => 'morning'
+        );
+
+
+        $holidayHelper = new HolidayHelper(array(
+            'start' => '2020-12-24',
+            'hour_start' => '',
+            'end' => '2020-12-24',
+            'hour_end' => ''
+        ));
+
+        list($startHour, $endHour) = $holidayHelper->startEndHours($params);
+
+        $this->assertEquals('00:00:00', $startHour, 'Morning holiday starts at 00:00');
+        $this->assertEquals('12:00:00', $endHour, 'Morning holiday ends at 12:00');
+    }
+
+    public function testStartEndFulldaySameDay() {
+        $GLOBALS['config']['Conges-Mode'] = 'jours';
+        $GLOBALS['config']['Conges-demi-journees'] = 1;
+        $GLOBALS['dispatcher'] = '';
+
+        $params = array(
+            'halfday' => 1,
+            'start_halfday' => 'fullday',
+            'end_halfday' => 'fullday'
+        );
+
+
+        $holidayHelper = new HolidayHelper(array(
+            'start' => '2020-12-24',
+            'hour_start' => '',
+            'end' => '2020-12-24',
+            'hour_end' => ''
+        ));
+
+        list($startHour, $endHour) = $holidayHelper->startEndHours($params);
+
+        $this->assertEquals('00:00:00', $startHour, 'Fullday holiday starts at 00:00');
+        $this->assertEquals('23:59:59', $endHour, 'Fullday holiday ends at 23:59');
+    }
+
+    public function testStartEndFullday() {
+        $GLOBALS['config']['Conges-Mode'] = 'jours';
+        $GLOBALS['config']['Conges-demi-journees'] = 1;
+        $GLOBALS['dispatcher'] = '';
+
+        $params = array(
+            'halfday' => 1,
+            'start_halfday' => 'fullday',
+            'end_halfday' => 'fullday'
+        );
+
+
+        $holidayHelper = new HolidayHelper(array(
+            'start' => '2020-12-24',
+            'hour_start' => '',
+            'end' => '2020-12-25',
+            'hour_end' => ''
+        ));
+
+        list($startHour, $endHour) = $holidayHelper->startEndHours($params);
+
+        $this->assertEquals('00:00:00', $startHour, 'Fullday first holiday starts at 00:00');
+        $this->assertEquals('23:59:59', $endHour, 'Fullday last holiday ends at 23:59');
+    }
+
+    public function testStartEndAfternoonFullday() {
+        $GLOBALS['config']['Conges-Mode'] = 'jours';
+        $GLOBALS['config']['Conges-demi-journees'] = 1;
+        $GLOBALS['dispatcher'] = '';
+
+        $params = array(
+            'halfday' => 1,
+            'start_halfday' => 'afternoon',
+            'end_halfday' => 'fullday'
+        );
+
+
+        $holidayHelper = new HolidayHelper(array(
+            'start' => '2020-12-24',
+            'hour_start' => '',
+            'end' => '2020-12-25',
+            'hour_end' => ''
+        ));
+
+        list($startHour, $endHour) = $holidayHelper->startEndHours($params);
+
+        $this->assertEquals('12:00:00', $startHour, 'Afternoon first holiday starts at 12:00');
+        $this->assertEquals('23:59:59', $endHour, 'Fullday last holiday ends at 23:59');
+    }
+
+    public function testStartEndAfternoonMorning() {
+        $GLOBALS['config']['Conges-Mode'] = 'jours';
+        $GLOBALS['config']['Conges-demi-journees'] = 1;
+        $GLOBALS['dispatcher'] = '';
+
+        $params = array(
+            'halfday' => 1,
+            'start_halfday' => 'afternoon',
+            'end_halfday' => 'morning'
+        );
+
+
+        $holidayHelper = new HolidayHelper(array(
+            'start' => '2020-12-24',
+            'hour_start' => '',
+            'end' => '2020-12-25',
+            'hour_end' => ''
+        ));
+
+        list($startHour, $endHour) = $holidayHelper->startEndHours($params);
+
+        $this->assertEquals('12:00:00', $startHour, 'Afternoon first holiday starts at 12:00');
+        $this->assertEquals('12:00:00', $endHour, 'Morning last holiday ends at 12:00');
+    }
+}


### PR DESCRIPTION
This commit move all the code that define start and end
hours of a holiday in one place: HolidayHelper.

Also fix the following issue:
Holidays hours are wrong defined when checking for other holidays on same périod.
So adding a recory the morning for an agent, you can't add a holiday the afternoon (exemple).

HolidayHelper->startEndHours is covered by units tests.
You can run:

./vendor/bin/simple-phpunit --bootstrap tests/bootstrap.php
tests/PlanningBiblio/Helper/HolidayHelperTest.php