### PR TITLE
Show sites on the read-only agents page

### DIFF
--- a/src/Controller/AgentController.php
+++ b/src/Controller/AgentController.php
@@ -570,17 +570,15 @@ class AgentController extends BaseController
         if ($this->config('Multisites-nombre') > 1) {
             $sites_select = array();
             for ($i = 1; $i <= $this->config('Multisites-nombre'); $i++) {
-                if (in_array(21, $droits)) {
-                    $site_select = array(
-                        'id' => $i,
-                        'name' => $this->config("Multisites-site$i"),
-                        'checked' => 0
-                    );
-                    if ( in_array($i, $sites) ) {
-                        $site_select['checked'] = 1;
-                    }
-                    $sites_select[] = $site_select;
+                $site_select = array(
+                    'id' => $i,
+                    'name' => $this->config("Multisites-site$i"),
+                    'checked' => 0
+                );
+                if ( in_array($i, $sites) ) {
+                    $site_select['checked'] = 1;
                 }
+                $sites_select[] = $site_select;
             }
             $this->templateParams(array( 'sites_select' => $sites_select ));
         }


### PR DESCRIPTION
Test plan:
  - Multi-sites enabled,
  - Give an agent the "See agent account" only
  - Login with this agent,
  - Show an agent page
  => Sites are not shown
  - apply this patch