### PR TITLE
MT38947: Fix display of groups-free position in time statistics

### DIFF
--- a/src/Controller/StatisticController.php
+++ b/src/Controller/StatisticController.php
@@ -2553,7 +2553,7 @@ class StatisticController extends BaseController
 
                 // Totaux par groupe de postes
                 foreach ($groups as $g) {
-                    if ($g->id() >= 0 and in_array($elem['poste'], $groupes[$g->id()])) {
+                    if (in_array($elem['poste'], $groupes[$g->id()])) {
                         $tab[$elem['perso_id']]['groupe'][$g->id()] += diff_heures($elem['debut'], $elem['fin'], "decimal");
                         $tab[$elem['perso_id']][$elem['date']]['groupe'][$g->id()] += diff_heures($elem['debut'], $elem['fin'], "decimal");
                         $totauxGroupesHeures[$g->id()] += diff_heures($elem['debut'], $elem['fin'], "decimal");


### PR DESCRIPTION
Test plan:

1) Apply the patch
2) Go to time statistics (Statistiques -> Feuille de temps) 
3) Check that when a position is not part of a group, the hours are correctly displayed in the "Autres" category (both in the day column and on its own column)