### PR TITLE
MT39946: Fix time format parameter for ajax call in absence add

### DIFF
--- a/public/absences/js/modif.js
+++ b/public/absences/js/modif.js
@@ -922,8 +922,8 @@ function verif_absences(ctrl_form){
   debut=debut.replace(/([0-9]{2})\/([0-9]{2})\/([0-9]{4})/g,"$3-$2-$1");
   fin=fin.replace(/([0-9]{2})\/([0-9]{2})\/([0-9]{4})/g,"$3-$2-$1");
 
-  hre_debut=document.form.hre_debut.value;
-  hre_fin=document.form.hre_fin.value;
+  hre_debut=document.form.hre_debut.value + ':00';
+  hre_fin=document.form.hre_fin.value + ':00';
   hre_debut=hre_debut?hre_debut:"00:00:00";
   hre_fin=hre_fin?hre_fin:"23:59:59";
   debut=debut+" "+hre_debut;


### PR DESCRIPTION
holidayAbsenceControl expects debut and fin parameters to be in the following format: hh:mm:ss

public/absences/js/modif.js passed them in a hh:mm format, causing wrong date comparison in SQL query.