### PR TITLE
Escape json string containing skill in agent's form

### DIFF
--- a/templates/agents/edit.html.twig
+++ b/templates/agents/edit.html.twig
@@ -15,7 +15,7 @@
   </style>
   <script type='text/JavaScript'>
     <!--
-    complet = JSON.parse('{{ postes_completNoms_json|raw }}');
+    complet = JSON.parse('{{ postes_completNoms_json | e('js') }}');
     -->
     function save_password(agent_id, password) {
       $.ajax({


### PR DESCRIPTION
Reproduce by:
  - Create a skill with a single quote ("Your's")
  - Edit an agent:
    => first you should see a JS fail at page loading
  - Try to add a skill to this agent
    => Nothing happens