### PR TITLE
Use dependency injection instead of service container to get Notifier into controllers

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -20,19 +20,21 @@ services:
         resource: '../src/*'
         exclude: '../src/{DependencyInjection,Migrations,Tests,Kernel.php}'
 
+    notifier:
+        class: App\PlanningBiblio\Notifier
+        public: true
+
     # controllers are imported separately to make sure services can be injected
     # as action arguments even if you don't extend any base controller class
     App\Controller\:
         resource: '../src/Controller'
         tags: ['controller.service_arguments']
+        calls:
+            - setNotifier: ['@notifier']
 
     App\Listener\ControllerAuthorizationListener:
         tags:
             - { name: kernel.event_listener, event: kernel.request }
-
-    notifier:
-        class: App\PlanningBiblio\Notifier
-        public: true
 
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones

--- a/src/Controller/AgentController.php
+++ b/src/Controller/AgentController.php
@@ -881,7 +881,7 @@ class AgentController extends BaseController
                 $mdp = gen_trivial_password();
                 $mdp_crypt = password_hash($mdp, PASSWORD_BCRYPT);
 
-                $notifier = $this->container->get('notifier');
+                $notifier = $this->notifier;
                 $notifier->setRecipients($mail)
                          ->setMessageCode('create_account')
                          ->setMessageParameters(array(

--- a/src/Controller/BaseController.php
+++ b/src/Controller/BaseController.php
@@ -2,6 +2,8 @@
 
 namespace App\Controller;
 
+use App\PlanningBiblio\Notifier;
+
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
@@ -21,6 +23,8 @@ class BaseController extends AbstractController
 
     private $logger;
 
+    protected $notifier;
+
     public function __construct(RequestStack $requestStack, LoggerInterface $logger)
     {
         $request = $requestStack->getCurrentRequest();
@@ -34,6 +38,10 @@ class BaseController extends AbstractController
         $this->config = $GLOBALS['config'];
 
         $this->logger = $logger;
+    }
+
+    public function setNotifier(Notifier $notifier) {
+        $this->notifier = $notifier;
     }
 
     protected function templateParams( array $params = array() )


### PR DESCRIPTION
Since we use Symfony 4.4, our controllers extends AbstractController
instead of deprecated Controller Bundle. Now we can't retrieve our custom
services directly from container.