### PR TITLE
LDAP: Change LDAP-ID-Attribute value from supannAliasLogin to supannaliaslogin

### DIFF
--- a/public/setup/atomicupdate/20210304_LDAP_supannaliaslogin.php
+++ b/public/setup/atomicupdate/20210304_LDAP_supannaliaslogin.php
@@ -1,0 +1,4 @@
+<?php
+
+$sql[] = "UPDATE `{$dbprefix}config` SET `valeur` = 'supannaliaslogin' WHERE `valeur` = 'supannAliasLogin' AND `nom` = 'LDAP-ID-Attribute';";
+$sql[] = "UPDATE `{$dbprefix}config` SET `valeurs` = 'uid,samaccountname,supannaliaslogin' WHERE `nom` = 'LDAP-ID-Attribute';";

--- a/public/setup/db_data.php
+++ b/public/setup/db_data.php
@@ -299,7 +299,7 @@ $sql[]="INSERT INTO `{$dbprefix}config` (`nom`,`commentaires`,`categorie`,`ordre
 $sql[]="INSERT INTO `{$dbprefix}config` (`nom`,`commentaires`,`categorie`,`ordre`) VALUES ('LDAP-Filter','Filtre LDAP. OpenLDAP essayez \"(objectclass=inetorgperson)\" , Active Directory essayez \"(&(objectCategory=person)(objectClass=user))\". Vous pouvez bien-s&ucirc;r personnaliser votre filtre.','LDAP','50');";
 $sql[]="INSERT INTO `{$dbprefix}config` (`nom`,`commentaires`,`categorie`,`ordre`) VALUES ('LDAP-RDN','DN de connexion au serveur LDAP, laissez vide si connexion anonyme','LDAP','60');";
 $sql[]="INSERT INTO `{$dbprefix}config` (`nom`,`type`,`commentaires`,`categorie`,`ordre`) VALUES ('LDAP-Password','password','Mot de passe de connexion','LDAP','70');";
-$sql[]="INSERT INTO `{$dbprefix}config` (`nom`, `type`, `valeur`, `valeurs`, `commentaires`, `categorie`, `ordre`) VALUES ('LDAP-ID-Attribute', 'enum', 'uid', 'uid,samaccountname,supannAliasLogin', 'Attribut d&apos;authentification (OpenLDAP : uid, Active Directory : samaccountname)', 'LDAP', 80);";
+$sql[]="INSERT INTO `{$dbprefix}config` (`nom`, `type`, `valeur`, `valeurs`, `commentaires`, `categorie`, `ordre`) VALUES ('LDAP-ID-Attribute', 'enum', 'uid', 'uid,samaccountname,supannaliaslogin', 'Attribut d&apos;authentification (OpenLDAP : uid, Active Directory : samaccountname)', 'LDAP', 80);";
 $sql[]="INSERT INTO `{$dbprefix}config` (`nom`, `type`, `valeur`, `valeurs`, `commentaires`, `categorie`, `ordre`) VALUES ('LDAP-Matricule', 'text', '', '', 'Attribut &agrave; importer dans le champ matricule (optionnel)', 'LDAP', 90);";
 
 //	Ajout des infos CAS dans la table config


### PR DESCRIPTION
LDAP: Change LDAP-ID-Attribute value from supannAliasLogin to supannaliaslogin

- Fix issue #381
- Already donne for samaccountname here : df14e8efe81ea06f082a71dc44880cedaddab55a