### PR TITLE
MT39696: Set Recup-DelaiDefaut to 0 if not correctly set.

### DIFF
--- a/src/Controller/OvertimeController.php
+++ b/src/Controller/OvertimeController.php
@@ -168,7 +168,7 @@ class OvertimeController extends BaseController
         }
 
         $this->templateParams(array(
-            'recup_delaidefaut'         => $this->config('Recup-DelaiDefaut'),
+            'recup_delaidefaut'         => is_int($this->config('Recup-DelaiDefaut')) ? $this->config('Recup-DelaiDefaut') : 0,
             'recup_delaititulaire1'     => $this->config('Recup-DelaiTitulaire1'),
             'recup_delaititulaire2'     => $this->config('Recup-DelaiTitulaire2'),
             'recup_delaicontractuel1'   => $this->config('Recup-DelaiContractuel1'),


### PR DESCRIPTION
Test plan:

 1) Set Recup-DelaiDefaut (Conges section) to blank or to a non-integer value.

 2) Without the patch, check that a new overtime request triggers a JS error.

 3) With the patch, check that there is no JS error.
    (Recup-DelaiDefaut is set to 0)