### PR TITLE
Prevent creating empty working hours for non authorized users

### DIFF
--- a/src/Controller/AuthorizationsController.php
+++ b/src/Controller/AuthorizationsController.php
@@ -5,6 +5,7 @@ namespace App\Controller;
 use App\Controller\BaseController;
 
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 use Psr\Log\LoggerInterface;
@@ -166,7 +167,8 @@ class AuthorizationsController extends BaseController
      */
     public function denied(Request $request)
     {
-        return $this->output('access-denied.html.twig');
+        $content = $this->renderView('access-denied.html.twig');
+        return new Response($content, 403);
     }
 
     private function redirectCAS($logger)

--- a/src/Controller/WorkingHourController.php
+++ b/src/Controller/WorkingHourController.php
@@ -296,6 +296,11 @@ class WorkingHourController extends BaseController
         $nbSemaine = $this->config('nb_semaine');
         $nbSites = $this->config('Multisites-nombre');
         $multisites = array();
+
+        if (!$admin && !$this->config('PlanningHebdo-Agents') ) {
+            return $this->redirectToRoute('access-denied');
+        }
+
         for ($i = 1; $i < $nbSites+1; $i++) {
             $sites[] = $i;
             $multisites[$i] = $this->config("Multisites-site{$i}");

--- a/tests/Controller/WorkingHourControllerTest.php
+++ b/tests/Controller/WorkingHourControllerTest.php
@@ -122,4 +122,23 @@ class WorkingHourControllerTest extends PLBWebTestCase
         $this->assertEquals('Accepté', $statuses[3], 'User with 1201 right can choose status accepted level 2');
         $this->assertEquals('Refusé', $statuses[4], 'User with 1201 right can choose status rejected level 2');
     }
+
+    public function testCreateOwnWorkingHours() {
+        $client = static::createClient();
+        $builder = new FixtureBuilder();
+        $builder->delete(Agent::class);
+
+        $GLOBALS['config']['PlanningHebdo-Agents'] = 0;
+
+        $agent = $builder->build(Agent::class, array('login' => 'test'));
+
+        $this->logInAgent($agent, array(100));
+        $client->request('GET', '/workinghour/add');
+        $client->followRedirect();
+        $this->assertEquals(
+            403,
+            $client->getResponse()->getStatusCode(),
+            'With PlanningHebdo-Agents disabled, users without right cannot create own working hours'
+        );
+    }
 }


### PR DESCRIPTION
Test plan:
  - Disable PlanningHebdo-Agents,
  - Log in with an agent without right for working hours,
  - Access /workinghour/add
  => Access is OK (http code 200) and should not,
  => You cannot edit hours (disabled) but you can save empty hours and should not.