### PR TITLE
Lines with cells specifically disabled are never considered as empty

### DIFF
--- a/public/planning/poste/fonctions.php
+++ b/public/planning/poste/fonctions.php
@@ -194,7 +194,7 @@ function isAnEmptyLine($poste)
         return false;
     }
     foreach ($GLOBALS['cellules'] as $elem) {
-        if ($poste==$elem['poste']) {
+        if ($poste==$elem['poste'] && $elem['perso_id']) {
             return false;
         }
     }


### PR DESCRIPTION
Specifically disabled means: Disabled directly in the day planning and not in the framework configuration, so disabled for the current day and not for days using the framework).
When disabling a cell directly in the planning (right click on the planning and click on "Griser la cellule"), a new entry is added in pl_poste table (that for keep the "local" or "specific" disabling) with column perso_id == 0. For that reason, an empty line with a localy disabled cell is never considered as empty.

Test plan:
  - Uncheck Planning-lignesVides option (configuration => Planning) to get empty lines hidden,
  - On a planning, leave a line empty (without any agent),
  - Right click on a cell in the empty line and click on "Griser la cellule",
  - Lock the planning,
  - The empty line is not hidden.
  - Apply this patch,
  - repeat the test plan,
  - empty line is hidden
