### PR TITLE
Restriction de la période importée dans le calendrier ICS

### DIFF
--- a/public/ics/calendar.php
+++ b/public/ics/calendar.php
@@ -107,7 +107,7 @@ $db->selectInnerJoin(
     array(),
   array("perso_id"=>$id),
     $requete_personnel,
-    "ORDER BY `date` DESC, `debut` DESC, `fin` DESC"
+    "AND `date` > DATE_SUB(curdate(), INTERVAL 1 MONTH) ORDER BY `date` DESC, `debut` DESC, `fin` DESC"
 );
 if ($db->result) {
     $planning = $db->result;
@@ -129,7 +129,7 @@ if ($config['Multisites-nombre'] > 1) {
 // Recherche des plannings verrouillés pour exclure les plages concernant des plannings en attente
 $verrou = array();
 $db = new db();
-$db->select2("pl_poste_verrou", null, array('verrou2'=>'1'));
+$db->select2("pl_poste_verrou", null, array('verrou2'=>'1'), "AND `date` > DATE_SUB(curdate(), INTERVAL 1 MONTH)");
 if ($db->result) {
     foreach ($db->result as $elem) {
         $verrou[$elem['date'].'_'.$elem['site']] = array('date'=>$elem['validation2'], 'agent'=>$elem['perso2']);
@@ -140,7 +140,7 @@ if ($db->result) {
 $a=new absences();
 $a->valide = true;
 $a->documents = false;
-$a->fetch("`debut`,`fin`", $id, '0000-00-00 00:00:00', date('Y-m-d', strtotime(date('Y-m-d').' + 2 years')));
+$a->fetch("`debut`,`fin`", $id, date('Y-m-d',strtotime(date('Y-m-d').' - 1 months')), date('Y-m-d', strtotime(date('Y-m-d').' + 2 years')));
 $absences=$a->elements;
 
 // Recherche des congés (si le module est activé)
@@ -148,7 +148,7 @@ if ($config['Conges-Enable']) {
     require_once "../conges/class.conges.php";
     $c = new conges();
     $c->perso_id = $id;
-    $c->debut = '0000-00-00 00:00:00';
+    $c->debut = date('Y-m-d',strtotime(date('Y-m-d').' - 1 months'));
     $c->fin = date('Y-m-d', strtotime(date('Y-m-d').' + 2 years'));
     $c->valide = true;
     $c->fetch();


### PR DESCRIPTION
Le début des dates moissonnées correspond maintenant à j moins un mois.

Olivier Crouzet