### PR TITLE
MT40167: Strike agents that have left in the stated week plannings

### DIFF
--- a/src/Controller/StatedWeekController.php
+++ b/src/Controller/StatedWeekController.php
@@ -236,6 +236,10 @@ class StatedWeekController extends BaseController
                 continue;
             }
 
+            if ($agent->leavingDatePassed($date)) {
+                continue;
+            }
+
             $available = array(
                 'fullname'          => $agent->nom() . ' ' . $agent->prenom(),
                 'id'                => $agent->id(),


### PR DESCRIPTION
     - Don't show an agent as available in context menu if his leaving date is
     before the given stated week planning.
