### PR TITLE
Fix display of html entities on information and absence information messages

### DIFF
--- a/public/planning/poste/index.php
+++ b/public/planning/poste/index.php
@@ -128,6 +128,7 @@ if ($db->result) {
 
 //	Selection des messages d'informations
 $db=new db();
+$db->sanitize_string = false;
 $db->select2("infos", "*", array("debut"=>"<={$date}", "fin"=>">={$date}"), "ORDER BY `debut`,`fin`");
 $messages_infos=null;
 if ($db->result) {

--- a/src/Controller/AbsenceController.php
+++ b/src/Controller/AbsenceController.php
@@ -1040,6 +1040,7 @@ class AbsenceController extends BaseController
     {
         $date = date("Y-m-d");
         $db = new \db();
+        $db->sanitize_string = false;
         $db->query("SELECT * FROM `{$this->dbprefix}absences_infos` WHERE `fin`>='$date' ORDER BY `debut`,`fin`;");
         $absences_infos = array();
         if ($db->result) {


### PR DESCRIPTION
Fix display of html entities on information and absence information messages

TEST PLAN :
- create an absence information message (absences / information) with simple and double quotes (' and ")
- Look at this message on the absences/add form
- create an information message (administration / information) with simple and double quotes (' and ")
- Look at this message on the planning page
