### PR TITLE
MT39276: Fix hours display in statistics/absence

### DIFF
--- a/src/Controller/StatisticController.php
+++ b/src/Controller/StatisticController.php
@@ -1546,7 +1546,7 @@ class StatisticController extends BaseController
         foreach ($tab as &$elem) {
             $elem['totalHeures'] = is_numeric($elem['totalHeures']) ? heure4($elem['totalHeures']) : "Erreur";
             foreach ($motifs as $motif) {
-                if ($elem[$motif]) {
+                if (!empty($elem[$motif])) {
                     $elem[$motif]['heures'] = is_numeric($elem[$motif]['heures']) ? heure4($elem[$motif]['heures']) : "Erreur";
                 }
             }

--- a/src/Controller/StatisticController.php
+++ b/src/Controller/StatisticController.php
@@ -1544,8 +1544,9 @@ class StatisticController extends BaseController
         }
 
         foreach ($tab as &$elem) {
+            $elem['totalHeures'] = is_numeric($elem['totalHeures']) ? heure4($elem['totalHeures']) : "Erreur";
             foreach ($motifs as $motif) {
-                if (in_array($motif, $elem)){
+                if ($elem[$motif]) {
                     $elem[$motif]['heures'] = is_numeric($elem[$motif]['heures']) ? heure4($elem[$motif]['heures']) : "Erreur";
                 }
             }


### PR DESCRIPTION
Hours were displayed in numeric format and not as hours and minutes.

The conversion was not made at all for totals and using UTF-8 strings as array keys was confusing the in_array function.