### PR TITLE
MT38997: Fix duplicate display of absence list (short version)

### DIFF
--- a/templates/planning/poste/index.html.twig
+++ b/templates/planning/poste/index.html.twig
@@ -149,11 +149,11 @@
           <table id='tablePlanningAbsences' class='CJDataTable' data-sort='[[0],[1]]'>
             <thead>
               <tr>
-                <th class='tableSort'>Nom</th>
-                <th class='tableSort'>Prénom</th>
-                <th class='dataTableDateFR tableSort'>Début</th>
-                <th class='dataTableDateFR tableSort'>Fin</th>
-                <th class='tableSort'>Motif</th>
+                <th>Nom</th>
+                <th>Prénom</th>
+                <th class='dataTableDateFR'>Début</th>
+                <th class='dataTableDateFR'>Fin</th>
+                <th>Motif</th>
               </tr>
             </thead>
             <tbody>
@@ -171,35 +171,6 @@
             </tbody>
           </table>
         {% endif %}
-
-      {% if config('Absences-planning') == 2 and absences_planning | length > 0 %}
-        <h3 style='text-align:left;margin:40px auto 0 auto; width: 90%;'>Liste des absents</h3>
-
-        <table id='tablePlanningAbsences' class='CJDataTable' data-sort='[[0],[1]]'>
-          <thead>
-            <tr>
-              <th>Nom</th>
-              <th>Prénom</th>
-              <th class='dataTableDateFR'>Début</th>
-              <th class='dataTableDateFR'>Fin</th>
-              <th>Motif</th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for a in absences_planning %}
-              {% if a.valide %}
-                <tr class="{{ a.bold }}">
-                  <td>{{ a.nom }}</td>
-                  <td>{{ a.prenom }}</td>
-                  <td>{{ a.debutAff }}</td>
-                  <td>{{ a.finAff }}</td>
-                  <td>{{ a.motif }}{{ a.nonValidee }}</td>
-                </tr>
-              {% endif %}
-            {% endfor %}
-          </tbody>
-        </table>
-      {% endif %}
 
       {% if config('Absences-planning') == 3 %}
         <div class='decalage-gauche'>


### PR DESCRIPTION
Voir détail sur le ticket MT 38997 

version courte (sans refacto)

Cette PR corrige l'affichage en double du tableau détaillé des absences sous les plannings

(version avec refacto : #780 