### PR TITLE
Use common function for getting managed agents in holiday and comptime controllers

### DIFF
--- a/src/Controller/CompTimeController.php
+++ b/src/Controller/CompTimeController.php
@@ -70,27 +70,8 @@ class CompTimeController extends BaseController
         // Search agents
         $agents = array();
         if ($this->admin) {
-            $p = new \personnel();
-            $p->responsablesParAgent = true;
-            $p->fetch();
-            $agents = $p->elements;
-
-            // If Absences-notifications-agent-par-agent is enables,
-            // filter unmanaged agents.
-            if ($this->config('Absences-notifications-agent-par-agent') and !$this->adminN2) {
-                $tmp = array();
-
-                foreach ($agents as $elem) {
-                    foreach ($elem['responsables'] as $resp) {
-                        if ($resp['responsable'] == $_SESSION['login_id']) {
-                            $tmp[$elem['id']] = $elem;
-                            break;
-                        }
-                    }
-                }
-
-                $agents = $tmp;
-            }
+            $helper = new HolidayHelper();
+            $agents = $helper->getManagedAgent($this->adminN2, false);
         }
 
         if (empty($agents[$_SESSION['login_id']])) {

--- a/src/PlanningBiblio/Helper/HolidayHelper.php
+++ b/src/PlanningBiblio/Helper/HolidayHelper.php
@@ -205,6 +205,58 @@ class HolidayHelper extends BaseHelper
         return $this->config('conges-hours-per-day');
     }
 
+    public function getManagedAgent($adminN2, $deleted_agents = false)
+    {
+        $access_rights = $GLOBALS['droits'];
+
+        $agents = array();
+        $p=new \personnel();
+        $p->responsablesParAgent = true;
+        if ($deleted_agents) {
+            $p->supprime=array(0,1);
+        }
+        $p->fetch();
+        $agents=$p->elements;
+
+        // If config Multi-sites : keep only users that we can manage.
+        if ($this->config('Multisites-nombre') > 1) {
+            $tmp = array();
+
+            foreach ($agents as $elem) {
+                if (is_array($elem['sites'])) {
+                    foreach ($elem['sites'] as $site_agent) {
+                        if (in_array((400+$site_agent), $access_rights) or in_array((600+$site_agent), $access_rights)) {
+                            $tmp[$elem['id']] = $elem;
+                            continue 2;
+                        }
+                    }
+                }
+            }
+            $agents = $tmp;
+        }
+
+        // Filtre pour n'afficher que les agents gérés si l'option "Absences-notifications-agent-par-agent" est cochée
+        if ($this->config('Absences-notifications-agent-par-agent') and !$adminN2) {
+            $tmp = array();
+
+            foreach ($agents as $elem) {
+                if ($elem['id'] == $_SESSION['login_id']) {
+                    $tmp[$elem['id']] = $elem;
+                } else {
+                    foreach ($elem['responsables'] as $resp) {
+                        if ($resp['responsable'] == $_SESSION['login_id']) {
+                            $tmp[$elem['id']] = $elem;
+                            break;
+                        }
+                    }
+                }
+            }
+            $agents = $tmp;
+        }
+
+        return $agents;
+    }
+
     private function applyWeekTable($week)
     {
         if($this->config('Conges-Mode') == 'heures' || $this->data['is_recover']) {

--- a/tests/PlanningBiblio/Helper/HolidayHelperTest.php
+++ b/tests/PlanningBiblio/Helper/HolidayHelperTest.php
@@ -1,0 +1,62 @@
+<?php
+
+use App\PlanningBiblio\Helper\HolidayHelper;
+use PHPUnit\Framework\TestCase;
+use Tests\Utils;
+
+class HolidayHelperTest extends TestCase
+{
+    public function testgetManagedAgentMultiSitesNonAdmin() {
+        $GLOBALS['config']['Multisites-nombre'] = 2;
+
+        // Logged in user can manage holidays for agent in site 1.
+        $GLOBALS['droits'] = array(
+            23,6,9,701,3,4,21,1101,
+            1201,22,5,17,1301,25,201,
+            202,501,502,301,302,
+            1001,1002,901,801,802,6,9,99,100,20
+        );
+
+        $luc_site1 = Utils::createAgent(array('login' => 'luc', 'sites' => '["1"]'));
+        $eric_site2 = Utils::createAgent(array('login'=> 'eric', 'sites' => '["2"]'));
+
+        $helper = new HolidayHelper();
+        $managed_agents = $helper->getManagedAgent(true, false);
+
+        $this->assertArrayNotHasKey($luc_site1->id(), $managed_agents);
+        $this->assertArrayNotHasKey($eric_site2->id(), $managed_agents);
+    }
+
+    public function testgetManagedAgentMultiSites() {
+        $GLOBALS['config']['Multisites-nombre'] = 2;
+
+        // Logged in user can manage holidays for agent in site 1.
+        $GLOBALS['droits'] = array(
+            23,6,9,701,3,4,21,1101,
+            1201,22,5,17,1301,25,201,
+            202,501,502,401,601,301,302,
+            1001,1002,901,801,802,6,9,99,100,20
+        );
+
+        $bob_site1 = Utils::createAgent(array('login' => 'bob', 'sites' => '["1"]'));
+        $john_site2 = Utils::createAgent(array('login'=> 'john', 'sites' => '["2"]'));
+        $olivia_all_site = Utils::createAgent(array('login' => 'olivia', 'sites' => '["1","2"]'));
+        $deleted_agent = Utils::createAgent(array('login' => 'foo', 'sites' => '["1","2"]', 'supprime' => 1));
+
+        $helper = new HolidayHelper();
+        $managed_agents = $helper->getManagedAgent(true, false);
+
+        $this->assertArrayHasKey($bob_site1->id(), $managed_agents, 'Bob is on site 1: managed');
+        $this->assertArrayNotHasKey($john_site2->id(), $managed_agents, 'John is on site 2: not managed');
+        $this->assertArrayHasKey($olivia_all_site->id(), $managed_agents, 'Olivia is on all site: managed');
+        $this->assertArrayNotHasKey($deleted_agent->id(), $managed_agents, 'Agent deleted: not managed');
+
+        // Call again getManagedAgent with deleted agents
+        $managed_agents = $helper->getManagedAgent(true, true);
+        $this->assertArrayHasKey($bob_site1->id(), $managed_agents, 'Bob is on site 1: managed');
+        $this->assertArrayNotHasKey($john_site2->id(), $managed_agents, 'John is on site 2: not managed');
+        $this->assertArrayHasKey($olivia_all_site->id(), $managed_agents, 'Olivia is on all sites: managed');
+        $this->assertArrayHasKey($deleted_agent->id(), $managed_agents, 'Agent on all sites: managed');
+
+    }
+}


### PR DESCRIPTION
Test plan:

- Enable multi-sites,
- create or use an admin  account with right 401 and 601 (but not 402 or 602) => Validate holidays,
- check you have some agents in site 1 and some in site 2,
- in holiday or comptime modules:
  - in the select of agents of the list page, you should see only agents in site 1,
  - you should see only existing holidays/comptimes for agent in site 1.
  - in the new form, you should be able to select agents in site 1 only.