### PR TITLE
MT36303:  Add more precision to hours count when adding holiday

### DIFF
--- a/src/PlanningBiblio/Helper/HolidayHelper.php
+++ b/src/PlanningBiblio/Helper/HolidayHelper.php
@@ -195,7 +195,7 @@ class HolidayHelper extends BaseHelper
             // If this is a closing day, don't check for
             // "normal" hours. Only take into account regularization.
             if (!$closingday) {
-                $per_week[$week_id]['times'] += number_format($today / 3600, 2, '.', '');
+                $per_week[$week_id]['times'] += $today / 3600;
             }
 
             $current = date("Y-m-d", strtotime("+1 day", strtotime($current)));

--- a/tests/PlanningBiblio/Helper/HolidayHelperTest.php
+++ b/tests/PlanningBiblio/Helper/HolidayHelperTest.php
@@ -224,4 +224,55 @@ class HolidayHelperTest extends TestCase
         $this->assertEquals(1, $result['days'], 'request 9h on 1 day (default reference time)');
 
     }
+
+    public function testgetCountedHoursHolidayModeHours() {
+        $GLOBALS['config']['Conges-Mode'] = 'heures';
+        $GLOBALS['config']['Conges-Recuperations'] = 0;
+        $GLOBALS['config']['Conges-demi-journees'] = 0;
+        $GLOBALS['config']['Conges-fullday-switching-time'] = '4';
+        $GLOBALS['config']['Conges-fullday-reference-time'] = '';
+
+        $builder = new FixtureBuilder();
+        $agent = $builder->build(Agent::class, array('login' => 'e.sosson'));
+
+        // No model for workinghours yet. Use db function.
+        $working_hours = array(
+            0 => array('0' => '09:10:00', '1' => '12:00:00', '2' => '12:40:00', '3' => '17:00:00'),
+            1 => array('0' => '09:10:00', '1' => '12:00:00', '2' => '12:40:00', '3' => '17:00:00'),
+            2 => array('0' => '', '1' => '', '2' => '', '3' => ''),
+            3 => array('0' => '09:10:00', '1' => '12:00:00', '2' => '12:40:00', '3' => '17:00:00'),
+            4 => array('0' => '09:10:00', '1' => '12:00:00', '2' => '12:40:00', '3' => '16:40:00'),
+            5 => array('0' => '', '1' => '', '2' => '', '3' => ''),
+        );
+
+        $_SESSION['oups']['CSRFToken'] = '00000';
+        $db = new \db();
+        $db->CSRFToken = '00000';
+        $db->delete('planning_hebdo');
+        $db->insert(
+            'planning_hebdo',
+            array(
+                'perso_id' => $agent->id(),
+                'debut' => '2021-01-01',
+                'fin' => '2035-12-31',
+                'temps' => json_encode($working_hours),
+                'valide' => 1,
+                'nb_semaine' => 1
+            )
+        );
+
+        $holidayHlper = new HolidayHelper(array(
+            'start' => '2022-08-01',
+            'hour_start' => '00:00:00',
+            'end' => '2022-08-12',
+            'hour_end' => '23:59:59',
+            'perso_id' => $agent->id(),
+            'is_recover' => 0,
+        ));
+        $result = $holidayHlper->getCountedHours();
+
+        $this->assertEquals(56, $result['hours']);
+        $this->assertEquals('56h40', $result['hr_hours']);
+    }
 }
+


### PR DESCRIPTION
    Test plan:
    
     - Find a configuration that leads to an imprecision in the number of hours
       calculation when adding an holiday. It is likely to happen when an holiday
       is long enough. Dynamic number of hours calculation on the holiday page
       will lead to something like 56h41 (instead of 56h40).
    
     - Apply this patch.
    
     - Check that the amount of hours is now correct.
