### PR TITLE
MT40167: Strike agents that have left in the stated week plannings.

### DIFF
--- a/public/js/statedweek.js
+++ b/public/js/statedweek.js
@@ -296,6 +296,10 @@ function placeOnPlanning(agent) {
         cell.addHoliday();
       }
 
+      if (agent.leaving_date_passed) {
+        cell.addLeavingDatePassed();
+      }
+
       if (agent.partially_holiday) {
         cell.addPartialHolidays(agent.partially_holiday);
       }
@@ -367,6 +371,13 @@ $( document ).ready(function() {
       cell.addClass('absent');
       cell.children('span').addClass('absent');
       cell.append('<br/><i> - Congés</i>');
+    };
+
+    $(this).init.prototype.addLeavingDatePassed = function() {
+      cell = $(this);
+      cell.addClass('absent');
+      cell.children('span').addClass('absent');
+      cell.append('<br/><i> - Date de départ dépassée</i>');
     };
 
     $(this).init.prototype.addPartialHolidays = function(holidays) {

--- a/src/Controller/StatedWeekController.php
+++ b/src/Controller/StatedWeekController.php
@@ -719,6 +719,10 @@ class StatedWeekController extends BaseController
                     $p['partially_holiday'] = $absence_times;
                 }
 
+                if ($agent->leavingDatePassed($date)) {
+                    $p['leaving_date_passed'] = 1;
+                }
+
                 $placed[] = $p;
             }
         }

--- a/src/Model/Agent.php
+++ b/src/Model/Agent.php
@@ -249,6 +249,19 @@ class Agent extends PLBEntity
 
         return false;
     }
+    public function leavingDatePassed($date)
+    {
+        $now = \DateTime::createFromFormat('Y-m-d', $date);
+
+        #TODO: This works but it is rather ugly. We probably shouldn't store "0000-00-00"
+        # in the database instead of NULL, because although it may (depending on the
+        # configuration) be permitted by MariaDB, it is not a valid date for PHP's DateTime.
+        # DateTime converts it to -0001-11-30 instead of throwing an error.
+        # See:
+        # https://stackoverflow.com/questions/29917598/why-does-0000-00-00-000000-return-0001-11-30-000000
+        # https://mariadb.com/kb/en/date/
+        return ($this->depart->format('Y-m-d') != '-0001-11-30' && $this->depart < $now);
+    }
 
     public function isOnVacationOn($from, $to)
     {


### PR DESCRIPTION
Test plan:

 1) Without the patch, place an agent in a stated week planning at a given date

 2) Edit that agent to set his leaving (depart) date at a prior date

 3) Check that the agent is not striked in the stated week planning

 4) Apply the patch, and check that the agent is striked in the stated week
    planning, with the following message: "Date de départ dépassée"