### PR TITLE
MT 31109: handle specifics js chars in id param of supprime function

### DIFF
--- a/public/js/script.js
+++ b/public/js/script.js
@@ -560,7 +560,7 @@ function supprime(page, id, CSRFToken){
     $.ajax({
       url: page+"/ajax.delete.php",
       type: "get",
-      data: "id="+id+"&CSRFToken="+CSRFToken,
+      data: "id="+ encodeURIComponent(id) +"&CSRFToken="+CSRFToken,
       success: function(){
 	window.location.reload(false);
       },


### PR DESCRIPTION
Test plan:

  - Create a planning's template named "DEGM: BO+ semaine",
  - go to template index (index.php?page=planning/modeles/index.php),
  - try to delete this template
  => fail
  - apply this patch,
  - try to delete the same template
  => success
