### PR TITLE
Settle migrations using Doctrine

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -110,7 +110,8 @@
     "scripts": {
         "auto-scripts": {
             "cache:clear": "symfony-cmd",
-            "assets:install %PUBLIC_DIR%": "symfony-cmd"
+            "assets:install %PUBLIC_DIR%": "symfony-cmd",
+            "doctrine:migrations:migrate": "symfony-cmd"
         },
         "post-install-cmd": [
             "@auto-scripts"

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -2,7 +2,7 @@ doctrine:
     dbal:
         # configure these for your database server
         driver: 'pdo_mysql'
-        server_version: '5.7'
+        server_version: 'mariadb-10.4.15'
         charset: utf8mb4
         default_table_options:
             charset: utf8mb4

--- a/config/packages/doctrine_migrations.yaml
+++ b/config/packages/doctrine_migrations.yaml
@@ -3,3 +3,28 @@ doctrine_migrations:
     # namespace is arbitrary but should be different from App\Migrations
     # as migrations classes should NOT be autoloaded
     #namespace: DoctrineMigrations
+    migrations_paths:
+        'App\Migrations': '%kernel.project_dir%/src/Migrations'
+
+    connection: default
+
+    storage:
+        # Default (SQL table) metadata storage configuration
+        table_storage:
+            table_name: 'doctrine_migration_versions'
+            version_column_name: 'version'
+            version_column_length: 192
+            executed_at_column_name: 'executed_at'
+            execution_time_column_name: 'execution_time'
+
+    # Possible values: "BY_YEAR", "BY_YEAR_AND_MONTH", false
+    organize_migrations: false
+
+    # Path to your custom migrations template
+    custom_template: ~
+
+    # Run all migrations in a transaction.
+    all_or_nothing: false
+
+    # Adds an extra check in the generated migrations to ensure that is executed on the same database type.
+    check_database_platform: true

--- a/config/permissions.yaml
+++ b/config/permissions.yaml
@@ -183,6 +183,8 @@
     - 100
 "legalnotices":
     - 100
+"maintenance":
+    - 100
 "notification.index":
     - 21
 "notification.save":

--- a/init/init.php
+++ b/init/init.php
@@ -37,11 +37,19 @@ require_once(__DIR__.'/init_entitymanager.php');
 require_once(__DIR__.'/init_plugins.php');
 
 // Vérification de la version de la base de données
-// Si la version est différente, mise à jour de la base de données
-if ($version!=$config['Version'] && $version != 'ajax') {
-    require_once(__DIR__.'/../public/setup/maj.php');
-}
+// Si une migration n'a pas été effectuée, on est redirigé sur la page de maintenance
+// FIXME Ceci doit être géré par un Listener
+// FIXME Ceci génère une boucle de redirection lorsque la session n'est pas ouverte
+$path = Request::createFromGlobals()->getPathInfo();
+use App\PlanningBiblio\Migration;
 
+if ($path != '/maintenance'){
+    $migration = new Migration;
+    if($migration->check() != 0){
+        header("Location: /maintenance");
+        exit();
+    }
+}
 // Initialisation des variables
 $request = Request::createFromGlobals();
 

--- a/migration_doctrine.md
+++ b/migration_doctrine.md
@@ -1,0 +1,139 @@
+# La migration avec Doctrine
+
+## Préparation de la migration
+
+### Installation de doctrine-migrations
+
+La mise en place de la migration avec Doctrine requiert donc la bibliothèque doctrine-migrations. 
+
+> Quid d'orm-pack ?
+
+Ce pack Symfony permet l'installation de Doctrine sur les projets Symfony à partir de la version 4. Il a lui-même besoin, à son installation, de plusieurs bibliothèques dont  doctrine-migrations.
+**L'installation d'orm-pack permet l'installation de doctrine-migrations : orm-pack est déjà installé et requiert doctrine-migrations, donc doctrine-migrations est déjà disponible.**
+Sinon, il faudra lancer cette commande depuis le terminal à la racine du projet : ` composer require doctrine/doctrine-migrations-bundle `
+
+### Configuration
+
+Doctrine a besoin de se connecter à la base de données : cela lui permettra d'ajouter dans un tableau les migrations déjà effectuées.
+Sur le projet PLB, la connexion est déjà établie. On évitera les erreurs de métadonnées en modifiant, dans le fichier **config/packages/doctrine.yaml**, la valeur de server_version :
+
+```yaml
+doctrine:
+    dbal:
+        #configure these for your database server
+        driver: 'pdo_mysql'
+        server_version: 'maria-db-10.4.15'
+```
+
+Pour terminer la configuration, il suffira de modifier le fichier **doctrine_migrations.yaml** situé dans le répertoire config/packages :
+
+``` yaml
+doctrine_migrations:
+    #dir_name: '%kernel.project_dir%/src/Migrations'
+    # namespace is arbitrary but should be different from App\Migrations
+    # as migrations classes should NOT be autoloaded
+    #namespace: DoctrineMigrations
+    migrations_paths:
+        'App\Migrations': '%kernel.project_dir%/src/Migrations'
+
+    connection: default
+
+    storage:
+        # Default (SQL table) metadata storage configuration
+        table_storage:
+            table_name: 'doctrine_migration_versions'
+            version_column_name: 'version'
+            version_column_length: 1024
+            executed_at_column_name: 'executed_at'
+            execution_time_column_name: 'execution_time'
+
+    # Possible values: "BY_YEAR", "BY_YEAR_AND_MONTH", false
+    organize_migrations: false
+
+    # Path to your custom migrations template
+    custom_template: ~
+
+    # Run all migrations in a transaction.
+    all_or_nothing: true
+
+    # Adds an extra check in the generated migrations to ensure that is executed on the same database type.
+    check_database_platform: true
+```
+* *table_storage* est utilisé par doctrine-migrations pour suivre les migrations qui sont actuellement exécutées.
+* *all_or_nothing* est un paramètre permettant d'exécuter ou pas plusieurs migrations en une seule fois.
+* *check_database_platform* est un paramètre déterminant la vérification ou pas de la plateforme d'abstraction de la base de données (plus d'informations [ici](https://www.doctrine-project.org/projects/doctrine-dbal/en/2.4/reference/platforms.html) ) au début du code généré.
+
+## Création d'une migration
+
+Toute migration devra être définie dans un fichier placé dans le répertoire **src/Migrations**.
+
+Il est possible de générer un squelette de fichier de migration avec la commande `php bin/console doctrine:migrations:generate`.
+
+* Si bin/console n'est pas accessible depuis le terminal, il faudra écrire la commande suivante : `./vendor/bin/doctrine-migrations generate` 
+* Les migrations sont nommées automatiquement à la date et l'heure de la création du fichier, ce qui évite d'avoir des conflits de fichiers sur master. Il est toutefois possible de changer le nom de version.  Au même titre pour un controller, il faut que le nom du fichier soit cohérent avec le nom de la classe.
+
+Voici une migration générée par doctrine-migrations :
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20201116153145 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+
+    }
+}
+
+```
+
+* `declare(strict_types=1);` est une directive servant à éviter bon nombre de bugs, notamment en testant le type de la variable.
+* On observe trois méthodes, qui sont le minimum requis pour une migration :
+  * `getDescription()` : on peut forcer l'affichage de la description en changeant le retour de la fonction. La description s'affiche avec la commande `php bin/console doctrine:migrations:list` ou `./vendor/bin/doctrine-migrations :list`.
+  * `up()` et `down()`, qui sont appelées respectivement par la commande  `./vendor/bin/doctrine-migrations execute 'nomdelaversion' --up ` et `./vendor/bin/doctrine-migrations execute 'nomdelaversion' --down` . 
+    * `up()` détecte la migration qui n'a pas exécutée et d'opérer les changements écrits dans la fonction en base de donnée.
+    * `down()` détecte la migration précédemment exécutée pour défaire les modifications écrites dans la méthode up.
+    * Les méthodes à appeler dans ces deux fonctions sont :
+      * `addSql`: permet de passer une requête SQL et de l'exécuter dans le DBAL. Dans la requête, il sera possible de passer un tableau de paramètres pour réaliser des insertions simultanées dans la table, par exemple.
+      * `abortIf` : interrompt la migration à une condition donnée.
+      * `skipIf` : passe la migration à une condition donnée.
+      * `throwIrreversibleMigrationException` : *dans la méthode down() seulement*, renvoie une exception pour signaler qu'on ne peut pas revenir à la version précédant la migration.
+      * `warnIf` : envoie un message à une condition donnée.
+      * `write` : écrit une information dans la console (utile pour le débogage).
+
+Il est possible d'affiner le comportement de la migration en implémentant des méthodes appelées avant ou après up/down : `preUp`, `preDown`, `preDown`, `postDown`.
+
+## Manipulation des migrations
+
+Une fois la migration préparée, il existe différentes interactions avec doctrine-migrations, que l'on peut afficher avec la commande ` ./vendor/bin/doctrine-migrations list`  (attention, à ne pas confondre avec :list, qui va afficher la liste des migrations).
+
+Certaines sont à relever :
+
+* `./vendor/bin/doctrine-migrations status`, qui affiche le statut des migrations
+* `./vendor/bin/doctrine-migrations execute`, qui exécute une ou plusieurs migrations (il faudra donner le nom de chaque migration). Avec l'option --up ou --down, on peut réaliser une migration ou la défaire. Le tout est fait manuellement
+* `./vendor/bin/doctrine-migrations migrate 'nom_de_la_migration'`, qui effectue la migration de notre choix. **Si l'on ne met pas de nom, doctrine-migrations effectuera toutes les migrations détectées comme non-exécutées jusqu'à la dernière version disponible.**
+* `./vendor/bin/doctrine-migrations up-to-date`, qui affiche si l'on est ou pas à jour.
+  * <u>**Attention :**</u> si une mise à jour est réalisée manuellement, directement dans la base de données, elle n'est pas détectée et le schéma sera considéré comme "pas mis à jour". Il faudra peut-être ajouter la version dont on a reproduit le comporement de la méthode `up`, avec la commande `./vendor/bin/doctrine-migrations version --add 'nom de la version'` 
+

--- a/public/init.php
+++ b/public/init.php
@@ -50,9 +50,19 @@ require_once(__DIR__.'/init_entitymanager.php');
 require_once(__DIR__.'/init_plugins.php');
 
 // Vérification de la version de la base de données
-// Si la version est différente, mise à jour de la base de données
-if ($version!=$config['Version']) {
-    require_once(__DIR__.'/setup/maj.php');
+// Si une migration n'a pas été effectuée, on est redirigé sur la page de maintenance
+// FIXME Ceci doit être géré par un Listener
+// FIXME Ceci génère une boucle de redirection lorsque la session n'est pas ouverte
+
+use App\PlanningBiblio\Migration;
+
+$migration = new App\PlanningBiblio\Migration;
+
+if($_SERVER['SCRIPT_NAME']!='/authentification.php'){
+     if($migration->check() != 0){
+         header("Location: /maintenance");
+         exit();
+    }
 }
 
 // Initialisation des variables

--- a/public/setup/atomicupdate/create_table_doctrine_migration_versions.php
+++ b/public/setup/atomicupdate/create_table_doctrine_migration_versions.php
@@ -1,0 +1,9 @@
+<?php
+
+$sql[] = "CREATE TABLE IF NOT EXISTS `{$dbprefix}doctrine_migration_versions` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `version` TEXT COLLATE utf8mb4_unicode_ci NOT NULL,
+  `executed_at` TIMESTAMP NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `execution_time` TIMESTAMP NOT NULL DEFAULT '0000-00-00 00:00:00', 
+  PRIMARY KEY (`id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;";

--- a/public/setup/atomicupdate/create_table_doctrine_migration_versions.sql
+++ b/public/setup/atomicupdate/create_table_doctrine_migration_versions.sql
@@ -1,0 +1,8 @@
+
+CREATE TABLE IF NOT EXISTS `doctrine_migration_versions` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `version` TEXT COLLATE utf8mb4_unicode_ci NOT NULL,
+  `executed_at` TIMESTAMP NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `execution_time` TIMESTAMP NOT NULL DEFAULT '0000-00-00 00:00:00', 
+  PRIMARY KEY (`id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/public/setup/atomicupdate/path_to_maintenance.php
+++ b/public/setup/atomicupdate/path_to_maintenance.php
@@ -1,0 +1,3 @@
+<?php
+
+$sql[]="INSERT INTO `{$dbprefix}acces` (`nom`,`groupe_id`,`page`) VALUES ('Maintenance','','/maintenance');";

--- a/public/setup/db_data.php
+++ b/public/setup/db_data.php
@@ -50,6 +50,7 @@ $sql[]="INSERT INTO `{$dbprefix}acces` (`nom`,`groupe_id`,`page`) VALUES ('Cong�
 $sql[]="INSERT INTO `{$dbprefix}acces` (`nom`,`groupe_id`,`groupe`,`page`,`categorie`,`ordre`) VALUES ('Planning Poste', 301, 'Création / modification des plannings, utilisation et gestion des modèles', '', 'Planning', 110);";
 $sql[]="INSERT INTO `{$dbprefix}acces` (`nom`,`groupe`,`groupe_id`,`categorie`,`ordre`) VALUES ('Gestion des congés, validation niveau 2','Gestion des congés, validation niveau 2',601,'Congés','76');";
 $sql[]="INSERT INTO `{$dbprefix}acces` (`nom`,`groupe_id`,`groupe`,`categorie`,`ordre`) VALUES ('Gestion des congés, validation niveau 1','401','Gestion des congés, validation niveau 1','Congés','75');";
+$sql[]="INSERT INTO `{$dbprefix}acces` (`nom`,`groupe_id`,`page`) VALUES ('Maintenance','/maintenance');";
 
 //	Insertion des activités
 $sql[]="INSERT INTO `{$dbprefix}activites` (`id`, `nom`) VALUES ('1', 'Assistance audiovisuel');";

--- a/public/setup/db_structure.php
+++ b/public/setup/db_structure.php
@@ -119,6 +119,14 @@ $sql[]="CREATE TABLE `{$dbprefix}config` (
   UNIQUE KEY `nom` (`nom`)
 ) ENGINE=MyISAM  DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci;";
 
+$sql[] = "CREATE TABLE IF NOT EXISTS `{$dbprefix}doctrine_migration_versions` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `version` TEXT COLLATE utf8mb4_unicode_ci NOT NULL,
+  `executed_at` TIMESTAMP NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `execution_time` TIMESTAMP NOT NULL DEFAULT '0000-00-00 00:00:00', 
+  PRIMARY KEY (`id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;";
+
 $sql[]="CREATE TABLE `{$dbprefix}heures_absences` (
   `id` INT(11) NOT NULL AUTO_INCREMENT, 
   `semaine` DATE,

--- a/src/Controller/MaintenanceController.php
+++ b/src/Controller/MaintenanceController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Controller;
+
+use App\Controller\BaseController;
+use App\PlanningBiblio\Migration;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+
+class MaintenanceController extends BaseController
+{
+
+    /**
+     * @Route("/maintenance", name="maintenance", methods={"GET"})
+     */
+    public function maintenance(Request $request)
+    {
+        $migration = new Migration;
+        $check = $migration->check();
+        $display_add = array();
+        $display_delete = array();
+
+        if ($check > 0){
+            $display_add = $migration->toUp();
+        }
+
+        if ($check < 0){
+            $display_delete = $migration->toDown();
+        }
+
+        $this->templateParams(
+            array(
+                "toAdd"      =>   $display_add,
+                "toDelete"   =>   $display_delete
+            )
+        );
+        return $this->output('maintenance.html.twig');
+    }
+}

--- a/src/Migrations/Version20201113152728.php
+++ b/src/Migrations/Version20201113152728.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+
+final class Version20201113152728 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return 'This is a test';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        $this->addSql('CREATE TABLE example_table (id INT AUTO_INCREMENT NOT NULL, title VARCHAR(255) DEFAULT NULL, PRIMARY KEY(id))');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        $this->addSql('DROP TABLE example_table');
+    }
+}

--- a/src/PlanningBiblio/Migration.php
+++ b/src/PlanningBiblio/Migration.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace App\PlanningBiblio;
+
+include_once(__DIR__.'/../../public/include/db.php');
+
+class Migration
+{
+    //check vérifie s'il y a une différence entre les versions disponibles et les versions existant dans la base de données
+    //si count est différent de 0, on renverra vers la page de maintenance
+    public function check(){
+        $data = new \db();
+        $data->select2("doctrine_migration_versions", "version");
+        $migrated_versions = array();
+        $toAdd = 0;
+        $toDelete = 0;
+        $count = null;
+
+        $migrations_available = glob('../src/Migrations/*.php');
+
+        if(!empty($migrations_available)){
+            foreach ($migrations_available as &$m){
+                $m = "App\Migrations\\".substr($m,18,21);
+            }
+        }
+
+        if($data->result){
+            foreach ($data->result as $elem){
+                $migrated_versions[] = $elem['version'];
+            }
+        }
+
+        if(empty($migrated_versions) and !empty($migrations_available)){
+            $toAdd+=count($migrations_available);
+        } elseif (!empty($migrated_versions) and !empty($migrations_available)){
+                foreach($migrated_versions as $mv){
+                    if(!in_array($mv, $migrations_available)){
+                        $toDelete++;
+                    }
+                }
+                foreach($migrations_available as $ma){
+                    if(!in_array($ma, $migrated_versions)){
+                        $toAdd++;
+                    }
+                }
+            }
+        if ($toAdd == 0 and $toDelete == 0){
+            $count = 0;
+        } else {
+            if ($toAdd == 0 or $toDelete > $toAdd){
+                $count -= $toDelete;
+            } else{
+                $count += $toAdd;
+            }
+        }
+        return $count;
+    }
+
+    //toUp renvoie la liste des migrations à exécuter
+    public function toUp(){
+        $data = new \db();
+        $data->select2("doctrine_migration_versions", "version");
+        $migrated_versions = array();
+        $toDisplay = array();
+
+        $migrations_available = glob('../src/Migrations/*.php');
+
+        foreach ($migrations_available as &$m){
+            $m = "App\Migrations\\".substr($m,18,21);
+        }
+
+        if($data->result){
+            foreach ($data->result as $elem){
+                $migrated_versions[] = $elem['version'];
+            }
+        }
+
+        if(empty($migrated_versions) and !empty($migrations_available)){
+            foreach($migrations_available as $ma){
+                $toDisplay[]['version'] = $ma;
+            }
+        } elseif (!empty($migrated_versions) and !empty($migrations_available)){
+            foreach($migrations_available as $ma){
+                if(!in_array($ma, $migrated_versions)){
+                    $toDisplay[]['version'] = $ma;
+                }
+            }
+        }
+
+        return $toDisplay;
+    }
+
+    //toDown() renvoie la liste des migrations à retirer
+    public function toDown(){
+        $data = new \db();
+        $data->select2("doctrine_migration_versions", "version");
+        $migrated_versions = array();
+        $toDisplay = array();
+
+        $migrations_available = glob('../src/Migrations/*.php');
+
+        if(!empty($migrations_available)){
+            foreach ($migrations_available as &$m){
+                $m = "App\Migrations\\".substr($m,18,21);
+            }
+        }
+
+        foreach ($data->result as $elem){
+            $migrated_versions[] = $elem['version'];
+        }
+
+        if(!empty($migrated_versions) and !empty($migrations_available)){
+            foreach($migrated_versions as $mv){
+                if(!in_array($mv, $migrations_available)){
+                    $toDisplay[]['version'] = $mv;
+                }
+            }
+        } elseif (!empty($migrated_versions) and empty($migrations_available)){
+            foreach($migrated_versions as $mv){
+                $toDisplay[]['version'] = $mv;
+            }
+        }
+        return $toDisplay;
+    }
+
+}

--- a/templates/maintenance.html.twig
+++ b/templates/maintenance.html.twig
@@ -1,0 +1,36 @@
+{# maintenance.html.twig #}
+
+{% extends 'base.html.twig' %}
+
+{% block page %}
+    <div id='acces_refuse' style='font-weight:normal;'>
+      {% if toAdd is empty and toDelete is empty  %}
+        <h1>Votre version de PlanningBiblio est à jour !</h1>
+        <a href="{{ asset('/index.php') }}"> Retour </a>
+      {% else %}
+        <h1>Veuillez mettre à jour votre base de données pour utiliser PlanningBiblio</h1>
+        <br/>
+        {% if not toDelete is empty %}
+          <h3 style='text-align:left;'>Voici la liste des migrations incompatibles avec votre version de PlanningBiblio : </h3>
+          <ul style='text-align:left;'>
+            {% for version in toDelete %}
+              <li> <b>{{ version.version }}</b></li>
+            {% endfor %}
+          </ul>
+          <p style='text-align:left;'> Veuillez revenir à la version précédente, puis exécutez dans votre terminal la commande suivante avant de passer à cette version : <br/> <br/>
+            <i>php bin/console doctrine:migrations:execute {% for a in toDelete %} '{{ a.version }}' {% endfor %} --down</i>
+            <br/><br/>Pensez à copier cette ligne dans votre presse-papiers avant de quitter cette version de PlanningBiblio.
+          </p>
+        {% endif %}
+        {% if not toAdd is empty %}
+          <h3 style='text-align:left;'>Voici la liste des migrations disponibles à l'ajout :</h3>
+          <ul style='text-align:left;'>
+            {% for version in toAdd %}
+              <li> <b>{{ version.version }}</b> </li>
+            {% endfor %}
+          </ul>
+          <p style='text-align:left;'> Pour les intégrer, veuillez exécuter la commande suivante dans votre terminal :<i> php bin/console doctrine:migrations:migrate </i></p>
+        {% endif %}
+      {% endif %}
+    </div>
+{% endblock %}


### PR DESCRIPTION
squash, rebase et nettoyage de la branche de Sarah (#270) pour la mise en place de Doctrine

j'ai également apporté quelques petites corrections et ajouté l'exécution automatique des migrations avec `composer install` et `composer update`

il reste des erreurs à corriger. Ex: la redirection vers /maintenance ne fonctionne pas si on n'est pas logué et le contrôle devrait se faire dans un listener et non dans les fichiers init.php

il faut également trouver le moyen de créer la table doctrine_migration_versions car l'atomic_update échoue car il a déjà besoin de cette table.