### PR TITLE
MT39034: Add throttle to holiday edits

### DIFF
--- a/src/Controller/HolidayController.php
+++ b/src/Controller/HolidayController.php
@@ -3,17 +3,19 @@
 namespace App\Controller;
 
 use App\Controller\BaseController;
-use App\Model\Agent;
-use App\PlanningBiblio\Helper\HolidayHelper;
-use App\PlanningBiblio\Helper\WeekPlanningHelper;
-use App\Model\AbsenceReason;
 
+use App\Model\AbsenceReason;
+use App\Model\Agent;
+use App\Model\Holiday;
+
+use App\PlanningBiblio\Helper\HolidayHelper;
 use App\PlanningBiblio\Helper\HourHelper;
+use App\PlanningBiblio\Helper\WeekPlanningHelper;
 
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\HttpFoundation\Response;
 
 require_once(__DIR__ . '/../../public/conges/class.conges.php');
 require_once(__DIR__ . '/../../public/personnel/class.personnel.php');
@@ -306,16 +308,29 @@ class HolidayController extends BaseController
         $balance = $c->calculCreditRecup($perso_id);
 
         if ( $confirm ) {
-            $result = $this->update($request);
-            $msg = $result['msg'];
-            $msg2 = $result['msg2'];
-            $msg2Type = $result['msg2Type'];
-            $recover = 0;
 
+            if ($this->isAlreadyModified($id)) {
+                $msg = "Le congé n'a pas pu être modifié";
+                $msg2 = "Veuillez attendre quelques secondes avant de réessayer";
+                $msg2Type = "error";
+
+                $result['back_to'] = 'holiday';
+                if ($this->config('Conges-Recuperations') and $data['debit'] == 'recuperation') {
+                    $msg = "La récupération n'a pas pu être modifiée";
+                    $result['back_to'] = 'recover';
+                }
+
+            } else {
+                $result = $this->update($request);
+                $msg = $result['msg'];
+                $msg2 = $result['msg2'];
+                $msg2Type = $result['msg2Type'];
+            }
+
+            $recover = 0;
             if ($result['back_to'] == 'recover') {
                 $recover = 1;
             }
-
 
             if (!empty($msg)) {
                 $session->getFlashBag()->add('notice', $msg);
@@ -1099,7 +1114,7 @@ class HolidayController extends BaseController
 
         // If halfday is checked, starting and
         // ending hours depends on agent's working hours
-        if ($post['halfday']) {
+        if (isset($post['halfday']) && $post['halfday']) {
             $holidayHelper = new HolidayHelper(array(
                 'agent' => $perso_id,
                 'start' => $debutSQL,
@@ -1229,5 +1244,24 @@ class HolidayController extends BaseController
         $message.="<p>Lien vers la demande de " . ($recover ? "récupération" : "congé") . " :<br/><a href='$url'>$url</a></p>";
 
         return $message;
+    }
+
+    private function isAlreadyModified($id) {
+
+        $holiday = $this->entityManager->getRepository(Holiday::class)->find($id);
+
+        if (!$holiday) {
+            return false;
+        }
+
+        $throttle = $this->config('post_requests_throttle') ?? 1;
+        $last_modified = $holiday->modification();
+        $now = new \DateTime('now');
+        $difference = $now->getTimestamp() - $last_modified->getTimestamp();
+
+        if ($difference <= $throttle) {
+            return true;
+        }
+        return false;
     }
 }

--- a/src/Controller/HolidayController.php
+++ b/src/Controller/HolidayController.php
@@ -309,14 +309,18 @@ class HolidayController extends BaseController
 
         if ( $confirm ) {
 
+            $msgType = 'notice';
+
             if ($this->isAlreadyModified($id)) {
                 $msg = "Le congé n'a pas pu être modifié";
-                $msg2 = "Veuillez attendre quelques secondes avant de réessayer";
-                $msg2Type = "error";
+                $msg .= "#BR#Veuillez attendre quelques secondes avant de réessayer";
+                $msgType = "error";
 
                 $result['back_to'] = 'holiday';
                 if ($this->config('Conges-Recuperations') and $data['debit'] == 'recuperation') {
                     $msg = "La récupération n'a pas pu être modifiée";
+                    $msg .= "#BR#Veuillez attendre quelques secondes avant de réessayer";
+                    $msgType = "error";
                     $result['back_to'] = 'recover';
                 }
 
@@ -333,7 +337,7 @@ class HolidayController extends BaseController
             }
 
             if (!empty($msg)) {
-                $session->getFlashBag()->add('notice', $msg);
+                $session->getFlashBag()->add($msgType, $msg);
             }
 
             if (!empty($msg2)) {

--- a/src/Controller/HolidayController.php
+++ b/src/Controller/HolidayController.php
@@ -1260,6 +1260,11 @@ class HolidayController extends BaseController
 
         $throttle = $this->config('post_requests_throttle') ?? 1;
         $last_modified = $holiday->modification();
+
+        if (!$last_modified) {
+            return false;
+        }
+
         $now = new \DateTime('now');
         $difference = $now->getTimestamp() - $last_modified->getTimestamp();
 


### PR DESCRIPTION
In some cases (network hiccups for example), the POST request for editing an holiday can be sent twice, removing twice the number of holidays for the agent.

This patch adds a minimum delay between two edits of a given holiday of 1 second by default.

This value can be overridden with the following setting in custom_options.php:

$config['post_requests_throttle'] = n;

Test plan:

1) Set post_requests_throttle to a large enough value in custom_options.php
   (20 seconds should be enough)

2) Edit an holiday, check that the modification is made.

3) Within the 20 seconds, edit this holiday again, check that the modification
   is denied, with a message telling you to wait a few seconds before trying
   again.

4) After the 20 seconds are expired, edit this holiday again, and check that
   the modification is made.