### PR TITLE
MT40252: don't show the alert "select more than 1 year", follow up

### DIFF
--- a/public/absences/js/voir.js
+++ b/public/absences/js/voir.js
@@ -44,7 +44,7 @@ $(function(){
          end = new Date();
        }
        var number_of_days = (end - start) / (1000 * 60 * 60 * 24);
-       if (number_of_days > 366) {
+       if (number_of_days > 367) {
          alert('Veuillez sélectionner un intervalle inférieur à une année.');
          event.preventDefault();
        }


### PR DESCRIPTION
This alert is still there when we chose the following dates : 2023-03-31 - 2024-03-31