### PR TITLE
MT36346: Allow symfony-flex plugin without confirmation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,10 @@
         "preferred-install": {
             "*": "dist"
         },
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "symfony/flex": true
+        }
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
MT36346: Allow symfony-flex plugin without confirmation

Without this commit, when we run "composer install" or "install.sh", we need to confirm the installation of symfony flex.