### PR TITLE
Bigger planning week title

### DIFF
--- a/public/themes/default/default.css
+++ b/public/themes/default/default.css
@@ -894,7 +894,7 @@ a:hover.menuRed, a:hover.menu {
 .titreSemFixe{
   color:#7D3C25;
   text-decoration:none;
-  font-size:10.5pt;
+  font-size:12pt;
   font-family:Verdana;
   width:50%;
   text-align:center;


### PR DESCRIPTION
Planning week title (ie 'Planning du Mardi 9 février 20210') font size is only 10.5pt big.
In comparaison, '.td_postes' has font size 12pt.
This is the most important information of the page, should be at least 12pt big.