### PR TITLE
MT39966: Fix comments display under plannings

### DIFF
--- a/templates/planning/poste/index.html.twig
+++ b/templates/planning/poste/index.html.twig
@@ -47,7 +47,7 @@
       {% endif %}
     {% endif %}
 
-    {% if tab is defined and tab %}
+    {% if tabs is defined and tabs %}
       <div id="planning-data" data-verrou="{{ locked }}" data-autorisation="{{ autorisationN1 }}"
            data-validation="{{ validation2 }}" data-lignesVides="{{ lignesVides }}"
            data-sr-debut="{{ config('Planning-SR-debut') }}"


### PR DESCRIPTION
Test plan:

Without the patch:

 - Enable Planning-CommentairesToujoursActifs
 - Give only the "Modification des commentaires des plannings" to a user
 - With this user, try to add a comment to an unvalidated planning
 - Check that the "Ajouter un commentaire" button appears twice and has no effect.

With the patch:

 - In the same conditions, check that you can add a comment.