### PR TITLE
ICS import: Allow custom exclusions from custom_options.php

### DIFF
--- a/public/ics/class.ics.php
+++ b/public/ics/class.ics.php
@@ -200,6 +200,14 @@ class CJICS
 
         $events=array();
         foreach ($tmp as $elem) {
+
+            // Run custom exclusions
+            if (!empty($config['ICS-custom-exclusion'])) {
+                if ($config['ICS-custom-exclusion']($elem)) {
+                    continue;
+                }
+            }
+
             // Ne traite pas les événéments ayant le status X-MICROSOFT-CDO-INTENDEDSTATUS différent de BUSY (si le paramètre X-MICROSOFT-CDO-INTENDEDSTATUS existe)
             if (isset($elem['X-MICROSOFT-CDO-INTENDEDSTATUS']) and $elem['X-MICROSOFT-CDO-INTENDEDSTATUS'] != "BUSY") {
                 continue;


### PR DESCRIPTION
This commit allows the creation of a custom function that can be used to filter events before importing them
In the optional custom_options.php file, you can add the $config['ICS-custom-exclusion'] parameter and the associated function.

E.g. :
$config['ICS-custom-exclusion'] = 'myExclusionFunction';

function myExclusionFunction($event) {
    return $event['SUMMARY'] != 'Absent';
}

// Events that do not match with "Absent" won't be imported