### PR TITLE
Remove warning SR on lunch positions

### DIFF
--- a/public/planning/poste/ajax.updateCell.php
+++ b/public/planning/poste/ajax.updateCell.php
@@ -287,7 +287,7 @@ foreach ($tab as $k => $v) {
 
 // Recherche des sans repas en dehors de la boucle pour optimiser les performances (juillet 2016)
 $p = new planning();
-$sansRepas = $p->sansRepas($date, $debut, $fin);
+$sansRepas = $p->sansRepas($date, $debut, $fin, $poste);
 
 // Recherche des absences
 

--- a/public/planning/poste/class.planning.php
+++ b/public/planning/poste/class.planning.php
@@ -14,6 +14,7 @@ Utilisée par les fichiers du dossier "planning/poste"
 */
 
 use App\Model\Agent;
+use App\Model\Position;
 
 // pas de $version=acces direct aux pages de ce dossier => Accès refusé
 $version = $GLOBALS['version'] ?? null;
@@ -121,8 +122,6 @@ class planning
         $semaine3=$d->semaine3;
         $site=$this->site;
 
-        $lunch_positions = $config['Position-Lunch'] ?? array();
-
         if ($hide) {
             $display="display:none;";
             $groupe_hide=null;
@@ -193,10 +192,13 @@ class planning
       );
 
             if ($db_heures->result) {
+
+                $positions = $GLOBALS['entityManager']->getRepository(Position::class);
+
                 // Pour chaqe résultat, on ajoute le nombre d'heures correspondant à l'agent concerné, pour le jour, la semaine et/ou les 4 semaines
                 foreach ($db_heures->result as $elem) {
 
-          // Vérifie à partir de la table absences si l'agent est absent
+                    // Vérifie à partir de la table absences si l'agent est absent
                     // S'il est absent, on passe (continue 2)
                     foreach ($absencesDB as $a) {
                         if ($elem['perso_id']==$a['perso_id'] and $a['debut']< $elem['date'].' '.$elem['fin'] and $a['fin']> $elem['date']." ".$elem['debut']) {
@@ -204,7 +206,7 @@ class planning
                         }
                     }
 
-                    if (in_array($elem['poste'], $lunch_positions)) {
+                    if ($positions->find($elem['poste'])->lunch()) {
                         continue;
                     }
 
@@ -704,14 +706,16 @@ class planning
             return array();
         }
 
-        $lunch_position = null;
-        if (!empty($GLOBALS['config']['Position-Lunch'])) {
-            $lunch_position = implode(',', $GLOBALS['config']['Position-Lunch']);
+        $positions = $GLOBALS['entityManager']->getRepository(Position::class);
+
+        $lunch_positions = array();
+        foreach ($positions->findBy(['lunch' => true]) as $elem) {
+            $lunch_positions[] = $elem->id(); 
         }
 
-        if (!empty($GLOBALS['config']['Position-Lunch'])
-            and isset($poste)
-            and in_array($poste, $GLOBALS['config']['Position-Lunch'])) {
+        $lunch_positions = implode(',', $lunch_positions);
+       
+        if (isset($poste) and $positions->find($poste)->lunch()) {
             return array();
         }
 
@@ -732,8 +736,8 @@ class planning
       // Recherche dans la base de données des autres plages concernées
             $db=new db();
 
-            if ($lunch_position) {
-                $db->select("pl_poste", "*", "date = '$date' AND debut < '$sr_fin' AND fin > '$sr_debut' AND poste NOT IN ($lunch_position)", "ORDER BY debut,fin");
+            if (!empty($lunch_positions)) {
+                $db->select("pl_poste", "*", "date = '$date' AND debut < '$sr_fin' AND fin > '$sr_debut' AND poste NOT IN ($lunch_positions)", "ORDER BY debut,fin");
             } else {
                 $db->select2("pl_poste", "*", array("date"=>$date, "debut"=>"<$sr_fin", "fin"=>">$sr_debut"), "ORDER BY debut,fin");
             }

--- a/public/planning/poste/fonctions.php
+++ b/public/planning/poste/fonctions.php
@@ -1,13 +1,10 @@
 <?php
 /**
-Planning Biblio, Version 2.8
+Planning Biblio
 Licence GNU/GPL (version 2 et au dela)
 Voir les fichiers README.md et LICENSE
-@copyright 2011-2018 Jérôme Combes
 
-Fichier : planning/poste/fonctions.php
-Création : mai 2011
-Dernière modification : 25 avril 2018
+@file public/planning/poste/fonctions.php
 @author Jérôme Combes <jerome@planningbiblio.fr>
 
 Description :
@@ -30,7 +27,7 @@ function cellule_poste($date, $debut, $fin, $colspan, $output, $poste, $site)
   
     // Recherche des sans repas en dehors de la boucle pour optimiser les performances (juillet 2016)
         $p = new planning();
-        $sansRepas = $p->sansRepas($date, $debut, $fin);
+        $sansRepas = $p->sansRepas($date, $debut, $fin, $poste);
 
         foreach ($GLOBALS['cellules'] as $elem) {
             $title=null;

--- a/public/setup/atomicupdate/MT37144.php
+++ b/public/setup/atomicupdate/MT37144.php
@@ -1,3 +1,9 @@
 <?php
 
 $sql[] = "ALTER TABLE `{$dbprefix}postes` ADD COLUMN IF NOT EXISTS `lunch` TINYINT(1) NOT NULL DEFAULT 0 AFTER `bloquant`;";
+
+if (!empty($config['Position-Lunch']) and is_array($config['Position-Lunch'])) {
+    foreach ($config['Position-Lunch'] as $elem) {
+        $sql[] = "UPDATE `{$dbprefix}postes` SET `lunch` = '1' WHERE `id` = '$elem';";
+    }
+}

--- a/public/setup/atomicupdate/MT37144.php
+++ b/public/setup/atomicupdate/MT37144.php
@@ -1,0 +1,3 @@
+<?php
+
+$sql[] = "ALTER TABLE `{$dbprefix}postes` ADD COLUMN IF NOT EXISTS `lunch` TINYINT(1) NOT NULL DEFAULT 0 AFTER `bloquant`;";

--- a/public/setup/db_structure.php
+++ b/public/setup/db_structure.php
@@ -366,6 +366,7 @@ $sql[]="CREATE TABLE `{$dbprefix}postes` (
   `statistiques` ENUM('0','1') DEFAULT '1',
   `teleworking` ENUM('0','1') NOT NULL DEFAULT '0',
   `bloquant` enum('0','1') DEFAULT '1',
+  `lunch` tinyint(1) NOT NULL DEFAULT 0,
   `site` INT(1) DEFAULT '1',
   `categories` TEXT NULL DEFAULT NULL,
   `supprime` DATETIME NULL DEFAULT NULL,

--- a/src/Controller/PlanningJobController.php
+++ b/src/Controller/PlanningJobController.php
@@ -65,6 +65,8 @@ class PlanningJobController extends BaseController
             && $this->config('PlanningHebdo-PauseLibre')
         ) ? 1 : 0;
 
+        $lunch_positions = $this->config('Position-Lunch') ?? array();
+
         // PlanningHebdo and EDTSamedi are not compliant.
         // So, we disable EDTSamedi if
         // PlanningHebdo is enabled
@@ -250,9 +252,15 @@ class PlanningJobController extends BaseController
             $db = new \db();
             $dateSQL = $db->escapeString($date);
 
-            $db->query("SELECT perso_id, debut, fin FROM `{$dbprefix}pl_poste` WHERE date = '$dateSQL' AND supprime = '0';");
+            $db->query("SELECT perso_id, poste, debut, fin FROM `{$dbprefix}pl_poste` WHERE date = '$dateSQL' AND supprime = '0';");
             if ($db->result) {
                 foreach ($db->result as $elem) {
+                    // If the current position is a lunch, don't add it to duration
+                    // cause this a not worked position
+                    if (in_array($elem['poste'], $lunch_positions)) {
+                        continue;
+                    }
+
                     // Get day duration as timestamp
                     // for an easier comparison.
                     $elem_duration = strtotime($elem['fin']) - strtotime($elem['debut']);
@@ -378,7 +386,9 @@ class PlanningJobController extends BaseController
 
                 if ($break_countdown) {
                     $day_hour = isset($day_hours[$elem['id']]) ? $day_hours[$elem['id']] : 0;
-                    $requested_hours = strtotime($fin) - strtotime($debut);
+
+                    $is_a_break = in_array($poste, $lunch_positions) ? 1 : 0;
+                    $requested_hours = $is_a_break ? 0 : strtotime($fin) - strtotime($debut);
 
                     $wh = new WorkingHours($temps);
                     $tab = $wh->hoursOf($jour);

--- a/src/Controller/PlanningJobController.php
+++ b/src/Controller/PlanningJobController.php
@@ -6,6 +6,7 @@ use App\Controller\BaseController;
 use App\Model\Agent;
 use App\Model\AbsenceReason;
 use App\Model\PlanningPositionHistory;
+use App\Model\Position;
 
 use App\PlanningBiblio\WorkingHours;
 
@@ -65,7 +66,7 @@ class PlanningJobController extends BaseController
             && $this->config('PlanningHebdo-PauseLibre')
         ) ? 1 : 0;
 
-        $lunch_positions = $this->config('Position-Lunch') ?? array();
+        $positions = $this->entityManager->getRepository(Position::class);
 
         // PlanningHebdo and EDTSamedi are not compliant.
         // So, we disable EDTSamedi if
@@ -257,7 +258,7 @@ class PlanningJobController extends BaseController
                 foreach ($db->result as $elem) {
                     // If the current position is a lunch, don't add it to duration
                     // cause this a not worked position
-                    if (in_array($elem['poste'], $lunch_positions)) {
+                    if ($positions->find($elem['poste'])->lunch()) {
                         continue;
                     }
 
@@ -387,7 +388,7 @@ class PlanningJobController extends BaseController
                 if ($break_countdown) {
                     $day_hour = isset($day_hours[$elem['id']]) ? $day_hours[$elem['id']] : 0;
 
-                    $is_a_break = in_array($poste, $lunch_positions) ? 1 : 0;
+                    $is_a_break = $positions->find($poste)->lunch();
                     $requested_hours = $is_a_break ? 0 : strtotime($fin) - strtotime($debut);
 
                     $wh = new WorkingHours($temps);

--- a/src/Controller/PositionController.php
+++ b/src/Controller/PositionController.php
@@ -139,6 +139,8 @@ class PositionController extends BaseController
             $bloq2 = !$position->bloquant()?"checked='checked'":"";
             $teleworking1 = $position->teleworking() ? "checked='checked'" : "";
             $teleworking2 = !$position->teleworking() ? "checked='checked'" : "";
+            $lunch1 = $position->lunch() ? "checked='checked'" : "";
+            $lunch2 = !$position->lunch() ? "checked='checked'" : "";
         } else {
             $id = null;
             $nom =  null;
@@ -156,6 +158,8 @@ class PositionController extends BaseController
             $bloq2 = null;
             $teleworking1 = null;
             $teleworking2 = 'checked';
+            $lunch1 = null;
+            $lunch2 = 'checked';
         }
 
         // Floors, groups and skills
@@ -232,6 +236,8 @@ class PositionController extends BaseController
             'stat2'         => $stat2,
             'teleworking1'  => $teleworking1,
             'teleworking2'  => $teleworking2,
+            'lunch1'        => $lunch1,
+            'lunch2'        => $lunch2,
             'bloq1'         => $bloq1,
             'bloq2'         => $bloq2,
             'floors'        => $floors,
@@ -271,6 +277,7 @@ class PositionController extends BaseController
             $categories = $request->get('categories', []);
             $site = $request->get('site', 1);
             $bloquant = $request->get('bloquant', 1);
+            $lunch = $request->get('lunch', 0);
             $statistiques = $request->get('statistiques', 1);
             $teleworking = $request->get('teleworking', 0);
             $etage = $request->get('etage',"");
@@ -287,6 +294,7 @@ class PositionController extends BaseController
                 $position->bloquant($bloquant);
                 $position->statistiques($statistiques);
                 $position->teleworking($teleworking);
+                $position->lunch($lunch);
                 $position->etage($etage);
                 $position->groupe($groupe);
                 $position->groupe_id($groupe_id);
@@ -316,6 +324,7 @@ class PositionController extends BaseController
                 $position->bloquant($bloquant);
                 $position->statistiques($statistiques);
                 $position->teleworking($teleworking);
+                $position->lunch($lunch);
                 $position->etage($etage);
                 $position->groupe($groupe);
                 $position->groupe_id($groupe_id);

--- a/src/Model/Position.php
+++ b/src/Model/Position.php
@@ -39,6 +39,9 @@ class Position extends PLBEntity
     /** @Column(type="text", columnDefinition="ENUM('0','1')") )**/
     protected $bloquant;
 
+    /** @Column(type="boolean")**/
+    protected $lunch = false;
+
     /** @Column(type="integer", length=1)**/
     protected $site;
 

--- a/templates/position/edit.html.twig
+++ b/templates/position/edit.html.twig
@@ -60,8 +60,8 @@
                     <span class='pl-icon pl-icon-add' title='Ajouter' id='add-etage-button' style='cursor:pointer; margin-left:4px;'></span>
                   </td>
                 </tr>
-                <tr>
-                  {% if not config('Planook') %}
+                {% if not config('Planook') %}
+                  <tr>
                     <td>Groupe:</td>
                     <td style='white-space: nowrap;'>
                       <select name='groupe' id='groupe' style='width:255px' class='ui-widget-content ui-corner-all'>
@@ -104,8 +104,15 @@
                       <input type='radio' name='teleworking' value='1' {{ teleworking1 }}/> Oui
                       <input type='radio' name='teleworking' value='0' {{ teleworking2 }}/> Non
                     </td>
-                  {% endif %}
-                </tr>
+                  </tr>
+                  <tr>
+                    <td>Poste repas :</td>
+                    <td>
+                      <input type='radio' name='lunch' value='1' {{ lunch1 }}/> Oui
+                      <input type='radio' name='lunch' value='0' {{ lunch2 }}/> Non
+                    </td>
+                  </tr>
+                {% endif %}
               </table>
             </td>
 


### PR DESCRIPTION
Patch MT37144 dèjà appliqué à la BSG, à intégrer les versions maintenues.

TEST PLAN :
- Créer un poste nommé "Repas", cocher "Oui" sur la ligne "Poste repas"
- Créer un planning avec ce poste
- paramétrer les alertes sans repas, entre 12 et 14
- placer des agents non-stop entre 12 et 14 sur plusieurs poste, sans le poste "Repas" : l'alerte SR doit s'afficher dans le menu et sur les postes
- placer des agents non-stop entre 12 et 14 sur plusieurs poste, dont le poste "Repas" : l'alerte SR NE doit PAS s'afficher, ni dans le menu, ni sur les postes