### PR TITLE
MT39412: the datefull twig filter now interpret html tags

### DIFF
--- a/src/Twig/AppExtension.php
+++ b/src/Twig/AppExtension.php
@@ -20,7 +20,7 @@ class AppExtension extends AbstractExtension
    public function getFilters()
     {
         return [
-            new TwigFilter('datefull', [$this, 'dateFull']),
+            new TwigFilter('datefull', [$this, 'dateFull'], ['is_safe' => ['html']]),
             new TwigFilter('datefr', [$this, 'dateFr']),
             new TwigFilter('hours', [$this, 'hours']),
             new TwigFilter('hour_from_his', [$this, 'hourFromHis']),


### PR DESCRIPTION
See MT https://suivi.biblibre.com/view.php?id=39412#c227255

TEST PLAN : 
* create a planning for february, 1st
* display the week view
* - Without this PR, the date is displayed with html tags (sup)
* - With this PR, the date is well displayed (you may need to clear the server cache with `php bin/console cache:clear`)

With this PR, also check the folowings : 
* date displayed on planning day view for february, 1st
* date displayed on top of the dropdown menu "Choisissez un tableau" for february, 1st
* dates displayed in overtime form.