### PR TITLE
MT 36809: prevent include class.conges.php twice

### DIFF
--- a/public/conges/recuperation_valide.php
+++ b/public/conges/recuperation_valide.php
@@ -14,7 +14,7 @@ Description :
 Fichier permettant de modifier et valider les demandes de récupérations des samedis (validation du formulaire)
 */
 
-include "class.conges.php";
+include_once(__DIR__ . '/class.conges.php');
 
 use App\Model\Agent;
 


### PR DESCRIPTION
This fix a fatal error when changing comp-time status.