### PR TITLE
MT39194: Add param CAS-LoginAttribute

### DIFF
--- a/public/ldap/class.ldap.php
+++ b/public/ldap/class.ldap.php
@@ -50,6 +50,16 @@ function authCAS($logger)
     phpCAS::forceAuthentication();
 
     $login=phpCAS::getUser();
+
+    if (!empty($config['CAS-LoginAttribute'])) {
+        $attr = $config['CAS-LoginAttribute'];
+        $attributes = phpCAS::getAttributes();
+
+        if (!empty($attributes[$attr]) and is_string($attributes[$attr])) {
+            $login = $attributes[$attr];
+        }
+    }
+
     $login=filter_var($login, FILTER_SANITIZE_STRING);
 
     // Si authentification CAS et utilisateur existe : retourne son login

--- a/public/setup/atomicupdate/MT39194.php
+++ b/public/setup/atomicupdate/MT39194.php
@@ -1,0 +1,4 @@
+<?php
+
+$sql[]="INSERT INTO `{$dbprefix}config` (`nom`, `type`, `categorie`, `ordre`, `commentaires`) VALUES
+  ('CAS-LoginAttribute', 'text', 'CAS','48', 'Attribut CAS à utiliser pour mapper l\'utilisateur si et seulement si l\'UID CAS ne convient pas. Laisser ce champ vide par défaut. Exemple : \"mail\", dans ce cas, l\'adresse mail de l\'utilisateur est fournie par le serveur CAS et elle est renseignée dans le champ \"login\" des fiches agents de Planno.');";

--- a/public/setup/db_data.php
+++ b/public/setup/db_data.php
@@ -288,6 +288,9 @@ $sql[]="INSERT INTO `{$dbprefix}config` (`nom`, `type`, `valeur`, `valeurs`, `ca
 $sql[]="INSERT INTO `{$dbprefix}config` (`nom`, `type`, `categorie`, `ordre`, `commentaires`) VALUES
   ('CAS-ServiceURL', 'text', 'CAS','47', 'URL de Planning Biblio. A renseigner seulement si la redirection ne fonctionne pas après authentification sur le serveur CAS, si vous utilisez un Reverse Proxy par exemple.');";
 
+$sql[]="INSERT INTO `{$dbprefix}config` (`nom`, `type`, `categorie`, `ordre`, `commentaires`) VALUES
+  ('CAS-LoginAttribute', 'text', 'CAS','48', 'Attribut CAS à utiliser pour mapper l\'utilisateur si et seulement si l\'UID CAS ne convient pas. Laisser ce champ vide par défaut. Exemple : \"mail\", dans ce cas, l\'adresse mail de l\'utilisateur est fournie par le serveur CAS et elle est renseignée dans le champ \"login\" des fiches agents de Planno.');";
+
 $sql[]="INSERT INTO `{$dbprefix}config` (`nom`,`valeur`,`commentaires`,`categorie`,`ordre`) VALUES ('CAS-URI','cas','Page de connexion CAS','CAS','30');";
 $sql[]="INSERT INTO `{$dbprefix}config` (`nom`,`valeur`,`commentaires`,`categorie`,`ordre`) VALUES ('CAS-URI-Logout','cas/logout','Page de d&eacute;connexion CAS','CAS','30');";
 


### PR DESCRIPTION
MT39194: Add param CAS-LoginAttribute which can be used when the UID should not be used as login

Please see MT39194.

TEST PLAN : 
1./ Laisser le champ CAS-LoginAttribute vide et vérifier que le comportement habituel fonctionne (authentification CAS habituel, utilisation de l'UID comme login).

2./ Mettre la valeur "mail" dans le champ CAS-LoginAttribute.
Mettre l'email de l'agent de le champ "login" de sa fiche.
S'assurer que le serveur CAS renvoie le mail dans la liste des attributs (phpCAS::getAttributes() récupère un tableau indexé)
Tester l'authentification, l'agent doit être reconnu et mappé par son mail (qui est renseigné dans le champ login de sa fiche).

