### PR TITLE
Don't show right arrow on locked plannings or for agents without authorization

### DIFF
--- a/public/planning/poste/js/planning.js
+++ b/public/planning/poste/js/planning.js
@@ -78,6 +78,11 @@ $(document).ready(function(){
 
   $('td.menuTrigger').hover(
     function() {
+      if($("#planning-data").attr("data-verrou") >0 ||
+        $("#planning-data").attr("data-autorisation") != 1){
+        return false;
+      }
+
       if ($(this).is(':last-child')) {
         return;
       }


### PR DESCRIPTION
Test plan:
  - Create a planning,
  - Place some agents on it,
  - lock the planning,
  => right arrow is still available and clickable