### PR TITLE
Fix the reset ICS URL function (20.10.xx only)

### DIFF
--- a/public/js/script.js
+++ b/public/js/script.js
@@ -523,6 +523,9 @@ function resetICSURL(id, CSRFToken, nom){
   
   if(res){
     var baseURL = $('#baseURL').val();
+    if (typeof baseURL == 'undefined') {
+      baseURL = '';
+    }
 
     $.ajax({
       url: baseURL + '/ics/ajax.resetURL.php',


### PR DESCRIPTION
Fix the reset ICS URL function (20.10.xx only)

TEST PLAN
- Enable config ICS-EXPORT
- Go to My Account / ICS Calendar
- Click on the reset URL link