### PR TITLE
MT41151: Allow /holiday/accounts to be displayed in days

### DIFF
--- a/public/conges/class.conges.php
+++ b/public/conges/class.conges.php
@@ -711,9 +711,10 @@ class conges
 
         // Calcul des crédits utilisés et demandés en attente de validation
         $perso_ids=array_keys($tab);
+        $helper = new HolidayHelper();
         foreach ($perso_ids as $perso_id) {
 
-      // Initilisation
+            // Initialisation
             $tab[$perso_id]['conge_initial'] = isset($tab[$perso_id]['conge_initial']) ? $tab[$perso_id]['conge_initial'] : 0;
             $tab[$perso_id]['conge_restant'] = isset($tab[$perso_id]['conge_restant']) ? $tab[$perso_id]['conge_restant'] : 0;
             $tab[$perso_id]['reliquat_initial'] = isset($tab[$perso_id]['reliquat_initial']) ? $tab[$perso_id]['reliquat_initial'] : 0;
@@ -740,8 +741,19 @@ class conges
             $tab[$perso_id]['reliquat_classe']=$tab[$perso_id]['reliquat_demande']!=$tab[$perso_id]['reliquat_utilise']?"bold":null;
             $tab[$perso_id]['recup_classe']=$tab[$perso_id]['recup_demande']!=$tab[$perso_id]['recup_utilise']?"bold":null;
             $tab[$perso_id]['anticipation_classe']=$tab[$perso_id]['anticipation_demande']!=$tab[$perso_id]['anticipation_utilise']?"bold":null;
-        }
 
+            foreach ($tab[$perso_id] as $key => $value) {
+                if ($key != 'nom' && $key != 'prenom' && $key != 'agent') {
+                    if ($value == 0) {
+                        $tab[$perso_id][$key] = '';
+                    } elseif ($GLOBALS['config']['Conges-Mode'] == 'jours') {
+                        $tab[$perso_id][$key] = $helper->HumanReadableDuration($tab[$perso_id][$key]);
+                    } else {
+                        $tab[$perso_id][$key] = heure4($tab[$perso_id][$key]);
+                    }
+                }
+            }
+        }
         $this->elements=$tab;
     }
 

--- a/templates/conges/accounts.html.twig
+++ b/templates/conges/accounts.html.twig
@@ -99,91 +99,91 @@
           <tr style='vertical-align:top;'>
             <td>{{ a.agent }}</td>
             <td class='aRight nowrap'>
-              {{ a.conge_annuel | hours }}
+              {{ a.conge_annuel }}
               {% if hours_to_days %}
                 <br />{{ a.conge_annuel | hoursToDays(a.id) }}
               {% endif %}
             </td>
 
             <td class='aRight nowrap'>
-              {{ a.conge_initial | hours }}
+              {{ a.conge_initial }}
               {% if hours_to_days %}
                 <br />{{ a.conge_initial | hoursToDays(a.id) }}
               {% endif %}
             </td>
 
             <td class='aRight nowrap'>
-              {{ a.conge_utilise | hours }}
+              {{ a.conge_utilise }}
               {% if hours_to_days %}
                 <br />{{ a.conge_utilise | hoursToDays(a.id) }}
               {% endif %}
             </td>
 
             <td class='aRight nowrap'>
-              {{ a.conge_restant | hours }}
+              {{ a.conge_restant }}
               {% if hours_to_days %}
                 <br />{{ a.conge_restant | hoursToDays(a.id) }}
               {% endif %}
             </td>
 
             <td class='aRight nowrap'>
-              {{ a.reliquat_initial | hours }}
+              {{ a.reliquat_initial }}
               {% if hours_to_days %}
                 <br />{{ a.reliquat_initial | hoursToDays(a.id) }}
               {% endif %}
             </td>
 
             <td class='aRight nowrap'>
-              {{ a.reliquat_utilise | hours }}
+              {{ a.reliquat_utilise }}
               {% if hours_to_days %}
                 <br />{{ a.reliquat_utilise | hoursToDays(a.id) }}
               {% endif %}
             </td>
 
             <td class='aRight nowrap'>
-              {{ a.reliquat_restant | hours }}
+              {{ a.reliquat_restant }}
               {% if hours_to_days %}
                 <br />{{ a.reliquat_restant | hoursToDays(a.id) }}
               {% endif %}
             </td>
 
             <td class='aRight nowrap'>
-              {{ a.recup_initial | hours }}
+              {{ a.recup_initial }}
               {% if hours_to_days %}
                 <br />{{ a.recup_initial | hoursToDays(a.id) }}
               {% endif %}
             </td>
 
             <td class='aRight nowrap'>
-              {{ a.recup_utilise | hours }}
+              {{ a.recup_utilise }}
               {% if hours_to_days %}
                 <br />{{ a.recup_utilise | hoursToDays(a.id) }}
               {% endif %}
             </td>
 
             <td class='aRight nowrap'>
-              {{ a.recup_restant | hours }}
+              {{ a.recup_restant }}
               {% if hours_to_days %}
                 <br />{{ a.recup_restant | hoursToDays(a.id) }}
               {% endif %}
             </td>
 
             <td class='aRight nowrap'>
-              {{ a.anticipation_initial | hours }}
+              {{ a.anticipation_initial }}
               {% if hours_to_days %}
                 <br />{{ a.anticipation_initial | hoursToDays(a.id) }}
               {% endif %}
             </td>
 
             <td class='aRight nowrap'>
-              {{ a.anticipation_utilise | hours }}
+              {{ a.anticipation_utilise }}
               {% if hours_to_days %}
                 <br />{{ a.anticipation_utilise | hoursToDays(a.id) }}
               {% endif %}
             </td>
 
             <td class='aRight nowrap'>
-              {{ a.anticipation_restant | hours }}
+              {{ a.anticipation_restant }}
               {% if hours_to_days %}
                 <br />{{ a.anticipation_restant | hoursToDays(a.id) }}
               {% endif %}
@@ -195,91 +195,91 @@
           <tr style='vertical-align:top;' class='orange'>
             <td>{{ a.agent }}</td>
             <td class='aRight nowrap'>
-              {{ a.conge_annuel | hours }}
+              {{ a.conge_annuel }}
               {% if hours_to_days %}
                 <br />{{ a.conge_annuel | hoursToDays(a.id) }}
               {% endif %}
             </td>
 
             <td class='aRight nowrap'>
-              {{ a.conge_initial | hours }}
+              {{ a.conge_initial }}
               {% if hours_to_days %}
                 <br />{{ a.conge_initial | hoursToDays(a.id) }}
               {% endif %}
             </td>
 
             <td class='aRight nowrap {$elem['conge_classe']}'>
-              {{ a.conge_demande | hours }}
+              {{ a.conge_demande }}
               {% if hours_to_days %}
                 <br />{{ a.conge_demande | hoursToDays(a.id) }}
               {% endif %}
             </td>
 
             <td class='aRight nowrap {$elem['conge_classe']}'>
-              {{ a.conge_en_attente | hours }}
+              {{ a.conge_en_attente }}
               {% if hours_to_days %}
                 <br />{{ a.conge_en_attente | hoursToDays(a.id) }}
               {% endif %}
             </td>
 
             <td class='aRight nowrap'>
-              {{ a.reliquat_initial | hours }}
+              {{ a.reliquat_initial }}
               {% if hours_to_days %}
                 <br />{{ a.reliquat_initial | hoursToDays(a.id) }}
               {% endif %}
             </td>
 
             <td class='aRight nowrap {$elem['reliquat_classe']}'>
-              {{ a.reliquat_demande | hours }}
+              {{ a.reliquat_demande }}
               {% if hours_to_days %}
                 <br />{{ a.reliquat_demande | hoursToDays(a.id) }}
               {% endif %}
             </td>
 
             <td class='aRight nowrap {$elem['reliquat_classe']}'>
-              {{ a.reliquat_en_attente | hours }}
+              {{ a.reliquat_en_attente }}
               {% if hours_to_days %}
                 <br />{{ a.reliquat_en_attente | hoursToDays(a.id) }}
               {% endif %}
             </td>
 
             <td class='aRight nowrap'>
-              {{ a.recup_initial | hours }}
+              {{ a.recup_initial }}
               {% if hours_to_days %}
                 <br />{{ a.recup_initial | hoursToDays(a.id) }}
               {% endif %}
             </td>
 
             <td class='aRight nowrap {$elem['recup_classe']}'>
-              {{ a.recup_demande | hours }}
+              {{ a.recup_demande }}
               {% if hours_to_days %}
                 <br />{{ a.recup_demande | hoursToDays(a.id) }}
               {% endif %}
             </td>
 
             <td class='aRight nowrap {$elem['recup_classe']}'>
-              {{ a.recup_en_attente | hours }}
+              {{ a.recup_en_attente }}
               {% if hours_to_days %}
                 <br />{{ a.recup_en_attente | hoursToDays(a.id) }}
               {% endif %}
             </td>
 
             <td class='aRight nowrap'>
-              {{ a.anticipation_initial | hours }}
+              {{ a.anticipation_initial }}
               {% if hours_to_days %}
                 <br />{{ a.anticipation_initial | hoursToDays(a.id) }}
               {% endif %}
             </td>
 
             <td class='aRight nowrap {$elem['anticipation_classe']}'>
-              {{ a.anticipation_demande | hours }}
+              {{ a.anticipation_demande }}
               {% if hours_to_days %}
                 <br />{{ a.anticipation_demande | hoursToDays(a.id) }}
               {% endif %}
             </td>
 
             <td class='aRight nowrap {$elem['anticipation_classe']}'>
-              {{ a.anticipation_en_attente | hours }}
+              {{ a.anticipation_en_attente }}
               {% if hours_to_days %}
                 <br />{{ a.anticipation_en_attente | hoursToDays(a.id) }}
               {% endif %}


### PR DESCRIPTION
Currently, /holiday/accounts (Congés -> Crédits) is always displayed in hours regardless of the Conges-Mode parameter.

Test plan:

1) Without the patch, values are always displayed in hours, even if
   Conges-Mode is set to "jours"

2) With the patch, check that values are displayed accordingly to Conges-Mode
   setting.