### PR TITLE
MT 31819: Don't sanitizing config elements

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,4 +1,6 @@
 *** Unreleased ***
+-Fixes
+Don't sanitize config elements
 
 - Enhancements
 Move function calculPresence in dedicated class (WorkingHours)

--- a/public/include/config.php
+++ b/public/include/config.php
@@ -68,6 +68,7 @@ include 'db.php';
 
 // Get config values from DB
 $db = new db();
+$db->sanitize_string = false;
 $db->query("SELECT * FROM `{$dbprefix}config` ORDER BY `id`;");
 foreach ($db->result as $elem) {
   $config[$elem['nom']] = $elem['valeur'];


### PR DESCRIPTION
Tiny fix that allow a correct displaying of apostrophes in site's name in calendar