### PR TITLE
Remove html entities in read-only agents page

### DIFF
--- a/templates/agents/agent_table.html.twig
+++ b/templates/agents/agent_table.html.twig
@@ -25,7 +25,7 @@
 
   <tr>
     <td>Statut :</td>
-    <td style='white-space:nowrap'>{{ statut }}</td>
+    <td style='white-space:nowrap'>{{ statut | striptags | raw }}</td>
   </tr>
 
   <tr>
@@ -35,7 +35,7 @@
 
   <tr>
     <td>Service de rattachement:</td>
-    <td style='white-space:nowrap'>{{ service }}</td>
+    <td style='white-space:nowrap'>{{ service | striptags | raw }}</td>
   </tr>
 
   <tr>


### PR DESCRIPTION
Test plan:
  - set status and service with accentued values for an agent,
  - Access the agent account on read-only
  => You can see html entities on status and service
  - Apply this patch, test again
  