### PR TITLE
MT36370: Do not filter on first site when gathering absents for statistics

### DIFF
--- a/src/Controller/StatisticController.php
+++ b/src/Controller/StatisticController.php
@@ -1326,7 +1326,7 @@ class StatisticController extends BaseController
             $absences = new \absences();
             $absences->valide = false;
             $absent_ids = array(2);
-            $absences->fetch("`nom`,`prenom`,`debut`,`fin`", null, $date, $date, array(1));
+            $absences->fetch("`nom`,`prenom`,`debut`,`fin`", null, $date, $date);
             $absents = $absences->elements;
 
             foreach ($conges as $elem) {


### PR DESCRIPTION
On the attendees/missing statistics page, some agents may not appear as absents although they are.
    
This is because the list of absents is built with the first site hardcoded on fetch call.
    
This patch removes the filter to have all agents.
