### PR TITLE
MT36087: fix encoding issues on agents' name in calendar's dropdown menu

### DIFF
--- a/src/Controller/CalendarController.php
+++ b/src/Controller/CalendarController.php
@@ -57,6 +57,7 @@ class CalendarController extends BaseController
         //Sélection du personnel pour le menu déroulant
         $agent = null;
         $db = new \db();
+        $db->sanitize_string = false;
         $db->query("SELECT * FROM `{$GLOBALS['dbprefix']}personnel` WHERE actif='Actif' AND id > 2 ORDER by `nom`,`prenom`;");
         $agents = $db->result;
 


### PR DESCRIPTION
- When agent's name contains apostrophes
- This fix is relative to M36087 but does not fix the client request