### PR TITLE
Working hours: fix days and week total hours with breaktimes and prevent NaN values

### DIFF
--- a/public/js/plb/planno-timepicker.js
+++ b/public/js/plb/planno-timepicker.js
@@ -75,6 +75,14 @@ function roundTimePiker(obj) {
     hours = tp.options.minHour;
   }
 
+  if (isNaN(hours)) {
+    hours = 0;
+  }
+
+  if (isNaN(rounded)) {
+    rounded = 0;
+  }
+
   $(obj).val(formatHHmm(hours, rounded));
 }
 

--- a/public/planningHebdo/js/script.planningHebdo.js
+++ b/public/planningHebdo/js/script.planningHebdo.js
@@ -60,7 +60,7 @@ function plHebdoCalculHeures(object,num){
     if ($("input[name*='breaktime["+i+"]']").val()){
       breaktime = $("input[name*='breaktime["+i+"]']").val();
       hm = breaktime.split(':');
-      breaktime = (hm[0] + (hm[1] / 60))
+      breaktime = (parseInt(hm[0]) + (hm[1] / 60))
     }
     
     diff=0;


### PR DESCRIPTION
Test plan:

- Edit working hours (planning_hebdo enabled),
- In the column "Temps de pause" set a value et check total days/week countdown:
  - 00:15 => ok,
  - 00:30 => ok,
  - 01:00 => KO,
  - 01:30 => KO,
  - 02:00 => KO,

Only values up to 00:45 fail.
Also, if i manually empty a timepicker, the value become NaN:NaN