### PR TITLE
MT38396 Hide the display of the hour/day equivalence when the necessa…

### DIFF
--- a/templates/conges/add.html.twig
+++ b/templates/conges/add.html.twig
@@ -183,7 +183,7 @@
                   </tr>
                 {% endif %}
 
-                {% if conges_mode == 'heures' and hours_per_day is defined %}
+                {% if conges_mode == 'heures' and hours_per_day is not empty %}
                   <tr class='hideWhenMultipleAgents'>
                     <td class="textAlignRight">
                         Nombre de jours ({{ hours_per_day }}h/jour) :

--- a/templates/conges/edit.html.twig
+++ b/templates/conges/edit.html.twig
@@ -187,7 +187,7 @@
         </tr>
       {% endif %}
 
-      {% if conges_mode == 'heures' and hours_per_day is defined %}
+      {% if conges_mode == 'heures' and hours_per_day is not empty %}
         <tr>
           <td>
             Nombre de jours ({{ hours_per_day }}h/jour) :


### PR DESCRIPTION
Hide the display of the hour/day equivalence when the necessary setting is not defined

Please see MT38396 

TEST PLAN
Config
- Conges-enable
- Conges-mode = Heures

Tests
- create a new holliday, select an agent and a date
- The number of hours is shown : OK
- without this PR, the equivalence hours/day is shown : KO
- with this PR, the equivalence hours/day is not shown : OK

- save then edit the holiday and make the same tests
- create a new recover and make the same tests
- save and edit the recover and make the same tests

Create a file named custom_options.php with the following content : 
`<?php
$config['conges-hours-per-day'] = array(
        '175.50' => 7,
        '0' => 6,
    );
`

- create a new holliday, select an agent and a date
- The number of hours is shown : OK
- the equivalence hours/day is shown : OK

- save then edit the holiday and make the same tests
- create a new recover and make the same tests
- save and edit the recover and make the same tests

NB : The equivalence is well calulated with the right value of hours_per_day for the selected agent, but the number of hours is not updated when we change the agent in the text "Nombre de jours (Xh/jour)". This text is not updated with Ajax. This must be fixed.
