### PR TITLE
MT41028: Show an alert when a recurring absence is added and the enddate is set

### DIFF
--- a/public/absences/js/modif.js
+++ b/public/absences/js/modif.js
@@ -239,16 +239,17 @@ $(function() {
 
   $("#recurrence-checkbox").change(function() {
     if($("#recurrence-checkbox").prop('checked')){
-      if($('#recurrence-hidden').val()){
-        $('#recurrence-info').show();
-      } else {
-        $("#recurrence-form").dialog( "open" );
-      }
       if (
         $('input[name="fin"]').val() != '' &&
         $('input[name="fin"]').val() != $('input[name="debut"]').val()
       ) {
         $("#recurrence-enddate-alert").dialog("open");
+      } else {
+        if($('#recurrence-hidden').val()){
+          $('#recurrence-info').show();
+        } else {
+          $("#recurrence-form").dialog( "open" );
+        }
       }
     } else {
       $('#recurrence-info').hide();
@@ -395,6 +396,13 @@ $(function() {
       },
       "Non": function() {
         $(this).dialog("close");
+      }
+    },
+    close: function() {
+      if($('#recurrence-hidden').val()){
+        $('#recurrence-info').show();
+      } else {
+        $("#recurrence-form").dialog( "open" );
       }
     }
   });

--- a/public/absences/js/modif.js
+++ b/public/absences/js/modif.js
@@ -244,8 +244,20 @@ $(function() {
       } else {
         $("#recurrence-form").dialog( "open" );
       }
+      if($('input[name="fin"]').val() != '' &&
+         $('input[name="fin"]').val() != $('input[name="debut"]').val()) {
+        $("#recurrence-enddate-alert").dialog("open");
+      }
     } else {
       $('#recurrence-info').hide();
+    }
+  });
+
+  $('input[name="fin"]').change(function() {
+    if($("#recurrence-checkbox").prop('checked') &&
+       $('input[name="fin"]').val() != '' &&
+       $('input[name="fin"]').val() != $('input[name="debut"]').val()) {
+      $("#recurrence-enddate-alert").dialog("open");
     }
   });
 
@@ -363,6 +375,22 @@ $(function() {
     buttons: {
       "Fermer": function() {
         $( this ).dialog( "close" );
+      }
+    }
+  });
+
+  $("#recurrence-enddate-alert").dialog({
+    autoOpen: false,
+    height: 200,
+    width: 650,
+    modal: true,
+    buttons: {
+      "Oui": function() {
+        $(this).dialog("close");
+        $('input[name="fin"]').val("");
+      },
+      "Non": function() {
+        $(this).dialog("close");
       }
     }
   });

--- a/public/absences/js/modif.js
+++ b/public/absences/js/modif.js
@@ -244,8 +244,10 @@ $(function() {
       } else {
         $("#recurrence-form").dialog( "open" );
       }
-      if($('input[name="fin"]').val() != '' &&
-         $('input[name="fin"]').val() != $('input[name="debut"]').val()) {
+      if (
+        $('input[name="fin"]').val() != '' &&
+        $('input[name="fin"]').val() != $('input[name="debut"]').val()
+      ) {
         $("#recurrence-enddate-alert").dialog("open");
       }
     } else {
@@ -254,9 +256,11 @@ $(function() {
   });
 
   $('input[name="fin"]').change(function() {
-    if($("#recurrence-checkbox").prop('checked') &&
-       $('input[name="fin"]').val() != '' &&
-       $('input[name="fin"]').val() != $('input[name="debut"]').val()) {
+    if (
+      $("#recurrence-checkbox").prop('checked') &&
+      $('input[name="fin"]').val() != '' &&
+      $('input[name="fin"]').val() != $('input[name="debut"]').val()
+    ) {
       $("#recurrence-enddate-alert").dialog("open");
     }
   });

--- a/templates/absences/add.html.twig
+++ b/templates/absences/add.html.twig
@@ -281,6 +281,10 @@
         {% endif %}
 
       </div>
+      <div id="recurrence-enddate-alert" title="Date de fin de récurrence" class='noprint' style='display:none;'>Attention, vous vous apprêtez à enregistrer une absence récurrente. La fin de la série
+sera configurée dans la fenêtre de configuration de la récurrence et ne doit pas être saisie dans le formulaire d'absence.<br />
+Voulez-vous supprimer la date de fin choisie ?
+      </div>
       <div id="recurrence-form" title="Récurrence" class='noprint' style='display:none;'>
         <p class="validateTips">&nbsp;</p>
         <form>


### PR DESCRIPTION
In order to prevent users from confusing an absence end date and its associated recurring absence end of series date, a warning is displayed when adding an absence with a recurring pattern if the absence end date is set and different from the absence start date.