### PR TITLE
MT39529: Fix erroneous message on absence add

### DIFF
--- a/public/absences/class.absences.php
+++ b/public/absences/class.absences.php
@@ -1244,7 +1244,7 @@ class absences
             }
         }
 
-        $this->recipients=$recipients;
+        $this->recipients = array_unique(array_filter($recipients));
     }
 
 
@@ -1345,7 +1345,7 @@ class absences
         break;
     }
 
-        $this->recipients = array_unique($destinataires);
+        $this->recipients = array_unique(array_filter($destinataires));
     }
 
 

--- a/public/absences/class.absences.php
+++ b/public/absences/class.absences.php
@@ -344,7 +344,7 @@ class absences
                 $m->send();
 
                 // Si erreur d'envoi de mail
-                if ($m->error) {
+                if ($m->error && $m->error_CJInfo) {
                     $msg2 .= "<li>".$m->error_CJInfo."</li>";
                     $msg2_type = "error";
                 }

--- a/src/Controller/AbsenceController.php
+++ b/src/Controller/AbsenceController.php
@@ -1337,21 +1337,13 @@ class AbsenceController extends BaseController
             // Pour chaque agent, recherche des destinataires de notification en fonction de la config. (responsables absences, responsables directs, agent).
             $ids = array_column($agents, 'perso_id'); 
             $staff_members = $this->entityManager->getRepository(Agent::class)->findById($ids);
-            $destinataires=array();
+            $destinataires = array();
             foreach ($staff_members as $member) {
                 $a = new \absences();
                 $a->getRecipients("-$workflow$notifications", $responsables, $member);
-                $destinataires=array_merge($destinataires, $a->recipients);
+                $destinataires = array_merge($destinataires, $a->recipients);
             }
-
-            // Suppresion des doublons dans les destinataires
-            $tmp = array();
-            foreach ($destinataires as $elem) {
-                if (!in_array($elem, $tmp)) {
-                    $tmp[]=$elem;
-                }
-            }
-            $destinataires=$tmp;
+            $destinataires = array_unique($destinataires);
         }
 
         // Recherche des plages de SP concernées pour ajouter cette information dans le mail.

--- a/src/Model/Agent.php
+++ b/src/Model/Agent.php
@@ -235,6 +235,10 @@ class Agent extends PLBEntity
     public function get_manager_emails() {
         $emails_string = $this->mails_responsables();
 
+        if ($emails_string == '') {
+            return array();
+        }
+
         return explode(';', $emails_string);
     }
 

--- a/tests/Model/AgentTest.php
+++ b/tests/Model/AgentTest.php
@@ -335,8 +335,13 @@ class AgentTest extends TestCase
         $builder = new FixtureBuilder();
         $builder->delete(Agent::class);
 
-        $agent = $builder->build(Agent::class, array('login' => 'jdevoe', 'mails_responsables' => 'jcharles@mail.fr;jmarc@mail.fr;j.paul@mail.com'));
+        // MT39529: No managers should return an empty array, not an array with an empty value.
+        $agent = $builder->build(Agent::class, array('login' => 'jdevoe', 'mails_responsables' => ''));
+        $this->assertEquals(sizeof($agent->get_manager_emails()), 0);
 
+        $builder->delete(Agent::class);
+
+        $agent = $builder->build(Agent::class, array('login' => 'jdevoe', 'mails_responsables' => 'jcharles@mail.fr;jmarc@mail.fr;j.paul@mail.com'));
         $this->assertEquals($agent->get_manager_emails(), ['jcharles@mail.fr', 'jmarc@mail.fr', 'j.paul@mail.com']);
     }
 }


### PR DESCRIPTION
Test plan:

 1) Without the patch, make sure that direct managers (Reponsables directs)
 are checked in at least one of the absences notifications workflows
 (Absences-notifications-* in the Absences tab of the configuration page)

 2) For a user that has no direct managers, add an absence

 3) Check that the message "`<li></li>`" is displayed before the message saying
 that the absence has been added.

 4) With the patch, check that the message "`<li></li>`" is gone.

This happens because there is an empty email in the list of recipients.

This patch fixes the problem in two ways:

 - Make get_manager_emails return an empty array when there are no managers (and not an array with an empty value)

 - Remove empty values in getRecipients* functions to make sure no empty emails are passed to the CJMail class.