### PR TITLE
Return access denied when editing unknown absence id

### DIFF
--- a/src/Controller/AbsenceController.php
+++ b/src/Controller/AbsenceController.php
@@ -340,7 +340,7 @@ class AbsenceController extends BaseController
         $a->fetchById($id);
 
         if (empty($a->elements)) {
-            include __DIR__.'/../include/accessDenied.php';
+            return $this->output('access-denied.html.twig');
         }
 
         $absence = $a->elements;


### PR DESCRIPTION
Test plan:
 - edit an absence by manually typing non existing absence id: /absence/<unknown_id>
 => get an empty absence form
 - apply this patch
 - edit an absence by manually typing non existing absence id: /absence/<unknown_id>
 - get access denied