### PR TITLE
MT35426_2  Defined variables on WorkingHoursController

### DIFF
--- a/public/themes/default/default.css
+++ b/public/themes/default/default.css
@@ -1262,6 +1262,10 @@ div.presents-absents {
   white-space: nowrap;
 }
 
+.planno-timepicker:disabled {
+    color: black;
+}
+
 .abs-timepicker, .comptime-timepicker {
   width: 100%;
 }

--- a/src/Controller/WorkingHourController.php
+++ b/src/Controller/WorkingHourController.php
@@ -539,6 +539,12 @@ class WorkingHourController extends BaseController
             $tab = $db->result;
         }
 
+        // The followings variables are only used when $cle is defined, but we need to initialize them to avoid errors.
+        $selected1 = false;
+        $selected2 = false;
+        $selected3 = false;
+        $selected4 = false;
+
         if (!$cle) {
             if ($modifAutorisee) {
                 $selected1 = isset($valide_n1) && $valide_n1 > 0 ? true : false;


### PR DESCRIPTION
MT35426_2  Defined variables on WorkingHoursController
MT35426_9 Fix display of "All site" on working hours on read only mode
MT35426_10 Display disabled timepicker in black 

This PR replace #544 

MT35426_10 Display disabled timepicker in black 
--> Does not change the template to put the hours in black, but uses CSS to do it.
