### PR TITLE
MT35413: Restrict absences list interval to a year maximum

### DIFF
--- a/public/absences/js/voir.js
+++ b/public/absences/js/voir.js
@@ -33,6 +33,24 @@ $(function(){
     });
   });
 
+  $("#absencesListForm").submit(function( event ) {
+    var start = $("#debut").datepicker("getDate");
+    var end = $("#fin").datepicker("getDate");
+    if (start || end) {
+       if (!start) {
+         start = new Date(); 
+       }
+       if (!end) {
+         end = new Date();
+       }
+       var number_of_days = (end - start) / (1000 * 60 * 60 * 24); 
+       if (number_of_days > 365) {
+         alert('Veuillez sélectionner un intervalle inférieur à une année.');
+         event.preventDefault();
+       }
+    }
+  });
+
 });
 
 function absences_reinit(){

--- a/templates/absences/index.html.twig
+++ b/templates/absences/index.html.twig
@@ -9,7 +9,7 @@
 {% block page %}
   <h3>Liste des absences</h3>
 
-  <form name='form' method='get' action='/absence'>
+  <form name='form' id='absencesListForm' method='get' action='/absence'>
     <span style='float:left; vertical-align:top; margin-bottom:20px;'>
       <table class='tableauStandard'>
         <tbody>
@@ -20,7 +20,7 @@
             </td>
             <td style='vertical-align:middle;'>
               <label class='intitule'>Fin :</label>
-              <input type='text' name='fin' value='{{ fin }}'  class='datepicker'/>
+              <input type='text' name='fin' id='fin' value='{{ fin }}'  class='datepicker'/>
             </td>
             {% if admin %}
               <td style='vertical-align:middle;text-align:left;'>


### PR DESCRIPTION
Test plan:
 - set an interval superior to a year in the absences list parameters
 - check that a message is displayed to tell you to select an interval inferior than a year
 - check that it also works when only the start date or end date is set