### PR TITLE
MT36452 - Prevent Hours helper to convert non H:i values

### DIFF
--- a/src/PlanningBiblio/Helper/HourHelper.php
+++ b/src/PlanningBiblio/Helper/HourHelper.php
@@ -40,6 +40,10 @@ class HourHelper extends BaseHelper
             return '';
         }
 
+        if (!\DateTime::createFromFormat('H:i', $time)) {
+            return $time;
+        }
+
         if (!\DateTime::createFromFormat('H:i:s', $time)) {
             $time_dt = \DateTime::createFromFormat('H:i', $time);
             $time = $time_dt->format('H:i:s');


### PR DESCRIPTION
Recently merged PR #587 brought a new method to convert H:i values to H:i:s. Problem, sometimes non H:i values are passed to it causing a fatal error. Test plan:

- Enable multi-sites,
- enable PlanningHebdo,
- Edit workinghours and set some sites in the table.
- Save
   => Crash: PHP Fatal error:  Uncaught Error: Call to a member function format() on bool 

This also cause a fail when updating to 21.11.00.002.
