### PR TITLE
Mt37151

### DIFF
--- a/src/Controller/AccountController.php
+++ b/src/Controller/AccountController.php
@@ -54,16 +54,25 @@ class AccountController extends BaseController
 
         // Crédits (congés, récupérations)
         if ($this->config('Conges-Enable')) {
+
+            // @note : $fulldayReferenceTime may change depending on param Conges-fullday-reference-time.
+            // Its default value is 7 hours
+            // Its value is always 7 hours if credits are managed in days (Conges-Mode=jours)
+
+            $fulldayReferenceTime = $this->config('Conges-fullday-reference-time') ?? 7;
+            if ($this->config('Conges-Mode') == 'jours') {
+                $fulldayReferenceTime = 7;
+            }
+
             $credits['annuel'] = heure4($p->elements[0]['conges_annuel']);
             $credits['conges'] = heure4($p->elements[0]['conges_credit']);
             $credits['reliquat'] = heure4($p->elements[0]['conges_reliquat']);
             $credits['anticipation'] = heure4($p->elements[0]['conges_anticipation']);
             $credits['recuperation'] = heure4($p->elements[0]['comp_time']);
-            $credits['joursAnnuel'] = number_format($credits['annuel']/7, 2, ",", " ");
-            $credits['joursConges'] = number_format($credits['conges']/7, 2, ",", " ");
-            $credits['joursReliquat'] = number_format($credits['reliquat']/7, 2, ",", " ");
-            $credits['joursAnticipation'] = number_format($credits['anticipation']/7, 2, ",", " ");
-            $credits['joursRecuperation'] = number_format($credits['recuperation']/7, 2, ",", " ");
+            $credits['joursAnnuel'] = number_format($p->elements[0]['conges_annuel']/$fulldayReferenceTime, 2, ",", " ");
+            $credits['joursConges'] = number_format($p->elements[0]['conges_credit']/$fulldayReferenceTime, 2, ",", " ");
+            $credits['joursReliquat'] = number_format($p->elements[0]['conges_reliquat']/$fulldayReferenceTime, 2, ",", " ");
+            $credits['joursAnticipation'] = number_format($p->elements[0]['conges_anticipation']/$fulldayReferenceTime, 2, ",", " ");
         }
 
         // Liste de tous les agents (pour la fonction nom()

--- a/templates/myAccount.html.twig
+++ b/templates/myAccount.html.twig
@@ -77,38 +77,47 @@
           </tr>
           <tr>
             <td>Crédit annuel</td>
-            <td style='text-align:right;'>
-              {{ credits.annuel }}
-            </td>
+            {% if config('Conges-Mode') == 'heures' %}
+              <td style='text-align:right;'>
+                {{ credits.annuel }}
+              </td>
+            {% endif %}
             <td style='text-align:right;'>
               {{ credits.joursAnnuel }} jours
             </td>
           </tr>
           <tr>
             <td>Crédit restant</td>
-            <td style='text-align:right;'>
-              {{ credits.conges }}
-            </td>
+            {% if config('Conges-Mode') == 'heures' %}
+              <td style='text-align:right;'>
+                {{ credits.conges }}
+              </td>
+            {% endif %}
             <td style='text-align:right;'>
               {{ credits.joursConges }} jours
             </td>
           </tr>
           <tr>
             <td>Reliquat</td>
-            <td style='text-align:right;'>
-              {{ credits.reliquat }}
-            </td>
+            {% if config('Conges-Mode') == 'heures' %}
+              <td style='text-align:right;'>
+                {{ credits.reliquat }}
+              </td>
+            {% endif %}
             <td style='text-align:right;'>
               {{ credits.joursReliquat}} jours
             </td>
           </tr>
           <tr>
             <td>Solde débiteur</td>
-            <td style='text-align:right;'>
-              {{ credits.anticipation }}</td>
+            {% if config('Conges-Mode') == 'heures' %}
               <td style='text-align:right;'>
-                {{ credits.joursAnticipation }} jours
+                {{ credits.anticipation }}
               </td>
+             {% endif %}
+             <td style='text-align:right;'>
+               {{ credits.joursAnticipation }} jours
+             </td>
           </tr>
           <tr>
             <td style='font-weight:bold;padding-top:20px;' colspan='2'>Récupérations</td>
@@ -117,9 +126,6 @@
             <td>Crédit</td>
             <td style='text-align:right;'>
               {{ credits.recuperation }}
-            </td>
-            <td style='text-align:right;'>
-              {{ credits.joursRecuperation }} jours
             </td>
           </tr>
         </table>


### PR DESCRIPTION
- Do not convert comp-time in days on My Account (Comp-time is always in hours)
- Do not display credits in hours on My Account if Conges-Mode=jours
- Correctly calculate holiday credits in days on My Account
- Use $fulldayReferenceTime variable to calcule credits in days, Its default value is 7 hours, it takes config(fullday_reference_time) if defined, and it is always 7 hours if Conges-Mode=jours

NB: if Conges-Mode=jours, credits are stored and computed in hours, then converted in days for display, always with 7 hours as reference time. Config(fullday_reference_time) is used to display the equivalent in days when credits are managed in hours.