### PR TITLE
Fix rowCounts error

### DIFF
--- a/src/Cron/PurgeLogTable.php
+++ b/src/Cron/PurgeLogTable.php
@@ -42,9 +42,9 @@ Example: php bin/console PlanningBiblio:PurgeLogTable \"12 MONTH\"
         // TODO: Now that the model exists, I could be replaced by a query builder.
         $query = "DELETE FROM " . $_ENV['DATABASE_PREFIX'] . "log WHERE timestamp < (NOW() - INTERVAL $delay)";
         $statement = $em->getConnection()->prepare($query);
-        $statement->execute();
+        $result = $statement->execute();
         $logger = new Logger($em, $input->getOption('stdout'));
-        $logger->log("Log table entries older than $delay purged (" . $statement->rowCount() . " deleted)", "PurgeLogTable");
+        $logger->log("Log table entries older than $delay purged (" . $result->rowCount() . " deleted)", "PurgeLogTable");
         $this->release();
     }
 }


### PR DESCRIPTION
PurgeLogTable throws an error :

> In PurgeLogTable.php line 47:
>                                                                                              
>   Attempted to call an undefined method named "rowCount" of class "Doctrine\DBAL\Statement".

The script purges the logs from the database correctly but the error prevents it to log the execution.

Seems like rowCounts() must be called on the result of the query and not the Statement.