### PR TITLE
Restote All site option on working hours form

### DIFF
--- a/src/Controller/CalendarController.php
+++ b/src/Controller/CalendarController.php
@@ -286,6 +286,8 @@ class CalendarController extends BaseController
                     $site = $horaires[4];
                     if ($site != '-1') {
                         $site_name = $this->config("Multisites-site$site");
+                    } else {
+                        $site_name = '';
                     }
                 }
                 $schedule = array();

--- a/templates/workinghour/tables.html.twig
+++ b/templates/workinghour/tables.html.twig
@@ -96,6 +96,11 @@
                                 <option value="{{ site }}">{{ multisites[site] | raw }}</option>
                               {% endif %}
                             {% endfor %}
+                            {% if temps is not null and temps[i-1][4] == '-1' %}
+                              <option value="-1" selected='selected' >Tout site</option>
+                            {% else %}
+                              <option value="-1" >Tout site</option>
+                            {% endif %}
                           </select>
                         </td>
                       {% else %}

--- a/templates/workinghour/tables.html.twig
+++ b/templates/workinghour/tables.html.twig
@@ -96,7 +96,7 @@
                                 <option value="{{ site }}">{{ multisites[site] | raw }}</option>
                               {% endif %}
                             {% endfor %}
-                            {% if temps is not null and temps[i-1][4] == '-1' %}
+                            {% if temps[i-1][4] is defined and temps[i-1][4] == '-1' %}
                               <option value="-1" selected='selected' >Tout site</option>
                             {% else %}
                               <option value="-1" >Tout site</option>


### PR DESCRIPTION
Restote "All site" option on working hours form

Tests : 
- config Multisites and planning_hebdo
- Edit an agent, check at least 2 sites in the first tab.
- edit its working hours
- select "Tout site" in the Site dropdown menu.

Release 21.04 : OK
Master and 21.10 : KO