### PR TITLE
MT36574: Do not publish crossed-out agents on ICS calendars

### DIFF
--- a/public/ics/calendar.php
+++ b/public/ics/calendar.php
@@ -206,6 +206,10 @@ if (isset($planning)) {
             }
         }
     
+        if ($elem['absent'] == 1) {
+            continue;
+        }
+
         // Regroupe les plages de SP qui se suivent sur le même poste
         if (isset($tab[$i-1])
             and $tab[$i-1]['date'] == $elem['date']


### PR DESCRIPTION
MT36574: Do not publish crossed-out agents on ICS calendars
See MT36574

TESTS : 
- Enable ICS-Export
- Add an agent's calendar in a calendar client (eg : Thunderbird). The requested URL is available in the tab "Agendas and Synchronisation" of the agent's record (administration / les agents)
- put this agent in a planning, lock the planning, refresh the calendar : you should see the agent's position in the calendar
- unlock the planning, cross-out the agent (right-clic + "barrer ..."), lock the planning, refresh the calendar : you should not see the agent's position in the calendar 
