### PR TITLE
MT34252: Data purge

### DIFF
--- a/public/absences/class.absences.php
+++ b/public/absences/class.absences.php
@@ -727,22 +727,6 @@ class absences
         return false;
     }
 
-    public function deleteAllDocuments() {
-        if (!$this->id) return;
-        $entityManager = $GLOBALS['entityManager'];
-        $absdocs = $entityManager->getRepository(AbsenceDocument::class)->findBy(['absence_id' => $this->id]);
-        foreach ($absdocs as $absdoc) {
-            $absdoc->deleteFile();
-            $entityManager->remove($absdoc);
-        }
-        $entityManager->flush();
-
-        $absenceDocument = new AbsenceDocument();
-        if (is_dir($absenceDocument->upload_dir() . $this->id)) {
-            rmdir($absenceDocument->upload_dir() . $this->id);
-        }
-    }
-
     public function fetch($sort="`debut`,`fin`,`nom`,`prenom`", $agent=null, $debut=null, $fin=null, $sites=null)
     {
         $entityManager = $GLOBALS['entityManager'];

--- a/public/setup/atomicupdate/20211022_MT34252.php
+++ b/public/setup/atomicupdate/20211022_MT34252.php
@@ -1,0 +1,9 @@
+<?php
+
+$sql[] = "ALTER TABLE `{$dbprefix}absences_recurrentes` MODIFY last_update TIMESTAMP";
+$sql[] = "ALTER TABLE `{$dbprefix}absences_recurrentes` MODIFY last_check TIMESTAMP";
+
+$sql[] = "ALTER TABLE `{$dbprefix}absences_infos` MODIFY debut DATE";
+$sql[] = "ALTER TABLE `{$dbprefix}absences_infos` MODIFY fin DATE";
+
+$sql[] = "ALTER TABLE `{$dbprefix}pl_notifications` MODIFY date DATE";

--- a/public/setup/db_structure.php
+++ b/public/setup/db_structure.php
@@ -51,8 +51,8 @@ $sql[]="CREATE TABLE `{$dbprefix}absences` (
 
 $sql[]="CREATE TABLE `{$dbprefix}absences_infos` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `debut` date NOT NULL DEFAULT '0000-00-00',
-  `fin` date NOT NULL DEFAULT '0000-00-00',
+  `debut` date DATE',
+  `fin` date DATE,
   `texte` text NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=MyISAM  DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci;";
@@ -64,8 +64,8 @@ $sql[]="CREATE TABLE `{$dbprefix}absences_recurrentes` (
   `event` TEXT,
   `end` ENUM ('0','1') NOT NULL DEFAULT '0',
   `timestamp` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  `last_update` VARCHAR(20) NOT NULL DEFAULT '',
-  `last_check` VARCHAR(20) NOT NULL DEFAULT '',
+  `last_update` TIMESTAMP,
+  `last_check` TIMESTAMP,
   PRIMARY KEY (`id`),
   KEY `uid`(`uid`),
   KEY `perso_id`(`perso_id`), 
@@ -190,7 +190,7 @@ $sql[]="CREATE TABLE `{$dbprefix}pl_notes` (
 
 $sql[]="CREATE TABLE `{$dbprefix}pl_notifications` (
   `id` INT(11) NOT NULL AUTO_INCREMENT, 
-  `date` VARCHAR(10),
+  `date` DATE,
   `site` INT(2) NOT NULL DEFAULT '1',
   `update_time` TIMESTAMP,
   `data` TEXT,

--- a/src/Controller/AbsenceController.php
+++ b/src/Controller/AbsenceController.php
@@ -4,6 +4,7 @@ namespace App\Controller;
 
 use App\Controller\BaseController;
 use App\Model\AbsenceDocument;
+use App\Model\Absence;
 use App\Model\Agent;
 
 use Symfony\Component\HttpFoundation\Request;
@@ -517,6 +518,7 @@ class AbsenceController extends BaseController
      */
     public function delete_absence(Request $request)
     {
+
         $CSRFToken = $request->get('CSRFToken');
         $id = $request->get('id');
         $recurrent = $request->get('rec');
@@ -577,7 +579,7 @@ class AbsenceController extends BaseController
             return $this->json($json_response);
         }
 
-        $a->deleteAllDocuments();
+        $this->entityManager->getRepository(Absence::class)->deleteAllDocuments($id);
 
         // Send an email to agent and in charge.
         $message="<b><u/>Suppression d'une absence</u></b> : \n";

--- a/src/Cron/PurgeData.php
+++ b/src/Cron/PurgeData.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Cron;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Command\LockableTrait;
+
+use App\PlanningBiblio\DataPurger;
+
+class PurgeData extends Command {
+
+    use LockableTrait;
+
+    protected function configure () {
+        $this->setName('PlanningBiblio:PurgeData');
+        $this->setDescription("Purges PlanningBiblio old data");
+        $this->setHelp("
+Purges PlanningBiblio old data.
+The delay parameter is the number of years to purge. It is optional (set to 5 by default)
+Usage:   php bin/console PlanningBiblio:PurgeData \"<YEARS>\"
+Example: php bin/console PlanningBiblio:PurgeData \"5\"
+        ");
+        $this->addArgument('delay', InputArgument::OPTIONAL, 'Number of years (5 by default)');
+        $this->addOption('stdout', null, InputOption::VALUE_OPTIONAL, 'Output result in stdout', false);
+    }
+
+    public function execute (InputInterface $input, OutputInterface $output) {
+
+        if (!$this->lock()) {
+            $output->writeln('The command is already running in another process.');
+            return 0;
+        }
+
+        $delay = $input->getArgument('delay');
+        if ($delay != null) {
+            if (!is_numeric($delay)) {
+                $output->writeln('The delay argument must be a number of years.');
+                return 0;
+            }
+        } else {
+            $delay = 5;
+        }
+
+        $kernel = $this->getApplication()->getKernel();
+        $container = $kernel->getContainer();
+        $em = $container->get('doctrine')->getManager();
+
+        $dataPurger = new DataPurger($em, $delay, $input->getOption('stdout'));
+        $dataPurger->purge();
+
+        $this->release();
+    }
+}
+
+?>

--- a/src/Cron/PurgeLogTable.php
+++ b/src/Cron/PurgeLogTable.php
@@ -39,6 +39,7 @@ Example: php bin/console PlanningBiblio:PurgeLogTable \"12 MONTH\"
         $kernel = $this->getApplication()->getKernel();
         $container = $kernel->getContainer();
         $em = $container->get('doctrine')->getManager();
+        // TODO: Now that the model exists, I could be replaced by a query builder.
         $query = "DELETE FROM " . $_ENV['DATABASE_PREFIX'] . "log WHERE timestamp < (NOW() - INTERVAL $delay)";
         $statement = $em->getConnection()->prepare($query);
         $statement->execute();

--- a/src/Model/Absence.php
+++ b/src/Model/Absence.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Model;
+
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\GeneratedValue;
+
+/**
+ * @Entity(repositoryClass="App\Repository\AbsenceRepository") @Table(name="absences")
+ **/
+class Absence extends PLBEntity
+{
+    /** @Id @Column(type="integer") @GeneratedValue **/
+    protected $id;
+
+    /** @Column(type="integer") **/
+    protected $perso_id;
+
+    /** @Column(type="datetime") **/
+    protected $debut;
+
+    /** @Column(type="datetime") */
+    protected $fin;
+
+    /** @Column(type="text") */
+    protected $motif;
+
+    /** @Column(type="text") */
+    protected $motif_autre;
+
+    /** @Column(type="text") */
+    protected $commentaires;
+
+    /** @Column(type="text") */
+    protected $etat;
+
+    /** @Column(type="datetime") */
+    protected $demande;
+
+    /** @Column(type="integer") */
+    protected $valide;
+
+    /** @Column(type="datetime") */
+    protected $validation;
+
+    /** @Column(type="integer") */
+    protected $valide_n1;
+
+    /** @Column(type="datetime") */
+    protected $validation_n1;
+
+    /** @Column(type="integer") */
+    protected $pj1;
+
+    /** @Column(type="integer") */
+    protected $pj2;
+
+    /** @Column(type="integer") */
+    protected $so;
+
+    /** @Column(type="string") */
+    protected $groupe;
+
+    /** @Column(type="text") */
+    protected $cal_name;
+
+    /** @Column(type="text") */
+    protected $ical_key;
+
+    /** @Column(type="text") */
+    protected $external_ical_key;
+
+    /** @Column(type="string") */
+    protected $last_modified;
+
+    /** @Column(type="text") */
+    protected $uid;
+
+    /** @Column(type="text") */
+    protected $rrule;
+
+    /** @Column(type="integer") */
+    protected $id_origin;
+}

--- a/src/Model/Absence.php
+++ b/src/Model/Absence.php
@@ -70,9 +70,6 @@ class Absence extends PLBEntity
     /** @Column(type="text") */
     protected $ical_key;
 
-    /** @Column(type="text") */
-    protected $external_ical_key;
-
     /** @Column(type="string") */
     protected $last_modified;
 

--- a/src/Model/AbsenceDocument.php
+++ b/src/Model/AbsenceDocument.php
@@ -2,6 +2,12 @@
 
 namespace App\Model;
 
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\GeneratedValue;
+
 /**
  * @Entity @Table(name="absences_documents")
  **/

--- a/src/Model/AbsenceDocument.php
+++ b/src/Model/AbsenceDocument.php
@@ -2,11 +2,7 @@
 
 namespace App\Model;
 
-use Doctrine\ORM\Mapping\Entity;
-use Doctrine\ORM\Mapping\Table;
-use Doctrine\ORM\Mapping\Id;
-use Doctrine\ORM\Mapping\Column;
-use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\{Entity, Table, Id, Column, GeneratedValue};
 
 /**
  * @Entity @Table(name="absences_documents")

--- a/src/Model/AbsenceInfo.php
+++ b/src/Model/AbsenceInfo.php
@@ -2,11 +2,7 @@
 
 namespace App\Model;
 
-use Doctrine\ORM\Mapping\Entity;
-use Doctrine\ORM\Mapping\Table;
-use Doctrine\ORM\Mapping\Id;
-use Doctrine\ORM\Mapping\Column;
-use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\{Entity, Table, Id, Column, GeneratedValue};
 
 /**
  * @Entity @Table(name="absences_infos")

--- a/src/Model/AbsenceReason.php
+++ b/src/Model/AbsenceReason.php
@@ -5,7 +5,8 @@ namespace App\Model;
 /**
  * @Entity @Table(name="select_abs")
  **/
-class AbsenceReason extends PLBEntity {
+class AbsenceReason extends PLBEntity
+{
     /** @Id @Column(type="integer") @GeneratedValue **/
     protected $id;
 

--- a/src/Model/AdminInfo.php
+++ b/src/Model/AdminInfo.php
@@ -2,11 +2,7 @@
 
 namespace App\Model;
 
-use Doctrine\ORM\Mapping\Entity;
-use Doctrine\ORM\Mapping\Table;
-use Doctrine\ORM\Mapping\Id;
-use Doctrine\ORM\Mapping\Column;
-use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\{Entity, Table, Id, Column, GeneratedValue};
 
 /**
  * @Entity @Table(name="infos")

--- a/src/Model/Agent.php
+++ b/src/Model/Agent.php
@@ -11,9 +11,10 @@ require_once(__DIR__ . '/../../public/absences/class.absences.php');
 require_once(__DIR__ . '/../../public/include/db.php');
 
 /**
- * @Entity @Table(name="personnel")
+ * @Entity(repositoryClass="App\Repository\AgentRepository") @Table(name="personnel")
  **/
-class Agent extends PLBEntity {
+class Agent extends PLBEntity
+{
     /** @Id @Column(type="integer") @GeneratedValue **/
     protected $id;
 

--- a/src/Model/CallForHelp.php
+++ b/src/Model/CallForHelp.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Model;
+
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\GeneratedValue;
+
+/**
+ * @Entity @Table(name="appel_dispo")
+ **/
+class CallForHelp extends PLBEntity
+{
+    /** @Id @Column(type="integer") @GeneratedValue **/
+    protected $id;
+
+    /** @Column(type="integer") **/
+    protected $site;
+
+    /** @Column(type="integer") **/
+    protected $poste;
+
+    /** @Column(type="datetime") **/
+    protected $date;
+
+    /** @Column(type="datetime") **/
+    protected $debut;
+
+    /** @Column(type="datetime") **/
+    protected $fin;
+
+    /** @Column(type="text") **/
+    protected $destinataires;
+
+    /** @Column(type="text") **/
+    protected $sujet;
+
+    /** @Column(type="text") **/
+    protected $message;
+
+    /** @Column(type="datetime") **/
+    protected $timestamp;
+}

--- a/src/Model/CompTime.php
+++ b/src/Model/CompTime.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Model;
+
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\GeneratedValue;
+
+/**
+ * @Entity @Table(name="recuperations")
+ **/
+class CompTime extends PLBEntity
+{
+    /** @Id @Column(type="integer") @GeneratedValue **/
+    protected $id;
+
+    /** @Column(type="integer") **/
+    protected $perso_id;
+
+    /** @Column(type="date") **/
+    protected $date;
+
+    /** @Column(type="date") **/
+    protected $date2;
+
+    /** @Column(type="float") **/
+    protected $heures;
+
+    /** @Column(type="string") **/
+    protected $etat;
+
+    /** @Column(type="text") **/
+    protected $commentaires;
+
+    /** @Column(type="datetime") **/
+    protected $saisie;
+
+    /** @Column(type="integer") **/
+    protected $saisie_par;
+
+    /** @Column(type="integer") **/
+    protected $modif;
+
+    /** @Column(type="datetime") **/
+    protected $modification;
+
+    /** @Column(type="integer") **/
+    protected $valide_n1;
+
+    /** @Column(type="datetime") **/
+    protected $validation_n1;
+
+    /** @Column(type="integer") **/
+    protected $valide;
+
+    /** @Column(type="datetime") **/
+    protected $validation;
+
+    /** @Column(type="text") **/
+    protected $refus;
+
+    /** @Column(type="float") **/
+    protected $solde_prec;
+
+    /** @Column(type="float") **/
+    protected $solde_actuel;
+}

--- a/src/Model/Detached.php
+++ b/src/Model/Detached.php
@@ -9,20 +9,17 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\GeneratedValue;
 
 /**
- * @Entity @Table(name="infos")
+ * @Entity @Table(name="volants")
  **/
-class AdminInfo extends PLBEntity
+class Detached extends PLBEntity
 {
     /** @Id @Column(type="integer") @GeneratedValue **/
     protected $id;
 
-    /** @Column(type="string") **/
-    protected $debut;
+    /** @Column(type="date") **/
+    protected $date;
 
-    /** @Column(type="string") **/
-    protected $fin;
-
-    /** @Column(type="text") **/
-    protected $texte;
+    /** @Column(type="integer") **/
+    protected $perso_id;
 
 }

--- a/src/Model/HiddenTables.php
+++ b/src/Model/HiddenTables.php
@@ -9,20 +9,24 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\GeneratedValue;
 
 /**
- * @Entity @Table(name="infos")
+ * @Entity @Table(name="hidden_tables")
  **/
-class AdminInfo extends PLBEntity
+class HiddenTables extends PLBEntity
 {
     /** @Id @Column(type="integer") @GeneratedValue **/
     protected $id;
 
-    /** @Column(type="string") **/
-    protected $debut;
+    /** @Column(type="integer") **/
+    protected $perso_id;
 
-    /** @Column(type="string") **/
-    protected $fin;
+    /** @Column(type="integer") **/
+    protected $tableau;
 
     /** @Column(type="text") **/
-    protected $texte;
+    protected $hidden_tables;
 
+    public function purge()
+    {
+        error_log("hidden tables purge");
+    }
 }

--- a/src/Model/Holiday.php
+++ b/src/Model/Holiday.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace App\Model;
+
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\GeneratedValue;
+
+/**
+ * @Entity @Table(name="conges")
+ **/
+class Holiday extends PLBEntity
+{
+    /** @Id @Column(type="integer") @GeneratedValue **/
+    protected $id;
+
+    /** @Column(type="integer") **/
+    protected $perso_id;
+
+    /** @Column(type="datetime") **/
+    protected $debut;
+
+    /** @Column(type="datetime") */
+    protected $fin;
+
+    /** @Column(type="string") */
+    protected $start_halfday;
+
+    /** @Column(type="string") */
+    protected $end_halfday;
+
+    /** @Column(type="text") */
+    protected $commentaires;
+
+    /** @Column(type="text") */
+    protected $refus;
+
+    /** @Column(type="string") */
+    protected $heures;
+
+    /** @Column(type="string") */
+    protected $debit;
+
+    /** @Column(type="datetime") */
+    protected $saisie;
+
+    /** @Column(type="integer") */
+    protected $saisie_par;
+
+    /** @Column(type="integer") */
+    protected $modif;
+
+    /** @Column(type="datetime") */
+    protected $modification;
+
+    /** @Column(type="integer") */
+    protected $valide_n1;
+
+    /** @Column(type="datetime") */
+    protected $validation_n1;
+
+    /** @Column(type="integer") */
+    protected $valide;
+
+    /** @Column(type="datetime") */
+    protected $validation;
+
+    /** @Column(type="float") */
+    protected $solde_prec;
+
+    /** @Column(type="float") */
+    protected $solde_actuel;
+
+    /** @Column(type="float") */
+    protected $recup_prec;
+
+    /** @Column(type="float") */
+    protected $recup_actuel;
+
+    /** @Column(type="float") */
+    protected $reliquat_prec;
+
+    /** @Column(type="float") */
+    protected $reliquat_actuel;
+
+    /** @Column(type="float") */
+    protected $anticipation_prec;
+
+    /** @Column(type="float") */
+    protected $anticipation_actuel;
+
+    /** @Column(type="integer") */
+    protected $supprime;
+
+    /** @Column(type="datetime") */
+    protected $suppr_date;
+
+    /** @Column(type="integer") */
+    protected $information;
+
+    /** @Column(type="datetime") */
+    protected $info_date;
+
+    /** @Column(type="integer") */
+    protected $regul_id;
+
+    /** @Column(type="integer") */
+    protected $origin_id;
+
+}

--- a/src/Model/Holiday.php
+++ b/src/Model/Holiday.php
@@ -2,11 +2,7 @@
 
 namespace App\Model;
 
-use Doctrine\ORM\Mapping\Entity;
-use Doctrine\ORM\Mapping\Table;
-use Doctrine\ORM\Mapping\Id;
-use Doctrine\ORM\Mapping\Column;
-use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\{Entity, Table, Id, Column, GeneratedValue};
 
 /**
  * @Entity @Table(name="conges")
@@ -22,91 +18,93 @@ class Holiday extends PLBEntity
     /** @Column(type="datetime") **/
     protected $debut;
 
-    /** @Column(type="datetime") */
+    /** @Column(type="datetime") **/
     protected $fin;
 
-    /** @Column(type="string") */
+    /** @Column(type="integer", length=4) **/
+    protected $halfday;
+
+    /** @Column(type="string", length=20) **/
     protected $start_halfday;
 
-    /** @Column(type="string") */
+    /** @Column(type="string", length=20) **/
     protected $end_halfday;
 
-    /** @Column(type="text") */
+    /** @Column(type="text")**/
     protected $commentaires;
 
-    /** @Column(type="text") */
+    /** @Column(type="text")**/
     protected $refus;
 
-    /** @Column(type="string") */
+    /** @Column(type="string", length=20) **/
     protected $heures;
 
-    /** @Column(type="string") */
+    /** @Column(type="string", length=20) **/
     protected $debit;
 
-    /** @Column(type="datetime") */
+    /** @Column(type="datetime") **/
     protected $saisie;
 
-    /** @Column(type="integer") */
+    /** @Column(type="integer", length=11) **/
     protected $saisie_par;
 
-    /** @Column(type="integer") */
+    /** @Column(type="integer", length=11) **/
     protected $modif;
 
-    /** @Column(type="datetime") */
+    /** @Column(type="datetime") **/
     protected $modification;
 
-    /** @Column(type="integer") */
+    /** @Column(type="integer", length=11) **/
     protected $valide_n1;
 
-    /** @Column(type="datetime") */
+    /** @Column(type="datetime") **/
     protected $validation_n1;
 
-    /** @Column(type="integer") */
+    /** @Column(type="integer", length=11) **/
     protected $valide;
 
-    /** @Column(type="datetime") */
+    /** @Column(type="datetime") **/
     protected $validation;
 
-    /** @Column(type="float") */
+    /** @Column(type="float")**/
     protected $solde_prec;
 
-    /** @Column(type="float") */
+    /** @Column(type="float")**/
     protected $solde_actuel;
 
-    /** @Column(type="float") */
+    /** @Column(type="float")**/
     protected $recup_prec;
 
-    /** @Column(type="float") */
+    /** @Column(type="float")**/
     protected $recup_actuel;
 
-    /** @Column(type="float") */
+    /** @Column(type="float")**/
     protected $reliquat_prec;
 
-    /** @Column(type="float") */
+    /** @Column(type="float")**/
     protected $reliquat_actuel;
 
-    /** @Column(type="float") */
+    /** @Column(type="float")**/
     protected $anticipation_prec;
 
-    /** @Column(type="float") */
+    /** @Column(type="float")**/
     protected $anticipation_actuel;
 
-    /** @Column(type="integer") */
+    /** @Column(type="integer", length=11) **/
     protected $supprime;
 
-    /** @Column(type="datetime") */
+    /** @Column(type="datetime") **/
     protected $suppr_date;
 
-    /** @Column(type="integer") */
+    /** @Column(type="integer", length=11) **/
     protected $information;
 
-    /** @Column(type="datetime") */
+    /** @Column(type="datetime") **/
     protected $info_date;
 
-    /** @Column(type="integer") */
+    /** @Column(type="integer", length=11) **/
     protected $regul_id;
 
-    /** @Column(type="integer") */
+    /** @Column(type="integer", length=11) **/
     protected $origin_id;
-
 }

--- a/src/Model/HolidayCET.php
+++ b/src/Model/HolidayCET.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Model;
+
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\GeneratedValue;
+
+/**
+ * @Entity @Table(name="conges_cet")
+ **/
+class HolidayCET extends PLBEntity
+{
+    /** @Id @Column(type="integer") @GeneratedValue **/
+    protected $id;
+
+    /** @Column(type="integer") **/
+    protected $perso_id;
+
+    /** @Column(type="int") **/
+    protected $jours;
+
+    /** @Column(type="text") */
+    protected $commentaires;
+
+    /** @Column(type="datetime") */
+    protected $saisie;
+
+    /** @Column(type="integer") */
+    protected $saisie_par;
+
+    /** @Column(type="integer") */
+    protected $modif;
+
+    /** @Column(type="datetime") */
+    protected $modification;
+
+    /** @Column(type="integer") */
+    protected $valide_n1;
+
+    /** @Column(type="datetime") */
+    protected $validation_n1;
+
+    /** @Column(type="integer") */
+    protected $valide_n2;
+
+    /** @Column(type="datetime") */
+    protected $validation_n2;
+
+    /** @Column(type="text") */
+    protected $refus;
+
+    /** @Column(type="float") */
+    protected $solde_prec;
+
+    /** @Column(type="float") */
+    protected $solde_actuel;
+
+    /** @Column(type="string") */
+    protected $annee;
+
+}

--- a/src/Model/HolidayInfo.php
+++ b/src/Model/HolidayInfo.php
@@ -9,20 +9,23 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\GeneratedValue;
 
 /**
- * @Entity @Table(name="infos")
+ * @Entity @Table(name="conges_infos")
  **/
-class AdminInfo extends PLBEntity
+class HolidayInfo extends PLBEntity
 {
     /** @Id @Column(type="integer") @GeneratedValue **/
     protected $id;
 
-    /** @Column(type="string") **/
+    /** @Column(type="date") **/
     protected $debut;
 
-    /** @Column(type="string") **/
+    /** @Column(type="date") **/
     protected $fin;
 
     /** @Column(type="text") **/
     protected $texte;
+
+    /** @Column(type="datetime") **/
+    protected $saisie;
 
 }

--- a/src/Model/HoursAbsence.php
+++ b/src/Model/HoursAbsence.php
@@ -9,20 +9,19 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\GeneratedValue;
 
 /**
- * @Entity @Table(name="infos")
+ * @Entity @Table(name="edt_samedi")
  **/
-class AdminInfo extends PLBEntity
+class HoursAbsence extends PLBEntity
 {
     /** @Id @Column(type="integer") @GeneratedValue **/
     protected $id;
 
-    /** @Column(type="string") **/
-    protected $debut;
+    /** @Column(type="date") **/
+    protected $semaine;
 
-    /** @Column(type="string") **/
-    protected $fin;
+    /** @Column(type="integer") **/
+    protected $update_time;
 
     /** @Column(type="text") **/
-    protected $texte;
-
+    protected $heures;
 }

--- a/src/Model/IPBlocker.php
+++ b/src/Model/IPBlocker.php
@@ -9,20 +9,23 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\GeneratedValue;
 
 /**
- * @Entity @Table(name="infos")
+ * @Entity @Table(name="ip_blocker")
  **/
-class AdminInfo extends PLBEntity
+class IPBlocker extends PLBEntity
 {
     /** @Id @Column(type="integer") @GeneratedValue **/
     protected $id;
 
     /** @Column(type="string") **/
-    protected $debut;
+    protected $ip;
 
     /** @Column(type="string") **/
-    protected $fin;
+    protected $login;
 
-    /** @Column(type="text") **/
-    protected $texte;
+    /** @Column(type="string") **/
+    protected $status;
+
+    /** @Column(type="datetime") **/
+    protected $timestamp;
 
 }

--- a/src/Model/Logs.php
+++ b/src/Model/Logs.php
@@ -9,20 +9,20 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\GeneratedValue;
 
 /**
- * @Entity @Table(name="infos")
+ * @Entity @Table(name="log")
  **/
-class AdminInfo extends PLBEntity
+class Logs extends PLBEntity
 {
     /** @Id @Column(type="integer") @GeneratedValue **/
     protected $id;
 
-    /** @Column(type="string") **/
-    protected $debut;
-
-    /** @Column(type="string") **/
-    protected $fin;
-
     /** @Column(type="text") **/
-    protected $texte;
+    protected $msg;
+
+    /** @Column(type="string") **/
+    protected $program;
+
+    /** @Column(type="datetime") */
+    protected $timestamp;
 
 }

--- a/src/Model/PlanningNote.php
+++ b/src/Model/PlanningNote.php
@@ -9,28 +9,26 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\GeneratedValue;
 
 /**
- * @Entity @Table(name="acces")
+ * @Entity @Table(name="pl_notes")
  **/
-class Access extends PLBEntity
+class PlanningNote extends PLBEntity
 {
     /** @Id @Column(type="integer") @GeneratedValue **/
     protected $id;
 
-    /** @Column(type="text") **/
-    protected $nom;
+    /** @Column(type="date") **/
+    protected $date;
 
     /** @Column(type="integer") **/
-    protected $groupe_id;
+    protected $site;
 
-    /** @Column(type="text") **/
-    protected $groupe;
-
-    /** @Column(type="string") **/
-    protected $page;
+    /** @Column(type="text") */
+    protected $text;
 
     /** @Column(type="integer") **/
-    protected $ordre;
+    protected $perso_id;
 
-    /** @Column(type="string") **/
-    protected $categorie;
+    /** @Column(type="datetime") **/
+    protected $timestamp;
+
 }

--- a/src/Model/PlanningNotification.php
+++ b/src/Model/PlanningNotification.php
@@ -9,7 +9,7 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\GeneratedValue;
 
 /**
- * @Entity @Table(name="pl_notes")
+ * @Entity @Table(name="pl_notifications")
  **/
 class PlanningNotification extends PLBEntity
 {

--- a/src/Model/PlanningNotification.php
+++ b/src/Model/PlanningNotification.php
@@ -9,20 +9,22 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\GeneratedValue;
 
 /**
- * @Entity @Table(name="absences_infos")
+ * @Entity @Table(name="pl_notes")
  **/
-class AbsenceInfo extends PLBEntity
+class PlanningNotification extends PLBEntity
 {
     /** @Id @Column(type="integer") @GeneratedValue **/
     protected $id;
 
     /** @Column(type="date") **/
-    protected $debut;
+    protected $date;
 
-    /** @Column(type="date") **/
-    protected $fin;
+    /** @Column(type="integer") **/
+    protected $site;
+
+    /** @Column(type="datetime") */
+    protected $update_time;
 
     /** @Column(type="text") **/
-    protected $texte;
-
+    protected $data;
 }

--- a/src/Model/PlanningPosition.php
+++ b/src/Model/PlanningPosition.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Model;
+
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\GeneratedValue;
+
+/**
+ * @Entity @Table(name="pl_poste")
+ **/
+class PlanningPosition extends PLBEntity
+{
+    /** @Id @Column(type="integer") @GeneratedValue **/
+    protected $id;
+
+    /** @Column(type="integer") **/
+    protected $perso_id;
+
+    /** @Column(type="date") **/
+    protected $date;
+
+    /** @Column(type="integer") **/
+    protected $poste;
+
+    /** @Column(type="string") **/
+    protected $absent;
+
+    /** @Column(type="integer") **/
+    protected $chgt_login;
+
+    /** @Column(type="datetime") **/
+    protected $chgt_time;
+
+    /** @Column(type="time") **/
+    protected $debut;
+
+    /** @Column(type="time") **/
+    protected $fin;
+
+    /** @Column(type="string") **/
+    protected $supprime;
+
+    /** @Column(type="integer") **/
+    protected $site;
+
+    /** @Column(type="string") **/
+    protected $grise;
+}

--- a/src/Model/PlanningPositionCells.php
+++ b/src/Model/PlanningPositionCells.php
@@ -9,28 +9,22 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\GeneratedValue;
 
 /**
- * @Entity @Table(name="acces")
+ * @Entity @Table(name="pl_poste_cellules")
  **/
-class Access extends PLBEntity
+class PlanningPositionCells extends PLBEntity
 {
     /** @Id @Column(type="integer") @GeneratedValue **/
     protected $id;
 
-    /** @Column(type="text") **/
-    protected $nom;
+    /** @Column(type="integer") **/
+    protected $numero;
 
     /** @Column(type="integer") **/
-    protected $groupe_id;
-
-    /** @Column(type="text") **/
-    protected $groupe;
-
-    /** @Column(type="string") **/
-    protected $page;
+    protected $tableau;
 
     /** @Column(type="integer") **/
-    protected $ordre;
+    protected $ligne;
 
-    /** @Column(type="string") **/
-    protected $categorie;
+    /** @Column(type="integer") **/
+    protected $colonne;
 }

--- a/src/Model/PlanningPositionHours.php
+++ b/src/Model/PlanningPositionHours.php
@@ -9,20 +9,22 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\GeneratedValue;
 
 /**
- * @Entity @Table(name="infos")
+ * @Entity @Table(name="pl_poste_horaires")
  **/
-class AdminInfo extends PLBEntity
+class PlanningPositionHours extends PLBEntity
 {
     /** @Id @Column(type="integer") @GeneratedValue **/
     protected $id;
 
-    /** @Column(type="string") **/
+    /** @Column(type="time") **/
     protected $debut;
 
-    /** @Column(type="string") **/
+    /** @Column(type="time") **/
     protected $fin;
 
-    /** @Column(type="text") **/
-    protected $texte;
+    /** @Column(type="integer") **/
+    protected $tableau;
 
+    /** @Column(type="integer") **/
+    protected $numero;
 }

--- a/src/Model/PlanningPositionLines.php
+++ b/src/Model/PlanningPositionLines.php
@@ -9,28 +9,25 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\GeneratedValue;
 
 /**
- * @Entity @Table(name="acces")
+ * @Entity @Table(name="pl_poste_lignes")
  **/
-class Access extends PLBEntity
+class PlanningPositionLines extends PLBEntity
 {
     /** @Id @Column(type="integer") @GeneratedValue **/
     protected $id;
 
-    /** @Column(type="text") **/
-    protected $nom;
+    /** @Column(type="integer") **/
+    protected $numero;
 
     /** @Column(type="integer") **/
-    protected $groupe_id;
-
-    /** @Column(type="text") **/
-    protected $groupe;
-
-    /** @Column(type="string") **/
-    protected $page;
+    protected $tableau;
 
     /** @Column(type="integer") **/
-    protected $ordre;
+    protected $ligne;
 
     /** @Column(type="string") **/
-    protected $categorie;
+    protected $poste;
+
+    /** @Column(type="string", columnDefinition="enum('poste', 'ligne', 'titre', 'classe')") **/
+    protected $type;
 }

--- a/src/Model/PlanningPositionLock.php
+++ b/src/Model/PlanningPositionLock.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Model;
+
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\GeneratedValue;
+
+/**
+ * @Entity @Table(name="pl_poste_verrou")
+ **/
+class PlanningPositionLock extends PLBEntity
+{
+    /** @Id @Column(type="integer") @GeneratedValue **/
+    protected $id;
+
+    /** @Column(type="date") **/
+    protected $date;
+
+    /** @Column(type="integer") **/
+    protected $verrou;
+
+    /** @Column(type="datetime") **/
+    protected $validation;
+
+    /** @Column(type="integer") **/
+    protected $perso;
+
+    /** @Column(type="integer") **/
+    protected $verrou2;
+
+    /** @Column(type="datetime") **/
+    protected $validation2;
+
+    /** @Column(type="integer") **/
+    protected $perso2;
+
+    /** @Column(type="integer") **/
+    protected $vivier;
+
+    /** @Column(type="integer") **/
+    protected $site;
+}

--- a/src/Model/PlanningPositionModel.php
+++ b/src/Model/PlanningPositionModel.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Model;
+
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\GeneratedValue;
+
+/**
+ * @Entity @Table(name="pl_poste_modeles")
+ **/
+class PlanningPositionModel extends PLBEntity
+{
+    /** @Id @Column(type="integer") @GeneratedValue **/
+    protected $id;
+
+    /** @Column(type="integer") **/
+    protected $model_id;
+
+    /** @Column(type="integer") **/
+    protected $perso_id;
+
+    /** @Column(type="integer") **/
+    protected $poste;
+
+    /** @Column(type="text") **/
+    protected $commentaire;
+
+    /** @Column(type="time") **/
+    protected $debut;
+
+    /** @Column(type="time") **/
+    protected $fin;
+
+    /** @Column(type="string") **/
+    protected $tableau;
+
+    /** @Column(type="string") **/
+    protected $jour;
+
+    /** @Column(type="integer") **/
+    protected $site;
+}

--- a/src/Model/PlanningPositionTab.php
+++ b/src/Model/PlanningPositionTab.php
@@ -9,28 +9,23 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\GeneratedValue;
 
 /**
- * @Entity @Table(name="acces")
+ * @Entity(repositoryClass="App\Repository\PlanningPositionTabRepository") @Table(name="pl_poste_tab")
  **/
-class Access extends PLBEntity
+class PlanningPositionTab extends PLBEntity
 {
     /** @Id @Column(type="integer") @GeneratedValue **/
     protected $id;
+
+    /** @Column(type="integer") **/
+    protected $tableau;
 
     /** @Column(type="text") **/
     protected $nom;
 
     /** @Column(type="integer") **/
-    protected $groupe_id;
+    protected $site;
 
-    /** @Column(type="text") **/
-    protected $groupe;
+    /** @Column(type="datetime") **/
+    protected $supprime;
 
-    /** @Column(type="string") **/
-    protected $page;
-
-    /** @Column(type="integer") **/
-    protected $ordre;
-
-    /** @Column(type="string") **/
-    protected $categorie;
 }

--- a/src/Model/PlanningPositionTabAffectation.php
+++ b/src/Model/PlanningPositionTabAffectation.php
@@ -9,20 +9,19 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\GeneratedValue;
 
 /**
- * @Entity @Table(name="infos")
+ * @Entity @Table(name="pl_poste_tab_affect")
  **/
-class AdminInfo extends PLBEntity
+class PlanningPositionTabAffectation extends PLBEntity
 {
     /** @Id @Column(type="integer") @GeneratedValue **/
     protected $id;
 
-    /** @Column(type="string") **/
-    protected $debut;
+    /** @Column(type="date") **/
+    protected $date;
 
-    /** @Column(type="string") **/
-    protected $fin;
+    /** @Column(type="integer") **/
+    protected $tableau;
 
-    /** @Column(type="text") **/
-    protected $texte;
-
+    /** @Column(type="integer") **/
+    protected $site;
 }

--- a/src/Model/PlanningPositionTabGroup.php
+++ b/src/Model/PlanningPositionTabGroup.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Model;
+
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\GeneratedValue;
+
+/**
+ * @Entity @Table(name="pl_poste_tab_grp")
+ **/
+class PlanningPositionTabGroup extends PLBEntity
+{
+    /** @Id @Column(type="integer") @GeneratedValue **/
+    protected $id;
+
+    /** @Column(type="text") **/
+    protected $nom;
+
+    /** @Column(type="integer") **/
+    protected $lundi;
+
+    /** @Column(type="integer") **/
+    protected $mardi;
+
+    /** @Column(type="integer") **/
+    protected $mercredi;
+
+    /** @Column(type="integer") **/
+    protected $jeudi;
+
+    /** @Column(type="integer") **/
+    protected $vendredi;
+
+    /** @Column(type="integer") **/
+    protected $samedi;
+
+    /** @Column(type="integer") **/
+    protected $dimanche;
+
+    /** @Column(type="integer") **/
+    protected $site;
+
+    /** @Column(type="datetime") **/
+    protected $supprime;
+
+}

--- a/src/Model/Position.php
+++ b/src/Model/Position.php
@@ -9,7 +9,7 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\GeneratedValue;
 
 /**
- * @Entity @Table(name="postes")
+ * @Entity(repositoryClass="App\Repository\PositionRepository") @Table(name="postes")
  **/
 class Position extends PLBEntity
 {

--- a/src/Model/PublicHoliday.php
+++ b/src/Model/PublicHoliday.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Model;
+
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\GeneratedValue;
+
+/**
+ * @Entity @Table(name="jours_feries")
+ **/
+class PublicHoliday extends PLBEntity
+{
+    /** @Id @Column(type="integer") @GeneratedValue **/
+    protected $id;
+
+    /** @Column(type="string") **/
+    protected $annee;
+
+    /** @Column(type="date") **/
+    protected $jour;
+
+    /** @Column(type="integer") */
+    protected $ferie;
+
+    /** @Column(type="integer") */
+    protected $fermeture;
+
+    /** @Column(type="text") */
+    protected $nom;
+
+    /** @Column(type="text") */
+    protected $commentaire;
+}

--- a/src/Model/PublicServiceHours.php
+++ b/src/Model/PublicServiceHours.php
@@ -9,20 +9,19 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\GeneratedValue;
 
 /**
- * @Entity @Table(name="infos")
+ * @Entity @Table(name="edt_samedi")
  **/
-class AdminInfo extends PLBEntity
+class PublicServiceHours extends PLBEntity
 {
     /** @Id @Column(type="integer") @GeneratedValue **/
     protected $id;
 
-    /** @Column(type="string") **/
-    protected $debut;
+    /** @Column(type="date") **/
+    protected $semaine;
 
-    /** @Column(type="string") **/
-    protected $fin;
+    /** @Column(type="integer") **/
+    protected $update_time;
 
     /** @Column(type="text") **/
-    protected $texte;
-
+    protected $heures;
 }

--- a/src/Model/RecurringAbsence.php
+++ b/src/Model/RecurringAbsence.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Model;
+
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\GeneratedValue;
+
+/**
+ * @Entity @Table(name="absences_recurrentes")
+ **/
+class RecurringAbsence extends PLBEntity
+{
+    /** @Id @Column(type="integer") @GeneratedValue **/
+    protected $id;
+
+    /** @Column(type="string") **/
+    protected $uid;
+
+    /** @Column(type="integer") **/
+    protected $perso_id;
+
+    /** @Column(type="text") **/
+    protected $event;
+
+    /** @Column(type="integer") **/
+    protected $end;
+
+    /** @Column(type="datetime") **/
+    protected $timestamp;
+
+    /** @Column(type="datetime") **/
+    protected $last_update;
+
+    /** @Column(type="datetime") **/
+    protected $last_check;
+}

--- a/src/Model/SaturdayWorkingHours.php
+++ b/src/Model/SaturdayWorkingHours.php
@@ -9,20 +9,20 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\GeneratedValue;
 
 /**
- * @Entity @Table(name="infos")
+ * @Entity @Table(name="edt_samedi")
  **/
-class AdminInfo extends PLBEntity
+class SaturdayWorkingHours extends PLBEntity
 {
     /** @Id @Column(type="integer") @GeneratedValue **/
     protected $id;
 
-    /** @Column(type="string") **/
-    protected $debut;
+    /** @Column(type="integer") **/
+    protected $perso_id;
 
-    /** @Column(type="string") **/
-    protected $fin;
+    /** @Column(type="date") **/
+    protected $semaine;
 
-    /** @Column(type="text") **/
-    protected $texte;
+    /** @Column(type="integer") **/
+    protected $tableau;
 
 }

--- a/src/Model/Skill.php
+++ b/src/Model/Skill.php
@@ -9,7 +9,7 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\GeneratedValue;
 
 /**
- * @Entity @Table(name="activites")
+ * @Entity(repositoryClass="App\Repository\SkillRepository") @Table(name="activites")
  **/
 class Skill extends PLBEntity{
     /** @Id @Column(type="integer", length = 11) @GeneratedValue **/

--- a/src/Model/Supervisor.php
+++ b/src/Model/Supervisor.php
@@ -9,20 +9,19 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\GeneratedValue;
 
 /**
- * @Entity @Table(name="infos")
+ * @Entity @Table(name="responsables")
  **/
-class AdminInfo extends PLBEntity
-{
+class Supervisor extends PLBEntity {
     /** @Id @Column(type="integer") @GeneratedValue **/
     protected $id;
 
-    /** @Column(type="string") **/
-    protected $debut;
+    /** @Column(type="integer") **/
+    protected $perso_id;
 
-    /** @Column(type="string") **/
-    protected $fin;
+    /** @Column(type="integer") **/
+    protected $responsable;
 
-    /** @Column(type="text") **/
-    protected $texte;
+    /** @Column(type="integer") **/
+    protected $notification;
 
 }

--- a/src/Model/WeekPlanning.php
+++ b/src/Model/WeekPlanning.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Model;
+
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\GeneratedValue;
+
+/**
+ * @Entity @Table(name="planning_hebdo")
+ **/
+class WeekPlanning extends PLBEntity
+{
+    /** @Id @Column(type="integer") @GeneratedValue **/
+    protected $id;
+
+    /** @Column(type="integer") **/
+    protected $perso_id;
+
+    /** @Column(type="date") **/
+    protected $debut;
+
+    /** @Column(type="date") **/
+    protected $fin;
+
+    /** @Column(type="text") **/
+    protected $temps;
+
+    /** @Column(type="text") **/
+    protected $breaktime;
+
+    /** @Column(type="datetime") **/
+    protected $saisie;
+
+    /** @Column(type="integer") **/
+    protected $modif;
+
+    /** @Column(type="datetime") **/
+    protected $modification;
+
+    /** @Column(type="integer") **/
+    protected $valide_n1;
+
+    /** @Column(type="datetime") **/
+    protected $validation_n1;
+
+    /** @Column(type="integer") **/
+    protected $valide;
+
+    /** @Column(type="datetime") **/
+    protected $validation;
+
+    /** @Column(type="integer") **/
+    protected $actuel;
+
+    /** @Column(type="integer") **/
+    protected $remplace;
+
+    /** @Column(type="string") **/
+    protected $cle;
+
+    /** @Column(type="integer") **/
+    protected $exception;
+
+    /** @Column(type="integer") **/
+    protected $nb_semaine;
+}

--- a/src/PlanningBiblio/DataPurger.php
+++ b/src/PlanningBiblio/DataPurger.php
@@ -50,14 +50,14 @@ class DataPurger
         $GLOBALS['entityManager'] = $this->entityManager;
         $this->log("Start purging $this->delay years old data");
 
-        $today = new \DateTime('NOW');
-        $limit_date = clone $today;
+        $first_of_january = new \DateTime('first day of January this year');
+        $limit_date = clone $first_of_january;
         $limit_date->sub(new \DateInterval('P' . $this->delay . 'Y'));
 
         $end_of_week_limit_date = clone $limit_date;
         $end_of_week_limit_date->sub(new \DateInterval('P6D'));
 
-        $three_years_limit_date = clone $today;
+        $three_years_limit_date = clone $first_of_january;
         $three_years_limit_date->sub(new \Dateinterval('P3Y'));
         $three_years_limit_date = ($limit_date > $three_years_limit_date) ? $three_years_limit_date : $limit_date;
 

--- a/src/PlanningBiblio/DataPurger.php
+++ b/src/PlanningBiblio/DataPurger.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace App\PlanningBiblio;
+
+use App\Model\Absence;
+use App\Model\AbsenceInfo;
+use App\Model\AdminInfo;
+use App\Model\Agent;
+use App\Model\CallForHelp;
+use App\Model\CompTime;
+use App\Model\Detached;
+use App\Model\Holiday;
+use App\Model\HolidayInfo;
+use App\Model\HoursAbsence;
+use App\Model\IPBlocker;
+use App\Model\Logs;
+use App\Model\PlanningNote;
+use App\Model\PlanningNotification;
+use App\Model\PlanningPosition;
+use App\Model\PlanningPositionLock;
+use App\Model\PlanningPositionTab;
+use App\Model\PlanningPositionTabAffectation;
+use App\Model\Position;
+use App\Model\PublicServiceHours;
+use App\Model\PublicHoliday;
+use App\Model\RecurringAbsence;
+use App\Model\SaturdayWorkingHours;
+use App\Model\WeekPlanning;
+use App\PlanningBiblio\Logger;
+
+use App\Model\HiddenTables;
+
+class DataPurger
+{
+
+    private $dbprefix;
+    private $delay;
+    private $entityManager;
+    private $stdout;
+
+    public function __construct($entityManager, $delay, $stdout)
+    {
+        $this->dbprefix = $_ENV['DATABASE_PREFIX'];
+        $this->delay = $delay;
+        $this->entityManager = $entityManager;
+        $this->logger = new Logger($entityManager, $stdout);
+    }
+
+    public function purge() {
+        $GLOBALS['entityManager'] = $this->entityManager;
+        $this->log("Start purging $this->delay years old data");
+
+        $today = new \DateTime('NOW');
+        $limit_date = clone $today;
+        $limit_date->sub(new \DateInterval('P' . $this->delay . 'Y'));
+
+        $end_of_week_limit_date = clone $limit_date;
+        $end_of_week_limit_date->sub(new \DateInterval('P6D'));
+
+        $three_years_limit_date = clone $today;
+        $three_years_limit_date->sub(new \Dateinterval('P3Y'));
+        $three_years_limit_date = ($limit_date > $three_years_limit_date) ? $three_years_limit_date : $limit_date;
+
+        $this->log("limit date: " . $limit_date->format('Y-m-d H:i:s'));
+        $this->log("end of week limit date: " . $end_of_week_limit_date->format('Y-m-d H:i:s'));
+        $this->log("three years limit date: " . $three_years_limit_date->format('Y-m-d H:i:s'));
+
+        $this->simplePurge(AbsenceInfo::class,                    'fin',       '<', $limit_date);
+        $this->simplePurge(AdminInfo::class,                      'fin',       '<', $limit_date);
+        $this->simplePurge(CallForHelp::class,                    'timestamp', '<', $limit_date);
+        $this->simplePurge(CompTime::class,                       'date',      '<', $limit_date);
+        $this->simplePurge(Detached::class,                       'date',      '<', $limit_date);
+        $this->simplePurge(Holiday::class,                        'fin',       '<', $limit_date);
+        $this->simplePurge(HolidayInfo::class,                    'fin',       '<', $limit_date);
+        $this->simplePurge(HoursAbsence::class,                   'semaine',   '<', $end_of_week_limit_date);
+        $this->simplePurge(IPBlocker::class,                      'timestamp', '<', $limit_date);
+        $this->simplePurge(Logs::class,                           'timestamp', '<', $limit_date);
+        $this->simplePurge(PlanningNote::class,                   'date',      '<', $limit_date);
+        $this->simplePurge(PlanningNotification::class,           'date',      '<', $limit_date);
+        $this->simplePurge(PlanningPosition::class,               'date',      '<', $limit_date);
+        $this->simplePurge(PlanningPositionLock::class,           'date',      '<', $limit_date);
+        $this->simplePurge(PlanningPositionTabAffectation::class, 'date',      '<', $limit_date);
+        $this->simplePurge(Position::class,                       'supprime',  '<', $three_years_limit_date);
+        $this->simplePurge(PublicServiceHours::class,             'semaine',   '<', $end_of_week_limit_date);
+        $this->simplePurge(PublicHoliday::class,                  'jour',      '<', $three_years_limit_date);
+        $this->simplePurge(SaturdayWorkingHours::class,           'semaine',   '<', $end_of_week_limit_date);
+        $this->simplePurge(WeekPlanning::class,                   'fin',       '<', $limit_date);
+
+        $this->log("Purging special cases:");
+
+        // Absences
+        $builder = $this->entityManager->createQueryBuilder();
+        $builder->select('a')
+                ->from(Absence::class, 'a')
+                ->andWhere('a.fin < :limit_date')
+                ->setParameter('limit_date', $limit_date);
+        $results = $builder->getQuery()->getResult();
+
+        $deleted_absences = 0;
+        foreach ($results as $result) {
+            $this->entityManager->getRepository(Absence::class)->purge($result->id());
+            $deleted_absences++;
+        }
+        $this->log("Purging $deleted_absences App\Model\Absence");
+
+        // Agents
+        $deleted_agents = $this->entityManager->getRepository(Agent::class)->purge();
+        $this->log("Purging $deleted_agents App\Model\Agent");
+
+        // Planning Position Tab
+        $builder = $this->entityManager->createQueryBuilder();
+        $builder->select('a')
+                ->from(PlanningPositionTab::class, 'a')
+                ->andWhere('a.supprime < :limit_date')
+                ->setParameter('limit_date', $three_years_limit_date);
+        $results = $builder->getQuery()->getResult();
+        $deleted_planning_position_tab = 0;
+        foreach ($results as $result) {
+            $this->entityManager->getRepository(PlanningPositionTab::class)->purge($result->id());
+            $deleted_planning_position_tab++;
+        }
+        $this->log("Purging $deleted_planning_position_tab App\Model\PlanningPositionTab");
+
+        // Recurring Absences
+        $builder = $this->entityManager->createQueryBuilder();
+        $builder->delete()
+                ->from(RecurringAbsence::class, 'a')
+                ->andWhere('a.end = :ended')
+                ->andWhere('a.timestamp < :limit_date')
+                ->setParameter('ended', "1")
+                ->setParameter('limit_date', $limit_date);
+        $results = $builder->getQuery()->getResult();
+        $this->log("Purging $results App\Model\RecurringAbsence");
+
+        $this->entityManager->flush();
+        $this->log("End purging old data");
+    }
+
+    private function simplePurge($class, $field, $operator, $value) {
+        $builder = $this->entityManager->createQueryBuilder();
+        $builder->delete()
+                ->from($class, 'a')
+                ->andWhere('a.' . $field . ' ' . $operator . ' :value')
+                ->setParameter('value', $value);
+        $results = $builder->getQuery()->getResult();
+        $this->log("Purging $results $class");
+    }
+
+    private function log($message) {
+        $this->logger->log($message, "DataPurger");
+    }
+
+}

--- a/src/Repository/AbsenceRepository.php
+++ b/src/Repository/AbsenceRepository.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Repository;
+
+use Doctrine\ORM\EntityRepository;
+use Doctrine\Common\Collections\Criteria;
+
+use App\Model\Absence;
+use App\Model\AbsenceDocument;
+
+class AbsenceRepository extends EntityRepository
+{
+    public function purge($id)
+    {
+        $entityManager = $this->getEntityManager();
+        $this->deleteAllDocuments($id);
+        $absence = $entityManager->getRepository(Absence::class)->find($id);
+        $entityManager->remove($absence);
+        $entityManager->flush();
+    }
+
+    public function deleteAllDocuments($id) {
+        $entityManager = $this->getEntityManager();
+        $absdocs = $entityManager->getRepository(AbsenceDocument::class)->findBy(['absence_id' => $id]);
+        foreach ($absdocs as $absdoc) {
+            $absdoc->deleteFile();
+            $entityManager->remove($absdoc);
+        }
+        $entityManager->flush();
+
+        $absenceDocument = new AbsenceDocument();
+        if (is_dir($absenceDocument->upload_dir() . $id)) {
+            rmdir($absenceDocument->upload_dir() . $id);
+        }
+    }
+}

--- a/src/Repository/AbsenceRepository.php
+++ b/src/Repository/AbsenceRepository.php
@@ -19,6 +19,22 @@ class AbsenceRepository extends EntityRepository
         $entityManager->flush();
     }
 
+    public function purgeAll($limit_date) {
+        $builder = $this->getEntityManager()->createQueryBuilder();
+        $builder->select('a')
+                ->from(Absence::class, 'a')
+                ->andWhere('a.fin < :limit_date')
+                ->setParameter('limit_date', $limit_date);
+        $results = $builder->getQuery()->getResult();
+
+        $deleted_absences = 0;
+        foreach ($results as $result) {
+            $this->purge($result->id());
+            $deleted_absences++;
+        }
+        return $deleted_absences;
+    }
+
     public function deleteAllDocuments($id) {
         $entityManager = $this->getEntityManager();
         $absdocs = $entityManager->getRepository(AbsenceDocument::class)->findBy(['absence_id' => $id]);

--- a/src/Repository/AgentRepository.php
+++ b/src/Repository/AgentRepository.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Repository;
+
+use Doctrine\ORM\EntityRepository;
+use Doctrine\Common\Collections\Criteria;
+
+use App\Model\Absence;
+use App\Model\CompTime;
+use App\Model\Detached;
+use App\Model\HiddenTables;
+use App\Model\Holiday;
+use App\Model\HolidayCET;
+use App\Model\PlanningNote;
+use App\Model\PlanningPosition;
+use App\Model\PlanningPositionLock;
+use App\Model\PlanningPositionModel;
+use App\Model\RecurringAbsence;
+use App\Model\SaturdayWorkingHours;
+use App\Model\Supervisor;
+use App\Model\WeekPlanning;
+
+class AgentRepository extends EntityRepository
+{
+    public function purge()
+    {
+        $agents = $this->findBy(['supprime' => '2']);
+        $entityManager = $this->getEntityManager();
+        $deleted_agents = 0;
+
+        foreach ($agents as $agent) {
+            $delete = true;
+            $perso_id = $agent->id();
+            $classes = [
+                Absence::class,
+                CompTime::class,
+                Detached::class,
+                HiddenTables::class,
+                Holiday::class,
+                HolidayCET::class,
+                PlanningNote::class,
+                PlanningPosition::class,
+                PlanningPositionModel::class,
+                RecurringAbsence::class,
+                SaturdayWorkingHours::class,
+                WeekPlanning::class
+            ];
+
+            foreach ($classes as $class) {
+                $objects = $entityManager->getRepository($class)->findBy(['perso_id' => $perso_id]);
+                if (count($objects)) { $delete = false; break; }
+            }
+
+            // Special cases:
+            // PlanningPositionLock::class
+            $planningPositionLockCriteria = new \Doctrine\Common\Collections\Criteria();
+            $planningPositionLockCriteria
+                ->orWhere($planningPositionLockCriteria->expr()->contains('perso', $perso_id))
+                ->orWhere($planningPositionLockCriteria->expr()->contains('perso2', $perso_id));
+
+            $planningPositionLocks = $entityManager->getRepository(PlanningPositionLock::class)->matching($planningPositionLockCriteria);
+            if (count($planningPositionLocks)) { $delete = false; }
+
+            // Supervisors
+            $supervisorCriteria = new \Doctrine\Common\Collections\Criteria();
+            $supervisorCriteria
+                ->orWhere($supervisorCriteria->expr()->contains('perso_id', $perso_id))
+                ->orWhere($supervisorCriteria->expr()->contains('responsable', $perso_id));
+
+            $supervisors = $entityManager->getRepository(Supervisor::class)->matching($supervisorCriteria);
+            if (count($supervisors)) { $delete = false; }
+
+            if ($delete == true) {
+                $entityManager->remove($agent);
+                $deleted_agents++;
+            }
+            $entityManager->flush();
+        }
+        return $deleted_agents;
+    }
+}

--- a/src/Repository/AgentRepository.php
+++ b/src/Repository/AgentRepository.php
@@ -6,6 +6,7 @@ use Doctrine\ORM\EntityRepository;
 use Doctrine\Common\Collections\Criteria;
 
 use App\Model\Absence;
+use App\Model\Agent;
 use App\Model\CompTime;
 use App\Model\Detached;
 use App\Model\HiddenTables;
@@ -22,7 +23,24 @@ use App\Model\WeekPlanning;
 
 class AgentRepository extends EntityRepository
 {
-    public function purge()
+
+    public function getAllSkills() {
+        $entityManager = $this->getEntityManager();
+        $agents = $entityManager->getRepository(Agent::class)->findAll();
+        $all_skills = array();
+        foreach ($agents as $agent) {
+            $activites = $agent->postes();
+            if (is_array($activites)) {
+                foreach ($activites as $activite) {
+                    array_push($all_skills, $activite);
+                }
+            }
+        }
+        $all_skills = array_unique($all_skills);
+        return $all_skills;
+    }
+
+    public function purgeAll()
     {
         $agents = $this->findBy(['supprime' => '2']);
         $entityManager = $this->getEntityManager();

--- a/src/Repository/PlanningPositionTabRepository.php
+++ b/src/Repository/PlanningPositionTabRepository.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Repository;
+
+use Doctrine\ORM\EntityRepository;
+
+use App\Model\HiddenTables;
+use App\Model\PlanningPositionCells;
+use App\Model\PlanningPositionLines;
+use App\Model\PlanningPositionHours;
+use App\Model\PlanningPositionTabGroup;
+
+class PlanningPositionTabRepository extends EntityRepository
+{
+    public function purge($id)
+    {
+        $planningPositionTab = $this->find($id);
+        $tableau = $planningPositionTab->tableau();
+        $entityManager = $this->getEntityManager();
+
+        $this->removeObjects(HiddenTables::class,          'tableau', $tableau);
+        $this->removeObjects(PlanningPositionCells::class, 'numero',  $tableau);
+        $this->removeObjects(PlanningPositionHours::class, 'numero',  $tableau);
+        $this->removeObjects(PlanningPositionLines::class, 'numero',  $tableau);
+
+        $builder = $entityManager->createQueryBuilder();
+        $builder->delete()
+                ->from(PlanningPositionTabGroup::class, 'a')
+                ->where('a.lundi = :tableau')
+                ->OrWhere('a.mardi = :tableau')
+                ->OrWhere('a.mercredi = :tableau')
+                ->OrWhere('a.jeudi = :tableau')
+                ->OrWhere('a.vendredi = :tableau')
+                ->OrWhere('a.samedi = :tableau')
+                ->OrWhere('a.dimanche = :tableau')
+                ->setParameter('tableau', $tableau);
+        $results = $builder->getQuery()->getResult();
+
+        $entityManager->remove($planningPositionTab);
+    }
+
+    private function removeObjects($class, $field, $value) {
+        $entityManager = $this->getEntityManager();
+        $objects = $entityManager->getRepository($class)->findBy([$field => $value]);
+        foreach ($objects as $object) {
+            $entityManager->remove($object);
+        }
+    }
+}

--- a/src/Repository/PositionRepository.php
+++ b/src/Repository/PositionRepository.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Repository;
+
+use Doctrine\ORM\EntityRepository;
+
+use App\Model\Position;
+use App\Model\PlanningPositionLines;
+
+class PositionRepository extends EntityRepository
+{
+    public function getAllSkills() {
+        $entityManager = $this->getEntityManager();
+        $positions = $entityManager->getRepository(Position::class)->findAll();
+        $all_skills = array();
+        foreach ($positions as $position) {
+            $activites = $position->activites();
+            if (is_array($activites)) {
+                foreach ($activites as $activite) {
+                    array_push($all_skills, $activite);
+                }
+            }
+        }
+        $all_skills = array_unique($all_skills);
+        return $all_skills;
+    }
+
+    public function purgeAll($limit_date) {
+        $entityManager = $this->getEntityManager();
+        $builder = $entityManager->createQueryBuilder();
+        $builder->select('a')
+                ->from(Position::class, 'a')
+                ->andWhere('a.supprime < :limit_date')
+                ->andWhere('a.supprime IS NOT NULL')
+                ->setParameter('limit_date', $limit_date);
+        $results = $builder->getQuery()->getResult();
+        $deleted_position = 0;
+        foreach ($results as $result) {
+            $builder = $entityManager->createQueryBuilder();
+            $builder->select('a')
+                    ->from(PlanningPositionLines::class, 'a')
+                    ->andWhere("a.type = 'poste'")
+                    ->andWhere('a.poste = :id')
+                    ->setParameter('id', $result->id());
+            $lines = $builder->getQuery()->getResult();
+            if (sizeof($lines) == 0) {
+                $entityManager->remove($result);
+                $deleted_position++;
+            }
+        }
+        $entityManager->flush();
+        return $deleted_position;
+    }
+}

--- a/src/Repository/SkillRepository.php
+++ b/src/Repository/SkillRepository.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Repository;
+
+use Doctrine\ORM\EntityRepository;
+use Doctrine\Common\Collections\Criteria;
+
+use App\Model\Agent;
+use App\Model\Position;
+use App\Model\Skill;
+
+class SkillRepository extends EntityRepository
+{
+    public function purge($id)
+    {
+        $entityManager = $this->getEntityManager();
+        $all_skills = $entityManager->getRepository(Position::class)->getAllSkills();
+
+        if (in_array($id, $all_skills)) {
+            return 0;
+        }
+
+        $all_skills = $entityManager->getRepository(Agent::class)->getAllSkills();
+
+        if (in_array($id, $all_skills)) {
+            return 0;
+        }
+
+        $skill = $entityManager->getRepository(Skill::class)->find($id);
+        $entityManager->remove($skill);
+        $entityManager->flush();
+        return 1;
+    }
+
+    public function purgeAll($limit_date) {
+        $entityManager = $this->getEntityManager();
+        $builder = $entityManager->createQueryBuilder();
+        $builder->select('a')
+                ->from(Skill::class, 'a')
+                ->andWhere('a.supprime < :limit_date')
+                ->andWhere('a.supprime IS NOT NULL')
+                ->setParameter('limit_date', $limit_date);
+        $results = $builder->getQuery()->getResult();
+        $deleted_skill = 0;
+        foreach ($results as $result) {
+            $deleted = $this->purge($result->id());
+            if ($deleted) $deleted_skill++;
+        }
+        return $deleted_skill;
+    }
+
+}


### PR DESCRIPTION
This script will purge old datas from the installation.
    
    php bin/console PlanningBiblio:PurgeData [--stdout=1] [YEARS]
    
    The script is silent by default, see the logs database table for processing
    informations.
    
    Options:
     --stdout=1: Also output logs in stdout
     YEARS: Purge data older than YEARS, 5 if not specified.
    
    Example:
    
    php bin/console PlanningBiblio:PurgeData 7

    The following data will be purged:
    
     - Absence
     - AbsenceInfo
     - AbsenceDocument (and their files)
     - AdminInfo
     - Agent
     - CallForHelp
     - CompTime
     - Detached
     - HiddenTables
     - Holiday
     - HolidayCET
     - HolidayInfo
     - HoursAbsence
     - IPBlocker
     - Logs
     - PlanningNote
     - PlanningNotification
     - PlanningPosition
     - PlanningPositionLock
     - PlanningPositionModel
     - PlanningPositionTab
     - PlanningPositionTabAffectation
     - Position
     - PublicServiceHours
     - PublicHoliday
     - RecurringAbsence
     - SaturdayWorkingHours
     - Supervisor
     - WeekPlanning
    
    Please note that some data more recent than 3 years will intentionally not be
    purged if delay is less than 3 years. The following are concerned:
    
     - Position
     - PublicHoliday
     - PlanningPositionTab

