### PR TITLE
Prevent redirect to wrong URL when config URL is not properly set

### DIFF
--- a/init/common.php
+++ b/init/common.php
@@ -1,0 +1,26 @@
+<?php
+
+use Symfony\Component\HttpFoundation\Request;
+
+use App\Model\ConfigParam;
+
+function plannoBaseUrl(Request $request) {
+    $entityManager = $GLOBALS['entityManager'];
+    $config_url = $entityManager
+        ->getRepository(ConfigParam::class)
+        ->findOneBy(array('nom' => 'URL'));
+
+    $request::setTrustedProxies(array($request->server->get('REMOTE_ADDR')), Request::HEADER_X_FORWARDED_ALL ^ Request::HEADER_X_FORWARDED_HOST);
+
+    $url = $request->getSchemeAndHttpHost() . $request->getBaseUrl();
+
+    $url = str_replace('/index.php', '', $url);
+
+    if ($config_url->valeur() != $url) {
+        $config_url->valeur($url);
+        $entityManager->persist($config_url);
+        $entityManager->flush();
+    }
+
+    return $url;
+}

--- a/public/index.php
+++ b/public/index.php
@@ -19,9 +19,12 @@ Inclut au départ les fichiers config.php, doctype.php et header.php
 Inclut à la fin le fichier footer.php
 */
 
+use Symfony\Component\HttpFoundation\Request;
+
 include_once('init.php');
 include_once(__DIR__.'/init_menu.php');
 include_once('init_templates.php');
+include_once(__DIR__ . '/../init/common.php');
 
 require_once(__DIR__.'/include/feries.php');
 if (isset($_SESSION['login_id'])) {
@@ -51,8 +54,8 @@ if (empty($_SESSION['login_id'])) {
         if ($noCAS) {
             $login_params['noCAS'] = '';
         }
-        // FIXME Here, $config['URL'] should not be set yet.
-        $login_url = "{$config['URL']}/login?" . http_build_query($login_params);
+        $base_url = plannoBaseUrl($request);
+        $login_url = "$base_url/login?" . http_build_query($login_params);
         header("Location: $login_url");
         exit;
     }

--- a/public/index_symfony.php
+++ b/public/index_symfony.php
@@ -10,6 +10,7 @@ require dirname(__DIR__).'/config/bootstrap.php';
 include_once(__DIR__.'/../init/init.php');
 include_once(__DIR__.'/../init/init_menu.php');
 include_once(__DIR__.'/../init/init_templates.php');
+include_once(__DIR__ . '/../init/common.php');
 
 if ($_SERVER['APP_DEBUG']) {
     #umask(0000);
@@ -22,8 +23,10 @@ $path = $request->getPathInfo();
 
 // Session has expired. Redirect to authentication page.
 if (empty($_SESSION['login_id']) && $path != '/login' && $path != 'logout') {
+
     $redirect = ltrim($path, '/');
-    header("Location: {$config['URL']}/login?redirURL=$redirect");
+    $base_url = plannoBaseUrl($request);
+    header("Location: $base_url/login?redirURL=$redirect");
     exit();
 }
 

--- a/src/Controller/ConfigController.php
+++ b/src/Controller/ConfigController.php
@@ -18,10 +18,6 @@ class ConfigController extends BaseController
         // Temporary folder
         $tmp_dir=sys_get_temp_dir();
 
-        // App URL
-        $request::setTrustedProxies(array($request->server->get('REMOTE_ADDR')), Request::HEADER_X_FORWARDED_ALL ^ Request::HEADER_X_FORWARDED_HOST);
-        $url = $request->getSchemeAndHttpHost() . $request->getBaseUrl();
-
         $configParams = $this->entityManager->getRepository(ConfigParam::class)->findBy(
             array(),
             array('categorie' => 'ASC', 'ordre' => 'ASC', 'id' => 'ASC')

--- a/src/Controller/ConfigController.php
+++ b/src/Controller/ConfigController.php
@@ -34,6 +34,8 @@ class ConfigController extends BaseController
                 'extra'       => $cp->extra(),
             );
 
+	    $url = plannoBaseUrl($request);
+
             if ($elem['nom'] == 'URL' ) {
                 $elem['valeur'] = $url;
             }


### PR DESCRIPTION
Test plan:
  - logout from planno,
  - set config url like this 'http://bionic'
  - try access symfonized / not symfonized Planno's pages