### PR TITLE
Notification page: move notifications.js to public/js/plb. Add baseURL to Ajax query

### DIFF
--- a/public/js/plb/notifications.js
+++ b/public/js/plb/notifications.js
@@ -1,12 +1,9 @@
 /**
-Planning Biblio, Version 2.8
+Planning Biblio
 Licence GNU/GPL (version 2 et au dela)
 Voir les fichiers README.md et LICENSE
-@copyright 2011-2018 Jérôme Combes
 
-Fichier : notifications/js/notifications.js
-Création : 15 janvier 2018
-Dernière modification : 25 janvier 2018
+@file public/js/plb/notifications.js
 @author Jérôme Combes <jerome@planningbiblio.fr>
 
 Description :
@@ -65,9 +62,11 @@ $(function() {
         
         notifications = JSON.stringify(tab);
 
+        var baseURL = $('#baseURL').val();
+
         // Enregistrement dans la base de données
         $.ajax({
-          url: "/notification",
+          url: baseURL + "/notification",
           type: "post",
           datatype: "json",
           data: {agents: agents, responsables: responsables, notifications: notifications, CSRFToken: $('#CSRFToken').val()},

--- a/templates/notifications/index.html.twig
+++ b/templates/notifications/index.html.twig
@@ -3,7 +3,7 @@
 {% extends 'base.html.twig' %}
 
 {% block specificjs %}
-  <script type="text/JavaScript" src="{{ app.request.getBaseURL() }}/notifications/js/notifications.js?version={{ version }}"></script>
+  <script type="text/JavaScript" src="{{ asset('js/plb/notifications.js') }}?version={{ version }}"></script>
 {% endblock %}
 
 {% block page %}


### PR DESCRIPTION
I created a new directory named "plb" in public/js

@alexarn @veggiematts ,
Please use this folder for new js files and when moving js files from legacy folders

Format : public/js/plb/[module_name].js