### PR TITLE
Avoid comparison between H:i:s and H:i when checking the presence of an agent

### DIFF
--- a/public/include/function.php
+++ b/public/include/function.php
@@ -596,17 +596,23 @@ function calculHeuresSP($date, $CSRFToken)
  */
 function calculSiPresent($debut, $fin, $temps, $jour)
 {
+    // convert variable from H:i:s to H:i
+    // to avoid comparison between 13:00:00 and 13:00
+    $start_dt = DateTime::createFromFormat('H:i:s', $debut);
+    $debut = $start_dt->format('H:i');
+    $end_dt = DateTime::createFromFormat('H:i:s', $fin);
+    $fin = $end_dt->format('H:i');
 
     $wh = new WorkingHours($temps);
     $tab = $wh->hoursOf($jour);
-  
+
     // Confrontation du créneau de service public aux tableaux
     foreach ($tab as $elem) {
         if (($elem[0] <= $debut) and ($elem[1] >= $fin)) {
             return true;
         }
     }
-  
+
     return false;
 }
 

--- a/src/Model/Agent.php
+++ b/src/Model/Agent.php
@@ -207,7 +207,7 @@ class Agent extends PLBEntity
         $config = $GLOBALS['config'];
 
         if (!$config['PlanningHebdo']) {
-            return array('temps' => json_decode($this->temps()));
+            return array('temps' => json_decode($this->temps(), true));
         }
 
         $working_hours = new \planningHebdo();


### PR DESCRIPTION
Test plan:
  - Set working hours for agent like: 10h00, 13h00, 14h30, 17h30
  - Try to place it on a planning for a position starting at 10h ending at 11h
  => Ok
  - Try to place it on a planning for a position  ending at 13h
  => Ko because of comparison between 13:00:00 and 13:00