### PR TITLE
MT32662 : Fix display of lines on frameworks configuration (20.10.xx only)

### DIFF
--- a/public/planning/postes_cfg/horaires.php
+++ b/public/planning/postes_cfg/horaires.php
@@ -20,7 +20,7 @@ Page incluse dans le fichier "planning/postes_cfg/modif.php"
 require_once "class.tableaux.php";
 
 $post = filter_input_array(INPUT_POST, FILTER_SANITIZE_STRING);
-$CSRFToken = $post['CSRFToken'];
+$CSRFToken = $post['CSRFToken'] ?? null;
 unset($post['CSRFToken']);
 
 //	Mise à jour du tableau (après validation)

--- a/public/planning/postes_cfg/lignes.php
+++ b/public/planning/postes_cfg/lignes.php
@@ -30,8 +30,10 @@ $postes=$p->elements;
 // Liste des lignes de séparation
 $db=new db();
 $db->select("lignes", null, null, "ORDER BY nom");
-$lignes_sep=$db->result;
-
+$lignes_sep = array();
+if ($db->result) {
+    $lignes_sep = $db->result;
+}
 
 // Le tableau (contenant les sous-tableaux)
 $t=new tableau();


### PR DESCRIPTION
MT32662 : Fix display of lines on frameworks configuration
    
    TEST PLAN
    - delete all seperation lines (administration / les tableaux)
    - edit a framework
    - select the lines tab
    - check the web server's logs
