### PR TITLE
Remove spaces from some read-only values in working hours table.

### DIFF
--- a/templates/workinghour/edit.html.twig
+++ b/templates/workinghour/edit.html.twig
@@ -122,8 +122,8 @@
                           </td>
                         {% endif %}
                     {% else %}
-                      <td id="temps_{{i-1}}_0" class='td_heures'>{{ (temps[i-1] is not empty) ? temps[i-1][0] : " " }} </td>
-                      <td id="temps_{{i-1}}_1" class='td_heures'>{{ (temps[i-1] is not empty) ? temps[i-1][1] : " " }} </td>
+                      <td id="temps_{{i-1}}_0" class='td_heures'>{{ (temps[i-1] is not empty) ? temps[i-1][0] : " " }}</td>
+                      <td id="temps_{{i-1}}_1" class='td_heures'>{{ (temps[i-1] is not empty) ? temps[i-1][1] : " " }}</td>
                       <td id="temps_{{i-1}}_2" class='td_heures'>{{ (temps[i-1] is not empty) ? temps[i-1][2] : " " }}</td>
                       {% if pause2_enabled == true %}
                         <td id="temps_{{i-1}}_5" class='td_heures'>{{ (temps[i-1] is not empty) ? temps[i-1][5] : " " }}</td>


### PR DESCRIPTION
These spaces cause bad duration calculation.
**21.04.xx only**