### PR TITLE
MT39693: Show closingday in menu only if Conges-Enable is enabled

### DIFF
--- a/public/include/class.menu.php
+++ b/public/include/class.menu.php
@@ -31,41 +31,48 @@ class menu
     {
     }
 
+    public function checkCondition($condition) {
+
+        if ($condition != null && $condition != '') {
+            if (substr($condition, 0, 7)=="config=") {
+                $tmp = substr($condition, 7);
+                $values = explode(";", $tmp);
+                foreach ($values as $value) {
+                    if (empty($GLOBALS['config'][$value])) {
+                        return false;
+                    }
+                }
+            } elseif (substr($condition, 0, 8)=="config!=") {
+                $tmp = substr($condition, 8);
+                $values = explode(";", $tmp);
+                foreach ($values as $value) {
+                    if (!empty($GLOBALS['config'][$value])) {
+                        return false;
+                    }
+                }
+            } else {
+                return false;
+            }
+        }
+        return true;
+    }
+
     public function fetch()
     {
         $menu=array();
         $db=new db();
         $db->select("menu", null, null, "ORDER BY `niveau1`,`niveau2`");
         foreach ($db->result as $elem) {
-            if ($elem['condition']) {
-                if (substr($elem['condition'], 0, 7)=="config=") {
-                    $tmp = substr($elem['condition'], 7);
-                    $values = explode(";", $tmp);
-                    foreach ($values as $value) {
-                        if (empty($GLOBALS['config'][$value])) {
-                            continue 2;
-                        }
-                    }
-                }
 
-                if (substr($elem['condition'], 0, 8)=="config!=") {
-                    $tmp = substr($elem['condition'], 8);
-                    $values = explode(";", $tmp);
-                    foreach ($values as $value) {
-                        if (!empty($GLOBALS['config'][$value])) {
-                            continue 2;
-                        }
-                    }
+            if ($this->checkCondition($elem['condition'])) {
+                if (substr($elem['url'], 0, 1) == '/') {
+                    $url = substr($elem['url'], 1);
+                } else {
+                    $url = 'index.php?page=' . $elem['url'];
                 }
-
+                $menu[$elem['niveau1']][$elem['niveau2']]['titre']=$elem['titre'];
+                $menu[$elem['niveau1']][$elem['niveau2']]['url'] = $url;
             }
-            if (substr($elem['url'], 0, 1) == '/') {
-                $url = substr($elem['url'], 1);
-            } else {
-                $url = 'index.php?page=' . $elem['url'];
-            }
-            $menu[$elem['niveau1']][$elem['niveau2']]['titre']=$elem['titre'];
-            $menu[$elem['niveau1']][$elem['niveau2']]['url'] = $url;
         }
 
         if ($GLOBALS['config']['Multisites-nombre']>1) {

--- a/public/include/class.menu.php
+++ b/public/include/class.menu.php
@@ -31,27 +31,31 @@ class menu
     {
     }
 
-    public function checkCondition($condition) {
+    public function checkCondition($allConditions) {
 
-        if ($condition != null && $condition != '') {
-            if (substr($condition, 0, 7)=="config=") {
-                $tmp = substr($condition, 7);
-                $values = explode(";", $tmp);
-                foreach ($values as $value) {
-                    if (empty($GLOBALS['config'][$value])) {
-                        return false;
+        if ($allConditions != null && $allConditions != '') {
+
+            $conditionsArray = explode('&', $allConditions);
+            foreach ($conditionsArray as $condition) {
+                if (substr($condition, 0, 7)=="config=") {
+                    $tmp = substr($condition, 7);
+                    $values = explode(";", $tmp);
+                    foreach ($values as $value) {
+                        if (empty($GLOBALS['config'][$value])) {
+                            return false;
+                        }
                     }
-                }
-            } elseif (substr($condition, 0, 8)=="config!=") {
-                $tmp = substr($condition, 8);
-                $values = explode(";", $tmp);
-                foreach ($values as $value) {
-                    if (!empty($GLOBALS['config'][$value])) {
-                        return false;
+                } elseif (substr($condition, 0, 8)=="config!=") {
+                    $tmp = substr($condition, 8);
+                    $values = explode(";", $tmp);
+                    foreach ($values as $value) {
+                        if (!empty($GLOBALS['config'][$value])) {
+                            return false;
+                        }
                     }
+                } else {
+                    return false;
                 }
-            } else {
-                return false;
             }
         }
         return true;

--- a/public/setup/atomicupdate/MT39693.php
+++ b/public/setup/atomicupdate/MT39693.php
@@ -1,0 +1,3 @@
+<?php
+// MT39693: Show closingday in menu only if Conges-Enable is enabled
+$sql[] = "UPDATE `{$dbprefix}menu` SET `condition` = 'config!=Planook&config=Conges-Enable' WHERE `url` = '/closingday' LIMIT 1;";

--- a/public/setup/db_data.php
+++ b/public/setup/db_data.php
@@ -410,7 +410,7 @@ $sql[]="INSERT INTO `{$dbprefix}menu` (`niveau1`,`niveau2`,`titre`,`url`,`condit
   ('50','40','Les postes','/position',NULL),
   ('50','50','Les mod&egrave;les','/model',NULL),
   ('50','60','Les tableaux','/framework',NULL),
-  ('50','70','Jours de fermeture','/closingday', 'config!=Planook'),
+  ('50','70','Jours de fermeture','/closingday', 'config!=Planook&config=Conges-Enable'),
   ('50','75','Heures de présence','/workinghour','config=PlanningHebdo'),
   ('50','77','Notifications / Validations','/notification','config=Absences-notifications-agent-par-agent'),
   ('50','80','Configuration','/config',NULL),

--- a/tests/Class/ClassMenuTest.php
+++ b/tests/Class/ClassMenuTest.php
@@ -25,13 +25,22 @@ class ClassMenuTest extends TestCase
         $GLOBALS['config']['Conges-Recuperations'] = 0;
         $this->assertEquals($menu->checkCondition('config=Conges-Enable;Conges-Recuperations'), false, 'multiple equal condition');
         $this->assertEquals($menu->checkCondition('config!=Conges-Enable;Conges-Recuperations'), false, 'multiple not equal condition');
+        $this->assertEquals($menu->checkCondition('config!=Conges-Enable&config=Conges-Recuperations'), false, 'both equal and not equal single conditions');
+        $this->assertEquals($menu->checkCondition('config=Conges-Enable&config!=Conges-Recuperations'), true, 'both equal and not equal single conditions');
 
         $GLOBALS['config']['Conges-Enable'] = 1;
         $GLOBALS['config']['Conges-Recuperations'] = 1;
         $this->assertEquals($menu->checkCondition('config=Conges-Enable;Conges-Recuperations'), true, 'multiple equal condition');
+        $this->assertEquals($menu->checkCondition('config!=Conges-Enable;Conges-Recuperations'), false, 'multiple not equal condition');
+        $this->assertEquals($menu->checkCondition('config!=Conges-Enable&config=Conges-Recuperations'), false, 'both equal and not equal single conditions');
+        $this->assertEquals($menu->checkCondition('config=Conges-Enable&config!=Conges-Recuperations'), false, 'both equal and not equal single conditions');
 
         $GLOBALS['config']['Conges-Enable'] = 0;
         $GLOBALS['config']['Conges-Recuperations'] = 0;
+        $this->assertEquals($menu->checkCondition('config=Conges-Enable;Conges-Recuperations'), false, 'multiple equal condition');
         $this->assertEquals($menu->checkCondition('config!=Conges-Enable;Conges-Recuperations'), true, 'multiple not equal condition');
+        $this->assertEquals($menu->checkCondition('config!=Conges-Enable&config=Conges-Recuperations'), false, 'both equal and not equal single conditions');
+        $this->assertEquals($menu->checkCondition('config=Conges-Enable&config!=Conges-Recuperations'), false, 'both equal and not equal single conditions');
+
     }
 }

--- a/tests/Class/ClassMenuTest.php
+++ b/tests/Class/ClassMenuTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once(__DIR__ . '/../../public/include/class.menu.php');
+
+class ClassMenuTest extends TestCase
+{
+    public function testMenuContent()
+    {
+        $menu = new menu();
+        $this->assertEquals($menu->checkCondition('random string'), false, 'random string is false');
+        $this->assertEquals($menu->checkCondition(null), true, 'null condition is true');
+        $this->assertEquals($menu->checkCondition(''), true, 'empty condition is true');
+
+        $GLOBALS['config']['Conges-Enable'] = 0;
+        $this->assertEquals($menu->checkCondition('config=Conges-Enable'), false, 'single equal condition');
+        $this->assertEquals($menu->checkCondition('config!=Conges-Enable'), true, 'single not equal condition');
+
+        $GLOBALS['config']['Conges-Enable'] = 1;
+        $this->assertEquals($menu->checkCondition('config=Conges-Enable'), true, 'single equal condition');
+        $this->assertEquals($menu->checkCondition('config!=Conges-Enable'), false, 'single not equal condition');
+
+        $GLOBALS['config']['Conges-Enable'] = 1;
+        $GLOBALS['config']['Conges-Recuperations'] = 0;
+        $this->assertEquals($menu->checkCondition('config=Conges-Enable;Conges-Recuperations'), false, 'multiple equal condition');
+        $this->assertEquals($menu->checkCondition('config!=Conges-Enable;Conges-Recuperations'), false, 'multiple not equal condition');
+
+        $GLOBALS['config']['Conges-Enable'] = 1;
+        $GLOBALS['config']['Conges-Recuperations'] = 1;
+        $this->assertEquals($menu->checkCondition('config=Conges-Enable;Conges-Recuperations'), true, 'multiple equal condition');
+
+        $GLOBALS['config']['Conges-Enable'] = 0;
+        $GLOBALS['config']['Conges-Recuperations'] = 0;
+        $this->assertEquals($menu->checkCondition('config!=Conges-Enable;Conges-Recuperations'), true, 'multiple not equal condition');
+    }
+}


### PR DESCRIPTION
    Test plan:
    
     - Run the SQL update (public/setup/updatedatabase.php)
    
     - Check that "Jours de fermeture" (/closingday) is displayed in the
     Administration menu only if Planook is disabled and Conges-Enable is enabled.
