### PR TITLE
MT40252: don't show the alert "please select more than 1 year" on leap years

### DIFF
--- a/public/absences/js/voir.js
+++ b/public/absences/js/voir.js
@@ -44,7 +44,7 @@ $(function(){
          end = new Date();
        }
        var number_of_days = (end - start) / (1000 * 60 * 60 * 24);
-       if (number_of_days > 365) {
+       if (number_of_days > 366) {
          alert('Veuillez sélectionner un intervalle inférieur à une année.');
          event.preventDefault();
        }


### PR DESCRIPTION
test plan : 

Search absences with the default dates : 
- Without this PR : alert please select more than  year
- With this PR : OK