### PR TITLE
MT39367: Remove FILTER_SANITIZE_STRING depreciations

### DIFF
--- a/init/init_ajax.php
+++ b/init/init_ajax.php
@@ -14,10 +14,16 @@
  * Init session, and entity manager for ajax scripts
  */
 
+ini_set('display_errors', 0);
+
 if ( session_status() == PHP_SESSION_NONE ) {
 	session_start();
 }
 
 require_once(__DIR__ . '/../vendor/autoload.php');
 require_once(__DIR__ . '/../public/include/config.php');
-require_once(__DIR__ . '/../init/init_entitymanager.php');
+require_once(__DIR__ . '/init_entitymanager.php');
+
+use Symfony\Component\HttpFoundation\Request;
+
+$request = Request::createFromGlobals();

--- a/public/absences/ajax.piecesJustif.php
+++ b/public/absences/ajax.piecesJustif.php
@@ -14,15 +14,16 @@ Description :
 Enregistre les modifications apportées sur les cases à cacher "Pièces justificatives" dans la liste des absences (voir.php)
 Appelé lors du clic sur les cases à cocher, évènement $(".absences-pj input[type=checkbox]").click(), fichier voir.js
 */
-session_start();
 
-require_once "../include/config.php";
-require_once "class.absences.php";
+require_once(__DIR__ . '/../../init/init_ajax.php');
+require_once('class.absences.php');
 
-$id = filter_input(INPUT_GET, 'id', FILTER_SANITIZE_NUMBER_INT);
-$pj = filter_input(INPUT_GET, 'pj', FILTER_SANITIZE_STRING);
-$checked = filter_input(INPUT_GET, 'checked', FILTER_SANITIZE_STRING);
-$CSRFToken = filter_input(INPUT_GET, 'CSRFToken', FILTER_SANITIZE_STRING);
+$id = $request->get('id');
+$pj = $request->get('pj');
+$checked = $request->get('checked');
+$CSRFToken = $request->get('CSRFToken');
+
+$id = filter_var($id, FILTER_SANITIZE_NUMBER_INT);
 
 $a=new absences();
 $a->CSRFToken = $CSRFToken;

--- a/public/conges/ajax.enregistreRecup.php
+++ b/public/conges/ajax.enregistreRecup.php
@@ -15,17 +15,21 @@ Enregistre la demande de récupération
 */
 
 require_once(__DIR__ . '/../../init/init_ajax.php');
-include "class.conges.php";
+include('class.conges.php');
 
 use App\Model\Agent;
 
 // Initialisation des variables
-$commentaires=trim(filter_input(INPUT_POST, "commentaires", FILTER_SANITIZE_STRING));
-$CSRFToken=trim(filter_input(INPUT_POST, "CSRFToken", FILTER_SANITIZE_STRING));
-$date=filter_input(INPUT_POST, "date", FILTER_CALLBACK, array("options"=>"sanitize_dateFr"));
-$date2=filter_input(INPUT_POST, "date2", FILTER_CALLBACK, array("options"=>"sanitize_dateFr"));
-$heures=filter_input(INPUT_POST, "heures", FILTER_SANITIZE_STRING);
-$perso_id=filter_input(INPUT_POST, "perso_id", FILTER_SANITIZE_NUMBER_INT);
+$commentaires = $request->get('commentaires');
+$CSRFToken = $request->get('CSRFToken');
+$heures = $request->get('heures');
+$date = $request->get('date');
+$date2 = $request->get('date2');
+$perso_id = $request->get('perso_id');
+
+$date = filter_var($date, FILTER_CALLBACK, array('options' => 'sanitize_dateFr'));
+$date2 = filter_var($date2, FILTER_CALLBACK, array('options' => 'sanitize_dateFr'));
+$perso_id = filter_var($perso_id, FILTER_SANITIZE_NUMBER_INT);
 
 list($hours, $minutes) = explode(':', $heures);
 $heures = intVal($hours) + intVal($minutes) / 60;

--- a/public/ics/ajax.resetURL.php
+++ b/public/ics/ajax.resetURL.php
@@ -15,13 +15,13 @@ Redéfini un nouveau code ICS pour l'agent sélectionné, ce qui génère une no
 Script appelé en ajax via la fonction resetICSURL() (js/script.js)
 */
 
-session_start();
+require_once(__DIR__ . '/../../init/init_ajax.php');
+require_once(__DIR__ . '/../personnel/class.personnel.php');
 
-require_once "../include/config.php";
-require_once "../personnel/class.personnel.php";
+$id = $request->get('id');
+$CSRFToken = $request->get('CSRFToken');
 
-$id = filter_input(INPUT_POST, 'id', FILTER_SANITIZE_NUMBER_INT);
-$CSRFToken = filter_input(INPUT_POST, 'CSRFToken', FILTER_SANITIZE_STRING);
+$id = filter_var($id, FILTER_SANITIZE_NUMBER_INT);
 
 $db = new db();
 $db->CSRFToken = $CSRFToken;

--- a/public/include/ajax.menus.php
+++ b/public/include/ajax.menus.php
@@ -19,14 +19,12 @@ TODO: Les groupes peuvent être supprimés s'ils sont attachés à des postes su
 TODO: Faire en sorte de conserver les ID dans la base de données et façon à les utiliser comme clé.
 */
 
-ini_set('display_errors', 0);
+require_once(__DIR__ . '/../../init/init_ajax.php');
 
-session_start();
+$CSRFToken = $request->get('CSRFToken');
+$menu = $request->get('menu');
+$option = $request->get('option');
 
-include "config.php";
-$CSRFToken=trim(filter_input(INPUT_POST, "CSRFToken", FILTER_SANITIZE_STRING));
-$menu = FILTER_INPUT(INPUT_POST, 'menu', FILTER_SANITIZE_STRING);
-$option = FILTER_INPUT(INPUT_POST, 'option', FILTER_SANITIZE_STRING);
 $tab = $_POST['tab'];
 
 // New method to use for updating menus

--- a/public/include/db.php
+++ b/public/include/db.php
@@ -109,7 +109,7 @@ class db
                         $result[$key]=filter_var($value, FILTER_UNSAFE_RAW);
                     } else {
                         if ($this->sanitize_string) {
-                            $result[$key] = filter_var($value, FILTER_SANITIZE_STRING);
+                            $result[$key] = htmlspecialchars(strval($value));
                         } else {
                             $result[$key] = filter_var($value, FILTER_UNSAFE_RAW);
                         }   
@@ -617,7 +617,7 @@ class dbh
         for ($i=0;$i<$this->nb;$i++) {
             $result=array();
             foreach ($tmp[$i] as $key => $value) {
-                $result[$key]=filter_var($value, FILTER_SANITIZE_STRING);
+                $result[$key] = htmlspecialchars(strval($value));
             }
             $this->result[]=$result;
         }

--- a/public/include/header.php
+++ b/public/include/header.php
@@ -71,18 +71,23 @@ echo $favicon;
 <body>
 
 <?php
+
 // Affichage des messages d'erreur ou de confirmation venant de la page précedente
-$msg=filter_input(INPUT_GET, "msg", FILTER_SANITIZE_STRING);
-$msgType=filter_input(INPUT_GET, "msgType", FILTER_SANITIZE_STRING);
+
+$msg = $request->get('msg');
+$msgType = $request->get('msgType');
+
 if ($msg) {
     echo "<script type='text/JavaScript'>CJInfo('$msg','$msgType');</script>\n";
 }
 
-$msg2=filter_input(INPUT_GET, "msg2", FILTER_SANITIZE_STRING);
-$msg2Type=filter_input(INPUT_GET, "msg2Type", FILTER_SANITIZE_STRING);
+$msg2 = $request->get('msg2');
+$msg2Type = $request->get('msg2Type');
+
 if ($msg2) {
     echo "<script type='text/JavaScript'>CJInfo('$msg2','$msg2Type',82,15000);</script>\n";
 }
+
 ?>
 
 <div id='opac' style='display:none'></div>

--- a/public/include/sanitize.php
+++ b/public/include/sanitize.php
@@ -21,14 +21,6 @@ if (__FILE__ == $_SERVER['SCRIPT_FILENAME']) {
     exit;
 }
 
-function sanitize_array_string($n)
-{
-    if (is_array($n)) {
-        return array_map("sanitize_array_string", $n);
-    }
-    return filter_var($n, FILTER_SANITIZE_STRING);
-}
-
 function sanitize_array_unsafe($n)
 {
     if (is_array($n)) {
@@ -128,22 +120,6 @@ function sanitize_on01($input)
     // Vérifions si le format est valide
     if ($input) {
         $reponse_filtre = 1;
-    }
-    return $reponse_filtre;
-}
-
-// sanitize_page
-// Contrôle si la page demandée peut être chargée
-function sanitize_page($input)
-{
-    $reponse_filtre = null;
-    $input=filter_var($input, FILTER_SANITIZE_STRING);
-    if ($input) {
-        $db=new db();
-        $db->select2("acces", "page", array("page"=>$input));
-        if ($db->result) {
-            $reponse_filtre = $input;
-        }
     }
     return $reponse_filtre;
 }

--- a/public/ldap/ajax.ldaptest.php
+++ b/public/ldap/ajax.ldaptest.php
@@ -14,19 +14,19 @@ Permet de tester les paramètres LDAP saisis sur la page administration / config
 Script appelé par la fonction JS ldaptest() (admin/js/config?js) lors du click sur le bouton "test" de la page administration / configuration / LDAP
 */
 
-session_start();
+require_once(__DIR__ . '/../../init/init_ajax.php');
+include_once('class.ldap.php');
 
-include_once "../include/config.php";
-include_once "class.ldap.php";
+$filter = $request->get('filter');
+$host = $request->get('host');
+$idAttribute = $request->get('idAttribute');
+$protocol = $request->get('protocol');
+$rdn = $request->get('rdn');
+$suffix = $request->get('suffix');
+$password = $request->get('password');
+$port = $request->get('port');
 
-$filter = filter_input(INPUT_POST, 'filter', FILTER_SANITIZE_STRING);
-$host = filter_input(INPUT_POST, 'host', FILTER_SANITIZE_STRING);
-$idAttribute = filter_input(INPUT_POST, 'idAttribute', FILTER_SANITIZE_STRING);
-$password = filter_input(INPUT_POST, 'password', FILTER_UNSAFE_RAW);
-$port = filter_input(INPUT_POST, 'port', FILTER_SANITIZE_NUMBER_INT);
-$protocol = filter_input(INPUT_POST, 'protocol', FILTER_SANITIZE_STRING);
-$rdn = filter_input(INPUT_POST, 'rdn', FILTER_SANITIZE_STRING);
-$suffix = filter_input(INPUT_POST, 'suffix', FILTER_SANITIZE_STRING);
+$port = filter_var($port, FILTER_SANITIZE_NUMBER_INT);
 
 // Connexion au serveur LDAP
 $url = $protocol.'://'.$host.':'.$port;

--- a/public/ldap/class.ldap.php
+++ b/public/ldap/class.ldap.php
@@ -60,7 +60,7 @@ function authCAS($logger)
         }
     }
 
-    $login=filter_var($login, FILTER_SANITIZE_STRING);
+    $login = htmlspecialchars(strval($login));
 
     // Si authentification CAS et utilisateur existe : retourne son login
     return $login;

--- a/public/personnel/ajax.delete.php
+++ b/public/personnel/ajax.delete.php
@@ -15,13 +15,11 @@ Les agents ne sont pas supprimés définitivement, ils sont marqués comme suppr
 Ce script est appelé par la fonction JS personnel/js/index.js : agent_list
 */
 
-session_start();
+require_once(__DIR__.'/../../init/init_ajax.php');
+require_once('class.personnel.php');
 
-require_once(__DIR__.'/../include/config.php');
-require_once "class.personnel.php";
-
-$list = filter_input(INPUT_POST, 'list', FILTER_SANITIZE_STRING);
-$CSRFToken = filter_input(INPUT_POST, 'CSRFToken', FILTER_SANITIZE_STRING);
+$list = $request->get('list');
+$CSRFToken = $request->get('CSRFToken');
 
 $list = html_entity_decode($list, ENT_QUOTES|ENT_IGNORE, 'UTF-8');
 

--- a/public/personnel/ajax.sendICSURL.php
+++ b/public/personnel/ajax.sendICSURL.php
@@ -18,22 +18,22 @@ Script appelé par $( "#ics-url-form" ).dialog({ Envoyer ]), personnel/js/modif.
 
 ini_set("display_errors", 0);
 
-session_start();
-
 // Includes
-require_once __DIR__.'/../include/config.php';
-require_once __DIR__.'/../include/function.php';
+require_once(__DIR__ . '/../../init/init_ajax.php');
+require_once(__DIR__ . '/../include/function.php');
 
 // data: {recipient: recipient, subject: subject, message: message},
 
-$CSRFToken = filter_input(INPUT_POST, 'CSRFToken', FILTER_SANITIZE_STRING);
-$recipient = filter_input(INPUT_POST, 'recipient', FILTER_SANITIZE_EMAIL);
-$subject = filter_input(INPUT_POST, 'subject', FILTER_SANITIZE_STRING);
-$message = filter_input(INPUT_POST, 'message', FILTER_SANITIZE_STRING);
+$CSRFToken = $request->get('CSRFToken');
+$message = $request->get('message');
+$recipient = $request->get('recipient');
+$subject = $request->get('subject');
 
 $message = trim($message);
 $message = preg_replace("/(http:\/\/.*[^ \n])/", "<a href='$1' target='_blank'>$1</a>", $message);
 $message = str_replace(array("\n","\r"), "<br/>", $message);
+
+$recipient = filter_var($recipient, FILTER_SANITIZE_EMAIL);
 
 // Envoi du mail
 $m = new CJMail();

--- a/public/personnel/ajax.update.php
+++ b/public/personnel/ajax.update.php
@@ -16,7 +16,6 @@ Ce script est appelé par la fonction JS personnel/js/index.js : agent_list
 
 use App\Model\Agent;
 
-require_once(__DIR__.'/../include/config.php');
 require_once(__DIR__ . '/../../init/init_ajax.php');
 
 if (!in_array(21, $_SESSION['droits'])) {
@@ -25,7 +24,7 @@ if (!in_array(21, $_SESSION['droits'])) {
 }
 
 // CSFR Protection
-$CSRFToken = filter_input(INPUT_POST, 'CSRFToken', FILTER_SANITIZE_STRING);
+$CSRFToken = $request->get('CSRFToken');
 if ( !isset($_SESSION['oups']['CSRFToken']) or $CSRFToken != $_SESSION['oups']['CSRFToken']) {
     error_log("CSRF Token Exception {$_SERVER['SCRIPT_NAME']}");
     echo json_encode("CSRF Token Exception {$_SERVER['SCRIPT_NAME']}");
@@ -33,24 +32,24 @@ if ( !isset($_SESSION['oups']['CSRFToken']) or $CSRFToken != $_SESSION['oups']['
 }
 
 // Selected agents
-$list = filter_input(INPUT_POST, 'list', FILTER_SANITIZE_STRING);
+$list = $request->get('list');
 $list = html_entity_decode($list, ENT_QUOTES|ENT_IGNORE, 'UTF-8');
 $list = json_decode($list);
 
 // Main tab
-$actif = filter_input(INPUT_POST, 'actif', FILTER_SANITIZE_STRING);
-$contrat = filter_input(INPUT_POST, 'contrat', FILTER_SANITIZE_STRING);
-$heures_hebdo = filter_input(INPUT_POST, 'heures_hebdo', FILTER_SANITIZE_STRING);
-$heures_travail = filter_input(INPUT_POST, 'heures_travail', FILTER_SANITIZE_STRING);
-$service = filter_input(INPUT_POST, 'service', FILTER_SANITIZE_STRING);
-$statut = filter_input(INPUT_POST, 'statut', FILTER_SANITIZE_STRING);
+$actif = $request->get('actif');
+$contrat = $request->get('contrat');
+$heures_hebdo = $request->get('heures_hebdo');
+$heures_travail = $request->get('heures_travail');
+$service = $request->get('service');
+$statut = $request->get('statut');
 
 $contrat = htmlentities($contrat, ENT_QUOTES|ENT_IGNORE, 'UTF-8', false);
 $service = htmlentities($service, ENT_QUOTES|ENT_IGNORE, 'UTF-8', false);
 $statut = htmlentities($statut, ENT_QUOTES|ENT_IGNORE, 'UTF-8', false);
 
 // Skills tab
-$postes = filter_input(INPUT_POST, 'postes', FILTER_SANITIZE_STRING);
+$postes = $request->get('postes');
 
 if ($postes != '-1') {
         $postes = explode(',', $postes);

--- a/public/personnel/class.personnel.php
+++ b/public/personnel/class.personnel.php
@@ -87,7 +87,7 @@ class personnel
         $filter=array();
 
         // Filtre selon le champ actif (administratif, service public)
-        $actif=htmlentities(strval($actif), ENT_QUOTES|ENT_IGNORE, "UTF-8", false);
+        $actif = htmlentities(strval($actif), ENT_QUOTES|ENT_IGNORE, "UTF-8", false);
         if ($actif) {
             $filter['actif'] = $actif;
         }

--- a/public/planning/poste/ajax.appelDispoMail.php
+++ b/public/planning/poste/ajax.appelDispoMail.php
@@ -18,21 +18,19 @@ Script appelé par $( "#pl-appelDispo-form" ).dialog({ Envoyer ]), planning/post
 
 ini_set("display_errors", 0);
 
-session_start();
-
 // Includes
-require_once "../../include/config.php";
-require_once "../../include/function.php";
+require_once(__DIR__ . '/../../../init/init_ajax.php');
+require_once(__DIR__ . '/../../include/function.php');
 
-$CSRFToken=filter_input(INPUT_POST, "CSRFToken", FILTER_SANITIZE_STRING);
-$site=filter_input(INPUT_POST, "site", FILTER_SANITIZE_STRING);
-$poste=filter_input(INPUT_POST, "poste", FILTER_SANITIZE_STRING);
-$date=filter_input(INPUT_POST, "date", FILTER_SANITIZE_STRING);
-$debut=filter_input(INPUT_POST, "debut", FILTER_SANITIZE_STRING);
-$fin=filter_input(INPUT_POST, "fin", FILTER_SANITIZE_STRING);
-$agents=filter_input(INPUT_POST, "agents", FILTER_SANITIZE_STRING);
-$sujet=filter_input(INPUT_POST, "sujet", FILTER_SANITIZE_STRING);
-$message=filter_input(INPUT_POST, "message", FILTER_SANITIZE_STRING);
+$CSRFToken = $request->get('CSRFToken');
+$site = $request->get('site');
+$poste = $request->get('poste');
+$date = $request->get('date');
+$debut = $request->get('debut');
+$fin = $request->get('fin');
+$agents = $request->get('agents');
+$sujet = $request->get('sujet');
+$message = $request->get('message');
 
 $agents=html_entity_decode($agents, ENT_QUOTES|ENT_IGNORE, "UTF-8");
 $agents=json_decode($agents, true);

--- a/public/planning/poste/ajax.hiddenTables.php
+++ b/public/planning/poste/ajax.hiddenTables.php
@@ -18,15 +18,14 @@ Cette page est appelée par la function JavaScript "afficheTableauxDiv" utilisé
 
 ini_set("display_errors", 0);
 
-session_start();
+require_once(__DIR__ . '/../../../init/init_ajax.php');
 
-// Includes
-require_once "../../include/config.php";
+$perso_id = $_SESSION['login_id'];
+$CSRFToken = $request->get('CSRFToken');
+$hiddenTables = $request->get('hiddenTables');
+$tableId = $request->get('tableId');
 
-$perso_id=$_SESSION['login_id'];
-$CSRFToken=filter_input(INPUT_POST, "CSRFToken", FILTER_SANITIZE_STRING);
-$tableId=filter_input(INPUT_POST, "tableId", FILTER_SANITIZE_NUMBER_INT);
-$hiddenTables=filter_input(INPUT_POST, "hiddenTables", FILTER_SANITIZE_STRING);
+$tableId = filter_var($tableId, FILTER_SANITIZE_NUMBER_INT);
 
 $db=new db();
 $db->CSRFToken = $CSRFToken;

--- a/public/planning/poste/ajax.notes.php
+++ b/public/planning/poste/ajax.notes.php
@@ -14,16 +14,17 @@ Description :
 Enregistre dans la base de donées les notes en bas des plannings
 */
 
-session_start();
-ini_set('display_errors', 0);
-include_once "../../include/config.php";
-include_once "class.planning.php";
+require_once(__DIR__ . '/../../../init/init_ajax.php');
+require_once('class.planning.php');
 
-$CSRFToken=filter_input(INPUT_POST, "CSRFToken", FILTER_SANITIZE_STRING);
-$date=filter_input(INPUT_POST, "date", FILTER_CALLBACK, array("options"=>"sanitize_dateSQL"));
-$site=filter_input(INPUT_POST, "site", FILTER_SANITIZE_NUMBER_INT);
-$text=filter_input(INPUT_POST, "text", FILTER_SANITIZE_STRING);
-$text=urldecode($text);
+$CSRFToken = $request->get('CSRFToken');
+$date = $request->get('date');
+$site = $request->get('site');
+$text = $request->get('text');
+
+$date = filter_var($date, FILTER_CALLBACK, array('options' => 'sanitize_dateSQL'));
+$site = filter_var($site, FILTER_SANITIZE_NUMBER_INT);
+$text = urldecode($text);
 
 // Sécurité : droits d'accès à la page
 $required1 = 300 + $site; // Droits de modifier les plannings du sites N° $site

--- a/public/planning/poste/ajax.notifications.php
+++ b/public/planning/poste/ajax.notifications.php
@@ -17,15 +17,16 @@ Page appelée en ajax lors du click sur les cadenas de la page /index
 (événement $("#icon-lock").click, page planning/poste/js/planning.js)
 */
 
-session_start();
-require_once "../../include/config.php";
-require_once "class.planning.php";
 require_once(__DIR__ . '/../../../init/init_ajax.php');
+require_once('class.planning.php');
 
 // Initialisation des variables
-$CSRFToken = filter_input(INPUT_GET, "CSRFToken", FILTER_SANITIZE_STRING);
-$date=filter_input(INPUT_GET, "date", FILTER_CALLBACK, array("options"=>"sanitize_dateSQL"));
-$site=filter_input(INPUT_GET, "site", FILTER_SANITIZE_NUMBER_INT);
+$CSRFToken = $request->get('CSRFToken');
+$date = $request->get('date');
+$site = $request->get('site');
+
+$date = filter_var($date, FILTER_CALLBACK, array('options' => 'sanitize_dateSQL'));
+$site = filter_var($site, FILTER_SANITIZE_NUMBER_INT);
 
 // Envoi des notification
 if ($config['Planning-Notifications']) {

--- a/public/planning/poste/ajax.updateCell.php
+++ b/public/planning/poste/ajax.updateCell.php
@@ -18,36 +18,42 @@ use App\Model\Position;
 use App\Model\PlanningPositionHistory;
 use App\PlanningBiblio\Helper\PlanningPositionHistoryHelper;
 
-ini_set("display_errors", 0);
-
-session_start();
-
-// Includes
-require_once(__DIR__ . '/../../include/config.php');
 require_once(__DIR__ . '/../../../init/init_ajax.php');
 require_once(__DIR__ . '/../../include/function.php');
 require_once(__DIR__ . '/../../absences/class.absences.php');
 require_once(__DIR__ . '/../../activites/class.activites.php');
-require_once(__DIR__ . '/class.planning.php');
 require_once(__DIR__ . '/../volants/class.volants.php');
+require_once('class.planning.php');
 
 //	Initialisation des variables
-$ajouter=filter_input(INPUT_POST, "ajouter", FILTER_CALLBACK, array("options"=>"sanitize_on"));
-$barrer=filter_input(INPUT_POST, "barrer", FILTER_SANITIZE_NUMBER_INT);
-$CSRFToken=filter_input(INPUT_POST, "CSRFToken", FILTER_SANITIZE_STRING);
-$date=filter_input(INPUT_POST, "date", FILTER_CALLBACK, array("options"=>"sanitize_dateSQL"));
-$debut=filter_input(INPUT_POST, "debut", FILTER_CALLBACK, array("options"=>"sanitize_time"));
-$fin=filter_input(INPUT_POST, "fin", FILTER_CALLBACK, array("options"=>"sanitize_time"));
-$griser=filter_input(INPUT_POST, "griser", FILTER_SANITIZE_NUMBER_INT);
-$perso_id=filter_input(INPUT_POST, "perso_id", FILTER_SANITIZE_STRING);
-$perso_id_origine=filter_input(INPUT_POST, "perso_id_origine", FILTER_SANITIZE_NUMBER_INT);
-$poste=filter_input(INPUT_POST, "poste", FILTER_SANITIZE_NUMBER_INT);
-$site=filter_input(INPUT_POST, "site", FILTER_SANITIZE_NUMBER_INT);
-$tout=filter_input(INPUT_POST, "tout", FILTER_CALLBACK, array("options"=>"sanitize_on"));
-$logaction=filter_input(INPUT_POST, "logaction", FILTER_CALLBACK, array("options"=>"sanitize_on"));
+$ajouter = $request->get('ajouter');
+$barrer = $request->get('barrer');
+$CSRFToken = $request->get('CSRFToken');
+$date = $request->get('date');
+$debut = $request->get('debut');
+$fin = $request->get('fin');
+$griser = $request->get('griser');
+$perso_id = $request->get('perso_id');
+$perso_id_origine = $request->get('perso_id_origine');
+$poste = $request->get('poste');
+$site = $request->get('site');
+$tout = $request->get('tout');
+$logaction = $request->get('logaction');
 
-$login_id=$_SESSION['login_id'];
-$now=date("Y-m-d H:i:s");
+$ajouter = filter_var($ajouter, FILTER_CALLBACK, array('options' => 'sanitize_on'));
+$barrer = filter_var($barrer, FILTER_SANITIZE_NUMBER_INT);
+$date = filter_var($date, FILTER_CALLBACK, array('options' => 'sanitize_dateSQL'));
+$debut = filter_var($debut, FILTER_CALLBACK, array('options' => 'sanitize_time'));
+$fin = filter_var($fin, FILTER_CALLBACK, array('options' => 'sanitize_time'));
+$griser = filter_var($griser, FILTER_SANITIZE_NUMBER_INT);
+$perso_id_origine = filter_var($perso_id_origine, FILTER_SANITIZE_NUMBER_INT);
+$poste = filter_var($poste, FILTER_SANITIZE_NUMBER_INT);
+$site = filter_var($site, FILTER_SANITIZE_NUMBER_INT);
+$tout = filter_var($tout, FILTER_CALLBACK, array('options' => 'sanitize_on'));
+$logaction = filter_var($logaction, FILTER_CALLBACK, array('options' => 'sanitize_on'));
+
+$login_id = $_SESSION['login_id'];
+$now = date("Y-m-d H:i:s");
 
 $barrer = intval($barrer);
 

--- a/public/planning/poste/ajax.validation.php
+++ b/public/planning/poste/ajax.validation.php
@@ -18,16 +18,18 @@ Page appelée en ajax lors du click sur les cadenas de la page /index
 (événements $("#icon-lock").click et $("#icon-unlock").click, page planning/poste/js/planning.js)
 */
 
-session_start();
-require_once "../../include/config.php";
-require_once "class.planning.php";
+require_once(__DIR__ . '/../../../init/init_ajax.php');
+require_once('class.planning.php');
 
 // Initialisation des variables
-$date=filter_input(INPUT_GET, 'date', FILTER_SANITIZE_STRING);
-$CSRFToken = filter_input(INPUT_GET, 'CSRFToken', FILTER_SANITIZE_STRING);
-$site=filter_input(INPUT_GET, 'site', FILTER_SANITIZE_NUMBER_INT);
-$verrou=filter_input(INPUT_GET, 'verrou', FILTER_SANITIZE_NUMBER_INT);
-//
+$CSRFToken = $request->get('CSRFToken');
+$date = $request->get('date');
+$site = $request->get('site');
+$verrou = $request->get('verrou');
+
+$site = filter_var($site, FILTER_SANITIZE_NUMBER_INT);
+$verrou = filter_var($verrou, FILTER_SANITIZE_NUMBER_INT);
+
 $d=new datePl($date);
 $d1=$d->dates[0];
 $perso_id=$_SESSION['login_id'];

--- a/public/setup/createconfig.php
+++ b/public/setup/createconfig.php
@@ -13,7 +13,7 @@ Récupère les informations saisies dans le formulaire de la page setup/index.ph
 nom de la base de données à créer, identifiant de l'utilisateur de la base de données à créer
 */
 
-session_start();
+require_once(__DIR__ . '/../../init/init_ajax.php');
 
 $env_file = __DIR__ . '/../../.env';
 $env_local_file = __DIR__ . '/../../.env.local';
@@ -22,16 +22,18 @@ if (file_exists(__DIR__ . '/../../.env.local')) {
     header('Location: index.php');
 }
 
-$dbhost = filter_input(INPUT_POST, 'dbhost', FILTER_SANITIZE_STRING);
-$dbport = filter_input(INPUT_POST, 'dbport', FILTER_SANITIZE_NUMBER_INT);
-$dbname = filter_input(INPUT_POST, 'dbname', FILTER_SANITIZE_STRING);
-$adminuser = filter_input(INPUT_POST, 'adminuser', FILTER_SANITIZE_STRING);
-$adminpass = filter_input(INPUT_POST, 'adminpass', FILTER_UNSAFE_RAW);
-$dbuser = filter_input(INPUT_POST, 'dbuser', FILTER_SANITIZE_STRING);
-$dbpass = filter_input(INPUT_POST, 'dbpass', FILTER_UNSAFE_RAW);
-$dbprefix = filter_input(INPUT_POST, 'dbprefix', FILTER_SANITIZE_STRING);
-$dropuser = filter_input(INPUT_POST, 'dropuser', FILTER_SANITIZE_STRING);
-$dropdb = filter_input(INPUT_POST, 'dropdb', FILTER_SANITIZE_STRING);
+$dbhost = $request->get('dbhost');
+$dbport = $request->get('dbport');
+$dbname = $request->get('dbname');
+$adminuser = $request->get('adminuser');
+$adminpass = $request->get('adminpass');
+$dbuser = $request->get('dbuser');
+$dbpass = $request->get('dbpass');
+$dbprefix = $request->get('dbprefix');
+$dropuser = $request->get('dropuser');
+$dropdb = $request->get('dropdb');
+
+$dbport = filter_var($dbport, FILTER_SANITIZE_NUMBER_INT);
 
 $app_secret = isset($_SESSION['app_secret']) ? $_SESSION['app_secret'] : bin2hex(random_bytes(16));
 $_SESSION['app_secret'] = $app_secret;

--- a/public/setup/createdb.php
+++ b/public/setup/createdb.php
@@ -16,19 +16,21 @@ Inclus ensuite le fichier setup/createconfig.php si la base a été créée corr
 Ce fichier valide le formulaire de la page setup/index.php
 */
 
-session_start();
+require_once(__DIR__ . '/../../init/init_ajax.php');
 
 //	Variables
-$dbhost=filter_input(INPUT_POST, "dbhost", FILTER_SANITIZE_STRING);
-$dbport = filter_input(INPUT_POST, 'dbport', FILTER_SANITIZE_NUMBER_INT);
-$dbname=filter_input(INPUT_POST, "dbname", FILTER_SANITIZE_STRING);
-$dbAdminUser=filter_input(INPUT_POST, "adminuser", FILTER_SANITIZE_STRING);
-$dbAdminPass=filter_input(INPUT_POST, "adminpass", FILTER_UNSAFE_RAW);
-$dbuser=filter_input(INPUT_POST, "dbuser", FILTER_SANITIZE_STRING);
-$dbpass=filter_input(INPUT_POST, "dbpass", FILTER_UNSAFE_RAW);
-$dbprefix=filter_input(INPUT_POST, "dbprefix", FILTER_SANITIZE_STRING);
-$dropUser=filter_input(INPUT_POST, "dropuser", FILTER_SANITIZE_STRING);
-$dropDB=filter_input(INPUT_POST, "dropdb", FILTER_SANITIZE_STRING);
+$dbhost = $request->get('dbhost');
+$dbport = $request->get('dbport');
+$dbname = $request->get('dbname');
+$dbAdminUser = $request->get('adminuser');
+$dbAdminPass = $request->get('adminpass');
+$dbuser = $request->get('dbuser');
+$dbpass = $request->get('dbpass');
+$dbprefix = $request->get('dbprefix');
+$dropUser = $request->get('dropuser');
+$dropDB = $request->get('dropdb');
+
+$dbport = filter_var($dbport, FILTER_SANITIZE_NUMBER_INT);
 
 $sql=array();
 $erreur=false;

--- a/public/setup/fin.php
+++ b/public/setup/fin.php
@@ -44,12 +44,13 @@ if (!file_exists(__DIR__ . '/../../.env.local')) {
 
 include "../include/config.php";
 
-$CSRFToken = filter_input(INPUT_POST, "CSRFToken", FILTER_SANITIZE_STRING);
-$nom=filter_input(INPUT_POST, "nom", FILTER_SANITIZE_STRING);
-$prenom=filter_input(INPUT_POST, "prenom", FILTER_SANITIZE_STRING);
-$password=filter_input(INPUT_POST, "password", FILTER_UNSAFE_RAW);
-$password2=filter_input(INPUT_POST, "password2", FILTER_UNSAFE_RAW);
-$email=filter_input(INPUT_POST, "email", FILTER_UNSAFE_RAW);
+$CSRFToken = $request->get('CSRFToken');
+$nom = $request->get('nom');
+$prenom = $request->get('prenom');
+$password = $request->get('password');
+$password2 = $request->get('password2');
+$email = $request->get('email');
+
 $erreur=false;
 
 if (strlen($password)<6) {

--- a/public/statistiques/export.php
+++ b/public/statistiques/export.php
@@ -17,19 +17,18 @@ les place dans les tableaux $cellules et $lignes, puis les écrit dans un fichie
 Page appelée par la fonction JavaScript "export_stat" lors du clique sur les liens "exporter" des pages de statistiques
 */
 
-session_start();
-require_once "../include/config.php";
-require_once "../include/sanitize.php";
-require_once "../include/function.php";
-require_once "class.statistiques.php";
+require_once(__DIR__ . '/../../init/init_ajax.php');
+require_once(__DIR__ . '/../include/sanitize.php');
+require_once(__DIR__ . '/../include/function.php');
+require_once('class.statistiques.php');
 
 
 // Initialisation des variables
-$nom=filter_input(INPUT_GET, "nom", FILTER_SANITIZE_STRING);
-$type=filter_input(INPUT_GET, "type", FILTER_SANITIZE_STRING);
+$nom = $request->get('nom');
+$type = $request->get('type');
 
-$nom=filter_var($nom, FILTER_SANITIZE_URL);
-$type=filter_var($type, FILTER_CALLBACK, array("options"=>"sanitize_file_extension"));
+$nom = filter_var($nom, FILTER_SANITIZE_URL);
+$type = filter_var($type, FILTER_CALLBACK, array('options' => 'sanitize_file_extension'));
 
  // Compter les jours ouvrables (ou ouvrés) entre début et fin
 $debut = isset($_SESSION['stat_debut']) ? $_SESSION['stat_debut'] : null;

--- a/src/Controller/FrameworkController.php
+++ b/src/Controller/FrameworkController.php
@@ -430,8 +430,8 @@ class FrameworkController extends BaseController
 
         $post=array();
         foreach ($_POST as $key => $value) {
-            $key = filter_var($key, FILTER_SANITIZE_STRING);
-            $post[$key] = filter_var($value, FILTER_SANITIZE_STRING);
+            $key = htmlspecialchars(strval($key));
+            $post[$key] = htmlspecialchars(strval($value));
         }
 
         // Suppression des infos concernant ce tableau dans la table pl_poste_lignes

--- a/src/Controller/IndexController.php
+++ b/src/Controller/IndexController.php
@@ -43,12 +43,12 @@ class IndexController extends BaseController
     {
         // Initialisation des variables
         $CSRFToken = $request->get('CSRFToken');
-        $this->CSRFToken = $CSRFToken;
         $groupe = $request->get('groupe');
         $site = $request->get('site');
         $tableau = $request->get('tableau');
         $date = $request->get('date');
 
+        $this->CSRFToken = $CSRFToken;
         $this->dbprefix = $GLOBALS['dbprefix'];
 
         // Contrôle sanitize en 2 temps pour éviter les erreurs CheckMarx


### PR DESCRIPTION
Remove some depreciations on PHP 8.1

test with PHP 8.1, APP_ENV=dev and APP_DEBUG=1.
Look for errors on var/log/dev.log : 
Focus on deprecated errors : `tail -n 30 -f var/log/dev.log | grep -i deprecated`
browse multiple pages
Compare this PR with master