### PR TITLE
Remove absence class from time-slot and make them dropable

### DIFF
--- a/public/js/statedweek.js
+++ b/public/js/statedweek.js
@@ -186,6 +186,9 @@ function emptyPlanning() {
     $(this).empty();
     $(this).removeAttr('data-agent');
     $(this).removeData('agent');
+    $(this).removeClass('absent');
+    $(this).removeClass('partially-absent');
+    initDroppable($(this));
   });
 };
 
@@ -323,7 +326,7 @@ $( document ).ready(function() {
       item = $('<span></span>');
       item = $('<span class="status_'+ agent.status + '"></span>');
       item.append('<span class="agent_name">' + agent.name + '</span>');
-      
+
       if (agent.custom_from && agent.custom_to) {
         item.append('<br/><i style="font-weight:normal;"> - de ' + agent.custom_from + ' à ' + agent.custom_to + '</i>');
       }


### PR DESCRIPTION
Test plan:
In the stated week page, place some agents like this:
  - In the first (left) column:
    - an agent whose name starts with A....
    - an agent whose name starts with C.... and make he is absent (red crossed)
  - in the second (middle) column:
    - an agent whose name starts with B....
  - move the B.... agent from middle to left column
  => The B... agent become absent.

Apply this patch and try again.