### PR TITLE
Add a div with class=attendance to isolate attendance information on calendars

### DIFF
--- a/templates/calendar/index.html.twig
+++ b/templates/calendar/index.html.twig
@@ -74,32 +74,34 @@
                   </td>
                 {% else %}
                   {% if d.presence is not empty %}
-                    {% if d.presence.schedule | length > 1 %}
-                      {% if nbSites > 1 %}
-                        {% if d.presence.site == -1 %}
-                          <p style='margin-bottom:0;'> Présence sur tous les sites : </p>
+                    <div class='attendance'>
+                      {% if d.presence.schedule | length > 1 %}
+                        {% if nbSites > 1 %}
+                          {% if d.presence.site == -1 %}
+                            <p style='margin-bottom:0;'> Présence sur tous les sites : </p>
+                          {% else %}
+                            <p style='margin-bottom:0;'> Présence à {{ d.presence.site_name }} : </p>
+                          {% endif %}
                         {% else %}
-                          <p style='margin-bottom:0;'> Présence à {{ d.presence.site_name }} : </p>
+                          <p style='margin-bottom:0;'> Présence :</p>
                         {% endif %}
+                        <ul>
+                        {% for p in d.presence.schedule %}
+                          <li> de {{ p.begin }} à {{ p.end }} </li>
+                        {% endfor %}
+                        </ul>
                       {% else %}
-                        <p style='margin-bottom:0;'> Présence :</p>
-                      {% endif %}
-                      <ul>
-                       {% for p in d.presence.schedule %}
-                         <li> de {{ p.begin }} à {{ p.end }} </li>
-                       {% endfor %}
-                      </ul>
-                    {% else %}
-                      {% if nbSites > 1 %}
-                        {% if d.presence.site == -1 %}
-                          <p> Présent(e) sur tous les sites de {{ d.presence.schedule[0].begin }} à {{ d.presence.schedule[0].end }} </p>
+                        {% if nbSites > 1 %}
+                          {% if d.presence.site == -1 %}
+                            <p> Présent(e) sur tous les sites de {{ d.presence.schedule[0].begin }} à {{ d.presence.schedule[0].end }} </p>
+                          {% else %}
+                            <p> Présent(e) à {{ d.presence.site_name }} de {{ d.presence.schedule[0].begin }} à {{ d.presence.schedule[0].end }} </p>
+                          {% endif %}
                         {% else %}
-                          <p> Présent(e) à {{ d.presence.site_name }} de {{ d.presence.schedule[0].begin }} à {{ d.presence.schedule[0].end }} </p>
+                          <p> Présent(e) de {{ d.presence.schedule[0].begin }} à {{ d.presence.schedule[0].end }} </p>
                         {% endif %}
-                      {% else %}
-                        <p> Présent(e) de {{ d.presence.schedule[0].begin }} à {{ d.presence.schedule[0].end }} </p>
                       {% endif %}
-                    {% endif %}
+                    </div>
                   {% endif %}
                   {% if d.absence is not empty %}
                     <div class ='important'>


### PR DESCRIPTION
Add a div with class=attendance to isolate attendance information on calendars

- Allows to customize the display of this information in CSS. Eg : #tab_agenda .attendance { display: none; }

TEST : 
Tester en config mono-site et multi-sites, avec les thèmes default, light_blue et cd34
Tester l'affichage des calendriers
Pour les thèmes default et light_blue, vous ne devez pas voir de différence (avec ou sans ce développement)
Pour le thème cd34, les heures de présence doivent être masquées dans les agendas.

- Afficher le calendrier d'un agent pour qui des heures de présence sont enregistrées
- Tester également avec un agent sans heure de présence
- vérifier le bon affichage de l'ensemble du calendrier
- Avec le thème cd34 : les heures de présence ne doivent pas s'afficher dans les agendas.

Pour installer le theme cd34 : 
`cd public/themes`
`git clone https://github.com/planningbiblio/theme_cd34 cd34`
Dans administration / configuration / Affichage, taper cd34 pour le paramètre Affichage-theme
