### PR TITLE
MT39958: Display the time of absence registrations

### DIFF
--- a/templates/absences/index.html.twig
+++ b/templates/absences/index.html.twig
@@ -131,7 +131,9 @@
               {{ abs.commentaires }}
             </div>
           </td>
-          <td>{{ abs.demande | date('d/m/Y') }}</td>
+          <td style='white-space:nowrap;'>
+            {{ abs.demande | date('d/m/Y H:i') }}
+          </td>
 
           {% if can_manage_sup_doc %}
             <td style='text-align:center;'>


### PR DESCRIPTION
TEST PLAN : 
Afficher la liste des absences

Sans cette PR : les dates de demande d'absence sont affichées sans les heures

Avec cette PR : les dates de demande d'absence sont affichées avec les heures et minutes (format d/m/Y H:i)