### PR TITLE
MT 31000 - Take in account empty site in agent's times in holiday validation workflow

### DIFF
--- a/public/conges/class.conges.php
+++ b/public/conges/class.conges.php
@@ -862,10 +862,9 @@ class conges
                 // Récupération du numéro du site concerné par la date courante
                 $offset=$jour-1+($semaine*7)-7;
                 if (array_key_exists($offset, $temps)) {
-                    if (array_key_exists(4, $temps[$offset])) {
+                    $site = 1;
+                    if (!empty($temps[$offset][4])) {
                         $site=$temps[$offset][4];
-                    } else {
-                        $site=1;
                     }
                     // Ajout du numéro du droit correspondant à la gestion des congés de ce site
                     // Validation niveau 1


### PR DESCRIPTION
Retrieving site number from agents times could bring an empty value. This can happen when validating holiday on a period whose at least one day has no site set (i.e a saturday: ['', '', '', '']).

According to PHP version or configuration, <?php 400 + '' ?> can just warn or ... crash.

This path fix that