### PR TITLE
MT39878: fix undefined variable  when using CAS-SQL mode and APP_DEBUG=1

### DIFF
--- a/src/Controller/AuthorizationsController.php
+++ b/src/Controller/AuthorizationsController.php
@@ -84,6 +84,7 @@ class AuthorizationsController extends BaseController
 
                 // CAS auth with SQL fallback.
                 case 'CAS-SQL':
+                    $auth = false;
                     if ($login and $_POST['auth'] == 'CAS'
                         and array_key_exists('login_id', $_SESSION)
                         and $login == $_SESSION['login_id']) {


### PR DESCRIPTION
MT39878: fix undefined variable  when using CAS-SQL mode and APP_DEBUG=1
See #850 

TEST PLAN : 
with APP_DEBUG=1, config Auth-Mode = CAS-SQL
Try to log in with an user who is not admin (add /?noCAS in the URL)
Without this PR : error warning undefined variable $auth
With this PR : the login is successfull 