### PR TITLE
MT40420: Fix the calculation of the free break

### DIFF
--- a/src/PlanningBiblio/Helper/HolidayHelper.php
+++ b/src/PlanningBiblio/Helper/HolidayHelper.php
@@ -129,35 +129,56 @@ class HolidayHelper extends BaseHelper
 
             // Convert free break as fixed break if needed
             $free_break_already_removed = false;
-            $has_fixed_break = !empty($planning['times'][$day_id][1]) || !empty($planning['times'][$day_id][5]);
 
-            if (!empty($planning['breaktimes'][$day_id]) && !$has_fixed_break) {
-
-                $free_break_already_removed = true;
-                $free_break_start = $this->config('PlanningHebdo-DebutPauseLibre');
-                $free_break_end = $this->config('PlanningHebdo-FinPauseLibre');
-                $free_break_duration = $planning['breaktimes'][$day_id] * 60;
-
-                if (strtotime($debutConges) >= strtotime($free_break_start) &&
-                    strtotime($finConges)   <= strtotime($free_break_end)) {
-
-                    // If the holiday is shorter than the free break, the free break starts at the beginning of the holiday
-                    $planning["times"][$day_id][1] = $debutConges;
-                    $planning["times"][$day_id][2] = date('H:i:s', strtotime("+ $free_break_duration minutes $debutConges"));
-
-                } elseif (substr($debutConges, 0, 2) >= 12) {
-
-                    // If the holiday is in the afternoon, the free break is at the end of its period.
-                    $fixed_free_break_start = date('H:i:s', strtotime("- $free_break_duration minutes $free_break_end"));
-                    $planning["times"][$day_id][1] = $fixed_free_break_start;
-                    $planning["times"][$day_id][2] = $free_break_end;
-
-                } else {
-
-                    // If the holiday is in the morning, the free break is at the beginning of its period.
-                    $fixed_free_break_end = date('H:i:s', strtotime("+ $free_break_duration minutes $free_break_start"));
-                    $planning["times"][$day_id][1] = $free_break_start;
-                    $planning["times"][$day_id][2] = $fixed_free_break_end;
+            if (!empty($planning['breaktimes'][$day_id])) {
+                if (!$this->hasFixedBreak($planning['times'][$day_id])) {
+    
+                    $free_break_already_removed = true;
+                    $free_break_start = $this->config('PlanningHebdo-DebutPauseLibre');
+                    $free_break_end = $this->config('PlanningHebdo-FinPauseLibre');
+                    $free_break_duration = $planning['breaktimes'][$day_id] * 60;
+    
+                    $planning['times'][$day_id] = $this->standardizeTime($planning['times'][$day_id]);
+    
+                    if (strtotime($debutConges) >= strtotime($free_break_start) &&
+                        strtotime($finConges)   <= strtotime($free_break_end)) {
+    
+                        // If the holiday is shorter than the free break, the free break starts at the beginning of the holiday
+                        $planning["times"][$day_id][1] = $debutConges;
+                        $planning["times"][$day_id][2] = date('H:i:s', strtotime("+ $free_break_duration minutes $debutConges"));
+    
+    
+                    } elseif ($free_break_start < $planning['times'][$day_id][0]) {
+    
+                        // If working hours start after the period defined in config, we move the break at the beginning of working hours
+                        $free_break_start = $planning['times'][$day_id][0];
+                        $fixed_free_break_end = date('H:i:s', strtotime("+ $free_break_duration minutes $free_break_start"));
+                        $planning["times"][$day_id][1] = $free_break_start;
+                        $planning["times"][$day_id][2] = $fixed_free_break_end;
+    
+    
+                    } elseif ($free_break_end > $planning['times'][$day_id][3]) {
+    
+                        // If working hours end before the period defined in config, we move the break at the end of working hours
+                        $free_break_end = $planning['times'][$day_id][3];
+                        $fixed_free_break_start = date('H:i:s', strtotime("- $free_break_duration minutes $free_break_end"));
+                        $planning["times"][$day_id][1] = $fixed_free_break_start;
+                        $planning["times"][$day_id][2] = $free_break_end;
+    
+                    } elseif (substr($debutConges, 0, 2) >= 12) {
+    
+                        // If the holiday is in the afternoon, the free break is at the end of its period.
+                        $fixed_free_break_start = date('H:i:s', strtotime("- $free_break_duration minutes $free_break_end"));
+                        $planning["times"][$day_id][1] = $fixed_free_break_start;
+                        $planning["times"][$day_id][2] = $free_break_end;
+    
+                    } else {
+    
+                        // If the holiday is in the morning, the free break is at the beginning of its period.
+                        $fixed_free_break_end = date('H:i:s', strtotime("+ $free_break_duration minutes $free_break_start"));
+                        $planning["times"][$day_id][1] = $free_break_start;
+                        $planning["times"][$day_id][2] = $fixed_free_break_end;
+                    }
                 }
             }
 
@@ -389,6 +410,7 @@ class HolidayHelper extends BaseHelper
      */
     private function getTimes($planning, $date, $free_break_already_removed)
     {
+
         // Sinon, on calcule les heures d'absence
         $d = new \datePl($date, $planning['nb_semaine']);
         $week = $d->semaine3;
@@ -444,5 +466,56 @@ class HolidayHelper extends BaseHelper
         }
 
         return false;
+    }
+
+    private function hasFixedBreak($times)
+    {
+        $indexes = array(0,1,2,3,5,6);
+
+        $slots = 0;
+        foreach ($indexes as $index) {
+            if (!empty($times[$index])) {
+                $slots++;
+            }
+        }
+
+        $break = $slots > 2;
+
+        return $break;
+    }
+
+    /** The standardizeTime function fills cells 0 and 3 in all cases to be able to place the break on cells 1 and 2
+      * Works if only one time slot if defined.
+      * Case 1 : 0 - 3
+      * Case 2 : 0 - 1
+      * Case 3 : 0 - 6
+      * Case 4 : 2 - 3
+      * Case 5 : 2 - 6
+      * Case 6 : 5 - 6
+      */
+    private function standardizeTime($times)
+    {
+
+        if (!empty($times[1])) {
+            $times[3] = $times[1];
+            $times[1] = null;
+        }
+
+        if (!empty($times[2])) {
+            $times[0] = $times[2];
+            $times[2] = null;
+        }
+
+        if (!empty($times[5])) {
+            $times[0] = $times[5];
+            $times[5] = null;
+        }
+
+        if (!empty($times[6])) {
+            $times[3] = $times[6];
+            $times[6] = null;
+        }
+
+        return $times;
     }
 }


### PR DESCRIPTION
Test plan:

 - For an agent that has working hours from 14:00 to 18:00 and one hour of free break (which starts at 12 and ends at 14), add a full day holiday

 - Without the patch, counted hours are 5 (incorrect)

 - With the patch, counted hours are 4 (correct)