### PR TITLE
MT 37380: make getCountedHours takes week rotation into account

### DIFF
--- a/src/PlanningBiblio/Helper/HolidayHelper.php
+++ b/src/PlanningBiblio/Helper/HolidayHelper.php
@@ -88,8 +88,6 @@ class HolidayHelper extends BaseHelper
         while ($current <= $fin) {
 
             $date_current = new \DateTime($current);
-            $week_id = $date_current->format("W");
-            $day_id = $date_current->format("N") - 1;
 
             // Check agent's planning.
             $planning = $this->getPlanning($current);
@@ -97,6 +95,12 @@ class HolidayHelper extends BaseHelper
                 $result['error'] = true;
                 return $result;
             }
+
+            $d = new \datePl($current, $planning['nb_semaine']);
+            $week_id = $d->semaine3;
+
+            $day = $d->position ? $d->position : 7;
+            $day_id = $day + (($week_id - 1) * 7) - 1;
 
             $week_helper = new WeekPlanningHelper($planning['times']);
             $per_week[$week_id]['worked_days'] = $week_helper->NumberWorkingDays();

--- a/tests/PlanningBiblio/Helper/HolidayHelperWeeklyRotation.php
+++ b/tests/PlanningBiblio/Helper/HolidayHelperWeeklyRotation.php
@@ -1,0 +1,67 @@
+<?php
+
+use App\Model\Agent;
+
+use App\PlanningBiblio\Helper\HolidayHelper;
+use PHPUnit\Framework\TestCase;
+use Tests\FixtureBuilder;
+
+class HolidayHelperWeeklyRotation extends TestCase
+{
+    public function testgetCountedHoursWithTwoWeekRotation()
+    {
+        $GLOBALS['config']['PlanningHebdo'] = 1;
+        $GLOBALS['config']['nb_semaine'] = 2;
+
+        $working_hours = array(
+            0 => array('09:00:00','','','17:30:00',''),
+            1 => array('09:00:00','','','17:30:00',''),
+            2 => array('09:00:00','','','17:30:00',''),
+            3 => array('09:00:00','','','17:30:00',''),
+            4 => array('09:00:00','','','17:30:00',''),
+            5 => array('','','','',''),
+            7 => array('08:00:00','','','17:30:00',''),
+            8 => array('08:00:00','','','17:30:00',''),
+            9 => array('08:00:00','','','17:30:00',''),
+            10 => array('08:00:00','','','17:30:00',''),
+            11 => array('08:00:00','','','17:30:00',''),
+            12 => array('','','','','')
+        );
+
+        //$breatimes = array(1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0);
+
+        $builder = new FixtureBuilder();
+        $agent = $builder->build(Agent::class, array('login' => 'twoweekrotation'));
+
+        $_SESSION['oups']['CSRFToken'] = '00000';
+        $db = new \db();
+        $db->CSRFToken = '00000';
+        $db->delete('planning_hebdo');
+        $db->insert(
+            'planning_hebdo',
+            array(
+                'perso_id' => $agent->id(),
+                'debut' => '2022-06-01',
+                'fin' => '2022-12-31',
+                'temps' => json_encode($working_hours),
+                'valide' => 1,
+                'nb_semaine' => 2
+            )
+        );
+
+        // Request holiday on even week.
+        // The week this agent works 9h30.
+        $holidayHlper = new HolidayHelper(array(
+            'start' => '2022-06-17',
+            'hour_start' => '00:00:00',
+            'end' => '2022-06-17',
+            'hour_end' => '23:59:59',
+            'perso_id' => $agent->id(),
+            'is_recover' => 0,
+        ));
+        $result = $holidayHlper->getCountedHours();
+
+        $this->assertEquals(9, $result['hours'], 'request 7h on 1 day');
+        $this->assertEquals(50, $result['minutes'], 'request 30 minutes on 1 day');
+    }
+}


### PR DESCRIPTION
Test plan:

Config: nb_semaine: 2
Create working hours for an agent. Make he works 7 hours all the days of the even week and 8 hours all the days of the odd week.
Add a holiday or comptime:
  - if the holiday is on odd week, it counts the hours of odd week => Ok
  - if the holiday is on even week, it counts the hours of odd week => KO
Apply this fix, try again. It works !