### PR TITLE
Remove html entities on param separator in plannings url

### DIFF
--- a/public/include/class.menu.php
+++ b/public/include/class.menu.php
@@ -61,7 +61,7 @@ class menu
             for ($i=0;$i<$GLOBALS['config']['Multisites-nombre'];$i++) {
                 $j=$i+1;
                 $menu[30][$j]['titre']=$GLOBALS['config']["Multisites-site".$j];
-                $menu[30][$j]['url']="index.php?page=planning/poste/index.php&amp;site=$j";
+                $menu[30][$j]['url']="index.php?page=planning/poste/index.php&site=$j";
             }
         }
 


### PR DESCRIPTION
Test plan:
  - Enable multi-sites,
  - go to a symfonized page (i.e /config)
  - click on Planning => site 2
  - get site 1 # Not OK. Url is like page=planning/poste/index.php&amp;site=2
  - Apply this patch,
  - repeat test plan
  => OK