### PR TITLE
MT39277: Include deleted agents in statistics by position

### DIFF
--- a/public/statistiques/postes.php
+++ b/public/statistiques/postes.php
@@ -123,6 +123,7 @@ $floors = $entityManager->getRepository(SelectFloor::class);
 
 // Récupération des infos sur les agents
 $p=new personnel();
+$p->supprime = array(0,1,2);
 $p->fetch();
 $agents_infos=$p->elements;
 


### PR DESCRIPTION
Include deleted agents in statistics by position to prevent wrong calculation and attribution to 'ZZZ_Autres' status or service.