### PR TITLE
MT 37194: LDAP import: fix positions and rights json serialization

### DIFF
--- a/public/ldap/import2.php
+++ b/public/ldap/import2.php
@@ -24,9 +24,9 @@ $CSRFToken = filter_input(INPUT_POST, 'CSRFToken', FILTER_SANITIZE_STRING);
 $actif="Actif";
 $date=date("Y-m-d H:i:s");
 $commentaires= "Importation LDAP $date";
-$droits="a:2:{i:0;i:99;i:1;i:100;}";
+$droits = json_encode(array(99, 100));
 $password="password_bidon_pas_importé_depuis_ldap";
-$postes='a:1:{i:0;s:0:"";}';
+$postes = json_encode(array());
 $erreurs=false;
 
 $post=filter_input_array(INPUT_POST, FILTER_SANITIZE_STRING);


### PR DESCRIPTION
We need this fix for 21.10.xx and BSG_master_20220725 where LDAP pages or not symfonized