### PR TITLE
MT38912: Show holiday accounts for managed agents only

### DIFF
--- a/public/conges/class.conges.php
+++ b/public/conges/class.conges.php
@@ -32,6 +32,7 @@ use App\Model\Agent;
 class conges
 {
     public $agent=null;
+    public $agents = array();
     public $agents_supprimes=array(0);
     public $admin=false;
     public $annee=null;
@@ -521,21 +522,15 @@ class conges
         // Affichage ou non des crédits des agents supprimés
         $supprime=implode("','", $this->agents_supprimes);
 
-        // Recherche des agents
-        // N'affiche que les agents des sites gérés (Multisites seulement)
-        $sitesReq=null;
-        if ($GLOBALS['config']['Multisites-nombre']>1) {
-            $tmp=array();
-            if (!empty($this->sites)) {
-                foreach ($this->sites as $elem) {
-                    $tmp[]="sites LIKE '%\"$elem\"%'";
-                    $sitesReq=" AND (".implode(" OR ", $tmp).") ";
-                }
-            }
+        // Show managed agents only
+        $perso_ids = array();
+        foreach ($this->agents as $agent) {
+            $perso_ids[] = $agent->id();
         }
+        $agents_req = 'AND `id` IN (' . implode(',', $perso_ids) . ')';
 
         $db=new db();
-        $db->select("personnel", "id,nom,prenom,conges_credit,conges_reliquat,conges_anticipation,comp_time,conges_annuel", "`supprime` IN ('$supprime') AND `id`<>'2' $sitesReq");
+        $db->select("personnel", "id,nom,prenom,conges_credit,conges_reliquat,conges_anticipation,comp_time,conges_annuel", "`supprime` IN ('$supprime') AND `id`<>'2' $agents_req");
         if (!$db->result) {
             return false;
         }

--- a/src/Controller/HolidayController.php
+++ b/src/Controller/HolidayController.php
@@ -712,6 +712,12 @@ class HolidayController extends BaseController
         $checked3=$credits_en_attente?"checked='checked'":null;
         $checked4=$hours_to_days?"checked='checked'":null;
 
+        // Look for managed agents only
+        $managed = $this->entityManager
+            ->getRepository(Agent::class)
+            ->setModule('holiday')
+            ->getManagedFor($_SESSION['login_id'], $agents_supprimes);
+
         $c = new \conges();
         if ($agents_supprimes) {
             $c->agents_supprimes = array(0,1);
@@ -719,6 +725,7 @@ class HolidayController extends BaseController
         if ($this->config('Multisites-nombre') > 1) {
             $c->sites = $sites;
         }
+        $c->agents = $managed;
         $c->fetchAllCredits();
 
         $this->templateParams(array(

--- a/src/Controller/HolidayController.php
+++ b/src/Controller/HolidayController.php
@@ -722,9 +722,6 @@ class HolidayController extends BaseController
         if ($agents_supprimes) {
             $c->agents_supprimes = array(0,1);
         }
-        if ($this->config('Multisites-nombre') > 1) {
-            $c->sites = $sites;
-        }
         $c->agents = $managed;
         $c->fetchAllCredits();
 


### PR DESCRIPTION
Please see MT38912

Show credits for managed agents only.
Use the existing function getManagedFor which work find in all situation (mono-site, site by site, absences-notificiation-agent-by-agent.