### PR TITLE
MT37467: Correctly take into account the number of weeks of working hours

### DIFF
--- a/src/Controller/CalendarController.php
+++ b/src/Controller/CalendarController.php
@@ -100,7 +100,7 @@ class CalendarController extends BaseController
         $db->select2("absences", null, "`perso_id`='$perso_id' $filter");
         if ($db->result){
             foreach ($db->result as $elem){
-                $verrou[$elem('site')][] = $elem['date'];
+                $verrou[$elem['site']][] = $elem['date'];
             }
         }
 
@@ -168,6 +168,8 @@ class CalendarController extends BaseController
                     $temps = array();
                 } else {
                     $temps = $p->elements[0]['temps'];
+                    $week_number = $p->elements[0]['nb_semaine'];
+                    $jour = $d->planning_day_index_for($perso_id, $week_number);
                 }
             }
             $horaires = null;

--- a/src/PlanningBiblio/PresentSet.php
+++ b/src/PlanningBiblio/PresentSet.php
@@ -44,17 +44,13 @@ class PresentSet
             if ($config['PlanningHebdo']) {
                 if (array_key_exists($elem['id'], $tempsPlanningHebdo)) {
                     $temps = $tempsPlanningHebdo[$elem['id']]['temps'];
+                    $week_number = $tempsPlanningHebdo[$elem['id']]['nb_semaine'];
                 }
             } else {
                 $temps = json_decode(html_entity_decode($elem['temps'], ENT_QUOTES|ENT_IGNORE, 'UTF-8'), true);
             }
 
-            $jour = $date_planning->position - 1;
-            if ($jour == -1) {
-                $jour = 6;
-            }
-
-            $jour += ($semaine3 - 1) * 7;
+            $jour = $date_planning->planning_day_index_for($elem['id'], $week_number);
 
             // Si l'emploi du temps est renseigné
             if (!empty($temps) and array_key_exists($jour, $temps)) {


### PR DESCRIPTION
Correctly take into account the number of weeks of a working hours'
period (when PlanningHebdo is enabled) for presence display on several pages:

 - attendees / missing (/statistics/attendeesmissing)

 - calendar (/calendar)

 - attendees / missing under a planning
   (Absences-planning set to "absents et présents")

Test plan:

 - Enable PlanningHebdo
 - Create a working hours period for an agent with number of weeks set to 1
 - Set number of weeks global parameter (nb_semaine) to 2
 - On any of the aforementioned pages:
   - without the patch, no presence is mentionned for the second week
   - with the patch, week 1 presence is correctly reported on week 2.