### PR TITLE
MT39277: Include deleted agents in statistics by position

### DIFF
--- a/src/Controller/StatisticController.php
+++ b/src/Controller/StatisticController.php
@@ -3180,6 +3180,7 @@ class StatisticController extends BaseController
 
         // Récupération des infos sur les agents
         $p = new \personnel();
+        $p->supprime = array(0,1,2);
         $p->fetch();
         $agents_infos = $p->elements;
 


### PR DESCRIPTION
Include deleted agents in statistics by position to prevent wrong calculation and attribution to 'ZZZ_Autres' status or service.