### PR TITLE
MT34284 : ICS : add a default cal_name is does not exist

### DIFF
--- a/public/ics/class.ics.php
+++ b/public/ics/class.ics.php
@@ -48,6 +48,7 @@ class CJICS
     public $CSRFToken = null;
     public $error=null;
     public $logs=null;
+    public $number = 0;
     public $pattern=null;
     public $perso_id=0;
     public $status = 'CONFIRMED';
@@ -139,8 +140,12 @@ class CJICS
         $events = $ical->events();
 
         // Récupération du nom du calendrier
-        $calName=$ical->calendarName();
+        $calName = $ical->calendarName();
         $calName = removeAccents($calName);
+
+        if (empty($calName)) {
+            $calName = "imported_calendar_{$this->number}_for_agent_$perso_id";
+        }
 
         // Product ID / Product name
         $prodID = $ical->calendarProdID();

--- a/src/Cron/Legacy/cron.ics.php
+++ b/src/Cron/Legacy/cron.ics.php
@@ -176,6 +176,7 @@ foreach ($agents as $agent) {
         $ics->perso_id=$agent["id"];
         $ics->pattern = $config["ICS-Pattern$i"];
         $ics->status = $config["ICS-Status$i"];
+        $ics->number = $i;
         $ics->table="absences";
         $ics->logs=true;
         $ics->CSRFToken = $CSRFToken;


### PR DESCRIPTION
Attention : events imported with an empty cal_name since commit 9580a31ced3333b9a4310884d498e4081caaa7ae (Fri Sept 24) must be manualy deleted from DB. If not, they will be duplicated.

eg  : delete from absences where cal_name='' and ical_key is not null;