### PR TITLE
MT41030: Allow to narrow ICS exports to a number of days in the past

### DIFF
--- a/public/ics/calendar.php
+++ b/public/ics/calendar.php
@@ -107,7 +107,7 @@ $db->selectInnerJoin(
     array(),
   array("perso_id"=>$id),
     $requete_personnel,
-    "ORDER BY `date` DESC, `debut` DESC, `fin` DESC"
+    "AND `date` > DATE_SUB(curdate(), INTERVAL 1 MONTH) ORDER BY `date` DESC, `debut` DESC, `fin` DESC"
 );
 if ($db->result) {
     $planning = $db->result;
@@ -129,7 +129,7 @@ if ($config['Multisites-nombre'] > 1) {
 // Recherche des plannings verrouillés pour exclure les plages concernant des plannings en attente
 $verrou = array();
 $db = new db();
-$db->select2("pl_poste_verrou", null, array('verrou2'=>'1'));
+$db->select2("pl_poste_verrou", null, array('verrou2'=>'1'), "AND `date` > DATE_SUB(curdate(), INTERVAL 1 MONTH)");
 if ($db->result) {
     foreach ($db->result as $elem) {
         $verrou[$elem['date'].'_'.$elem['site']] = array('date'=>$elem['validation2'], 'agent'=>$elem['perso2']);
@@ -140,7 +140,7 @@ if ($db->result) {
 $a=new absences();
 $a->valide = true;
 $a->documents = false;
-$a->fetch("`debut`,`fin`", $id, '0000-00-00 00:00:00', date('Y-m-d', strtotime(date('Y-m-d').' + 2 years')));
+$a->fetch("`debut`,`fin`", $id, date('Y-m-d',strtotime(date('Y-m-d').' - 1 months')), date('Y-m-d', strtotime(date('Y-m-d').' + 2 years')));
 $absences=$a->elements;
 
 // Recherche des congés (si le module est activé)
@@ -148,7 +148,7 @@ if ($config['Conges-Enable']) {
     require_once "../conges/class.conges.php";
     $c = new conges();
     $c->perso_id = $id;
-    $c->debut = '0000-00-00 00:00:00';
+    $c->debut = date('Y-m-d',strtotime(date('Y-m-d').' - 1 months'));
     $c->fin = date('Y-m-d', strtotime(date('Y-m-d').' + 2 years'));
     $c->valide = true;
     $c->fetch();

--- a/public/ics/calendar.php
+++ b/public/ics/calendar.php
@@ -104,6 +104,13 @@ if ($config['ICS-Interval'] != '' && intval($config['ICS-Interval'])) {
     $icsInterval = $config['ICS-Interval'];
 }
 
+$interval_get = filter_input(INPUT_GET, 'interval', FILTER_SANITIZE_NUMBER_INT);
+error_log("intval_get: $interval_get\n");
+if ($interval_get != '' && intval($interval_get)) {
+    $icsInterval = $interval_get;
+}
+error_log("icsInterval: $icsInterval\n");
+
 $db=new db();
 $db->selectInnerJoin(
     array("pl_poste","perso_id"),

--- a/public/ics/calendar.php
+++ b/public/ics/calendar.php
@@ -105,11 +105,9 @@ if ($config['ICS-Interval'] != '' && intval($config['ICS-Interval'])) {
 }
 
 $interval_get = filter_input(INPUT_GET, 'interval', FILTER_SANITIZE_NUMBER_INT);
-error_log("intval_get: $interval_get\n");
 if ($interval_get != '' && intval($interval_get)) {
     $icsInterval = $interval_get;
 }
-error_log("icsInterval: $icsInterval\n");
 
 $db=new db();
 $db->selectInnerJoin(

--- a/public/ics/class.ics.php
+++ b/public/ics/class.ics.php
@@ -110,7 +110,7 @@ class CJICS
         $event[] = 'X-MICROSOFT-CDO-INTENDEDSTATUS:BUSY';
         $event[] = 'TRANSP:OPAQUE';
 
-        if ($createdAT) {
+        if ($createdAt) {
             $event[] = "CREATED:$createdAt";
         }
 

--- a/public/setup/atomicupdate/MT41030.php
+++ b/public/setup/atomicupdate/MT41030.php
@@ -1,0 +1,4 @@
+<?php
+
+$sql[] = "INSERT IGNORE INTO `{$dbprefix}config` ( `nom`, `type`, `valeur`, `commentaires`, `categorie`, `valeurs`, `extra`, `ordre`) VALUES ('ICS-Interval', 'text', '365', 'Restriction de la période à exporter : renseigner le nombre de jours à rechercher dans le passé. Les événements à venir sont toujours exportés. Si le champ n\'est pas renseigné, tous les événements seront recherchés.', 'ICS', '', NULL, '80');";
+

--- a/templates/help/index.html.twig
+++ b/templates/help/index.html.twig
@@ -133,7 +133,9 @@ Vous pouvez dans ce cas s&eacute;lectionner le nom des agents dans un menu déro
 Si l'exportation des plages de service public au format ICS est activée dans la configuration, vous pouvez ajouter vos agendas "Planno" à votre agenda personnel (Google Calendar, Zimbra, Outlook, Thunderbird, etc.)<br/>
 Vous trouverez deux URL dans le menu "Mon Compte" / "Agendas ICS". La première URL vous permet d'importer vos plages de service public. La seconde vous permet d'importer à la fois les plages de service public et les absences enregistrées dans Planno.<br/>
 Si les URL sont protégées par un code de sécurité, vous pouvez les réinitialiser en cliquant sur le lien "Réinitialiser les URL".<br/>
-L'affichage et la réinitialisation des URLs sont également possibles depuis le menu "Les agents" pour les personnes ayant le droit "Gestion du personnel".
+L'affichage et la réinitialisation des URLs sont également possibles depuis le menu "Les agents" pour les personnes ayant le droit "Gestion du personnel".<br />
+L'option de configuration ICS-Interval permet de définir le nombre de jours à rechercher dans le passé pour l'export des agendas.<br />
+Il est également possible de rajouter un paramètre interval à l'URL de l'agenda pour outrepasser l'option de configuration ICS-Interval (exemple: &interval=10)
 
 <a name='planning'></a>
 <h3>3.) Planning</h3>


### PR DESCRIPTION
A new configuration is added: ICS-Interval, which is the number of days in the past to export ICS calendars from.
    
If ICS-Interval is not set, or set to a value that is not an integer, all events and/or absences in the past will be exported.

Regardless of ICS-Interval configuration, events in the future are still exported as before.

The configuration option ICS-Interval can be overridden by adding an interval parameter to the calendar URL:
    
 Example: <URL>&interval=10