### PR TITLE
MT 36248: Disabled notifications should not be considered as an error

### DIFF
--- a/public/include/function.php
+++ b/public/include/function.php
@@ -208,7 +208,6 @@ class CJMail implements NotificationTransporterInterface
   
     /* arrête la procédure d'envoi de mail si désactivé dans la config */
         if (!$GLOBALS['config']['Mail-IsEnabled']) {
-            $this->error.="L'envoi des e-mails est désactivé dans la configuration\n";
             $this->successAddresses=array();
             $this->failedAddresses=$this->to;
             return false;

--- a/src/Controller/AbsenceController.php
+++ b/src/Controller/AbsenceController.php
@@ -317,7 +317,7 @@ class AbsenceController extends BaseController
 
         $session->getFlashBag()->add('notice', $msg);
 
-        if ($msg2 && $msg2 != '<li></li>') {
+        if ($msg2) {
             $session->getFlashBag()->add($msg2_type, $msg2);
         }
 


### PR DESCRIPTION
If the notification system is disabled, CJMail class consider this as an error. This cause some empty error message in some places.

I.e: create an absence for more than one agent.