### PR TITLE
MT38897: ignore tables for which no correction is needed in fix_encod…

### DIFF
--- a/tools/fix_encoding_issues.php
+++ b/tools/fix_encoding_issues.php
@@ -467,6 +467,10 @@ foreach ($tables as $table) {
     $name = $table['name'];
     $fields = $table['fields'];
 
+    if (empty($fields)) {
+        continue;
+    }
+
     $sql[] = "ALTER TABLE `{$dbprefix}{$name}` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci";
 
     $fields_query = '`id`, `' . implode('`, `', $table['fields']) . '`';


### PR DESCRIPTION
…ing_issues.php

PR pour master, 22.10.xx et 22.04.xx
(Attention, cette PR est basée sur 22.10.xx).

Avec PHP 8.1 et mariaDB 10.6,
lorsqu'on utilise des données qui date de la version 19.10 ou inférieure
et qu'on exécute php tools/fix_encoding_issues.php
le script échoue avec une erreur fatal.

Cette correction permet d'ignorer les tables sur lesquelles il n'y a aucune correction à apporter. Ce qui évite la création des requêtes mal-formée et corrige le bug.