### PR TITLE
MT40441: Allow direct validation of compensatory time when Conges-val…

### DIFF
--- a/src/Controller/CompTimeController.php
+++ b/src/Controller/CompTimeController.php
@@ -130,6 +130,24 @@ class CompTimeController extends BaseController
 
         // Enregistrement du congés
         $data = $request->request->all();
+
+        // FIXME : this works only when Conges-validation is disabled.
+        // TODO : Handle the different levels of validation when the dropdown menu will be added to the template for config Conges-validation enabled
+        // TODO : an other (and better) way to fix this is to use the holiday controller and holiday templates for adding comp-time. It's already done for comp-time editions.
+
+        if ($request->get('valide')) {
+            $data['conges-recup'] = 1;
+            $data['conges-mode'] = $this->config('Conges-Mode');
+            $data['perso_ids'] = array($data['perso_id']);
+            $data['confirm'] = 'confirm';
+            $data['debit'] = 'recuperation';
+            $data['valide_init'] = 1;
+            $data['valide'] = $_SESSION['login_id'];
+            $data['valide_n1'] = $_SESSION['login_id'];
+            $data['validation'] = date('Y-m-d H:i:s');
+            $data['validation_n1'] = date('Y-m-d H:i:s');
+        }
+
         $c = new \conges();
         $c->CSRFToken = $CSRFToken;
         $c->add($data);

--- a/templates/comptime/add.html.twig
+++ b/templates/comptime/add.html.twig
@@ -143,6 +143,15 @@
                   <td>&nbsp;</td>
                 </tr>
 
+                {# TODO: add the validation menu when Conges-validation is enabled #}
+                <tr>
+                  <td>
+                    {% if not config('Conges-validation') %}
+                      <input type='hidden' name='valide' id='validation' value='1' />
+                    {% endif %}
+                  </td>
+                </tr>
+
                 <tr>
                   <td colspan="2" style="text-align:center;">
                     <input type="button" value="Annuler" onclick='document.location.href="/holiday/index?recup=1";' class="ui-button ui-button-type2"/>


### PR DESCRIPTION
MT40441: Allow direct validation of compensatory time when Conges-validation is disabled

Test plan.
Config :
Conges-Enable = Enabled
Conges-Mode	= test both Heures / Jours 
Conges-Recuperations = Dissocier
Conges-validation = Disabled

Add Compensatory time credit to an agent (field "Récupérations" on "Congés" tab)
Add working hours to this agent
create a new compensatory time request for this agent (menu Congés / Poser des récupérations)
Without this PR : the request is not validaded
With this PR : the request is valided, comp-time credits are affected

Test with the login admin ; with an login which is not admin but has rights to validate holiday ; and with a login that does not have rights
Check if credits are well computed.