### PR TITLE
MT39491: Fix save agent save when holidays values are empty

### DIFF
--- a/src/Controller/AgentController.php
+++ b/src/Controller/AgentController.php
@@ -1565,6 +1565,7 @@ class AgentController extends BaseController
 
         foreach ($available_keys as $key) {
             $params[$key . '_min'] = isset($params[$key . '_min']) ? $params[$key . '_min'] : 0;
+            $params[$key] = !empty($params[$key]) ? $params[$key] : 0;
         }
 
         if ($this->config('Conges-Mode') == 'jours' ) {

--- a/src/Controller/AgentController.php
+++ b/src/Controller/AgentController.php
@@ -1560,7 +1560,7 @@ class AgentController extends BaseController
             'conges_credit',
             'conges_reliquat',
             'conges_anticipation',
-            'recup',
+            'comp_time',
             'conges_annuel');
 
         foreach ($available_keys as $key) {


### PR DESCRIPTION
Test plan:

 1) without the patch, edit an agent and blank one value or more in the
    holidays tab.

 2) Check that saving fails.

 3) With the patch, edit an agent and blank one value or more in the
    holidays tab.

 4) Check that saving works and that the values have been defaulted to 0.