### PR TITLE
MT41027: Add absence block

### DIFF
--- a/config/permissions.yaml
+++ b/config/permissions.yaml
@@ -13,6 +13,16 @@
     - 100
 "absence.statuses":
     - 100
+"absence.block.add":
+    - 301
+"absence.block.delete":
+    - 301
+"absence.block.edit":
+    - 301
+"absence.block.index":
+    - 301
+"absence.block.update":
+    - 301
 "absences.document.index":
     - 100
 "absences.document.delete":

--- a/public/absences/js/modif.js
+++ b/public/absences/js/modif.js
@@ -994,6 +994,17 @@ function verif_absences(ctrl_form){
         }
       }
 
+      if (result['has_block'] >= 1 && retour == true) {
+        if (admin == true) {
+          if (!confirm("Vous essayer de placer une absence sur une période bloquée.\nVoulez-vous continuer ?")){
+            retour = false;
+          }
+        } else {
+          CJInfo("Vous ne pouvez pas enregistrer d'absences pour les dates suivantes car elles rentrent en conflit avec une période bloquée.", "error");
+          retour = false;
+        }
+      }
+
       // Contrôle si les agents apparaissent dans des plannings validés
       // Pour chaque agent
       if (retour == true) {

--- a/public/conges/class.conges.php
+++ b/public/conges/class.conges.php
@@ -883,7 +883,7 @@ class conges
                 $semaine=$d->semaine3;
                 // Récupération du numéro du site concerné par la date courante
                 $offset=$jour-1+($semaine*7)-7;
-                if (array_key_exists($offset, $temps)) {
+                if (is_array($temps) && array_key_exists($offset, $temps)) {
                     $site = 1;
                     if (!empty($temps[$offset][4])) {
                         $site=$temps[$offset][4];

--- a/public/conges/js/script.conges.js
+++ b/public/conges/js/script.conges.js
@@ -560,6 +560,17 @@ function verifConges(){
         }
       }
 
+      if (result['has_block'] >= 1 && valid == true) {
+        if (admin == true) {
+          if (!confirm("Vous essayer de placer un congé sur une période bloquée.\nVoulez-vous continuer ?")){
+            valid = false;
+          }
+        } else {
+          CJInfo("Vous ne pouvez pas enregistrer de congés pour les dates suivantes car elles rentrent en conflit avec une période bloquée.", "error");
+          valid = false;
+        }
+      }
+
       // Contrôle si les agents apparaissent dans des plannings validés
       // Pour chaque agent
       if (valid == true) {

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -402,6 +402,14 @@ function deleteAbsenceInfo(id) {
     }
 }
 
+function deleteAbsenceBlock(id) {
+    if (confirm("Êtes-vous sûr(e) de vouloir supprimer ce blocage ?")) {
+        $('#form').prepend("<input type='hidden' name='_method' value='DELETE' />");
+        $('#form').prepend("<input type='hidden' name='id' value='" + id + "' />");
+        $('#form').submit();
+    }
+}
+
 function deleteAdminInfo(id) {
     if (confirm("Etes vous sûr(e) de vouloir supprimer cette information ?")) {
         $('#form').prepend("<input type='hidden' name='_method' value='DEL' />");

--- a/public/setup/atomicupdate/MT41027.php
+++ b/public/setup/atomicupdate/MT41027.php
@@ -1,0 +1,14 @@
+<?php
+
+$sql[] = "INSERT IGNORE INTO `{$dbprefix}config` (`nom`, `type`, `valeur`, `commentaires`, `categorie`, `valeurs`, `extra`, `ordre`) VALUES ('Absences-blocage', 'boolean', '0', 'Permettre le blocage des absences et congés sur une période définie par les gestionnaires. Ce paramètre empêchera les agents qui n\'ont pas le droits de gérer les absences d\'enregistrer absences et congés sur les périodes définies. En configuration multi-sites, les agents de tous les sites seront bloqués sans distinction.', 'Absences', '', NULL, 5);";
+
+$sql[] = "INSERT IGNORE INTO `{$dbprefix}menu` (`niveau1`, `niveau2`, `titre`, `url`, `condition`) VALUES (10, 25, 'Bloquer les absences', '/absence/block', 'config=Absences-blocage');";
+
+$sql[]="CREATE TABLE IF NOT EXISTS `{$dbprefix}absence_blocks` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `start` date NOT NULL DEFAULT '0000-00-00',
+  `end` date NOT NULL DEFAULT '0000-00-00',
+  `comment` text COLLATE utf8mb4_unicode_ci NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;";
+

--- a/public/setup/db_data.php
+++ b/public/setup/db_data.php
@@ -158,6 +158,7 @@ $sql[] = "INSERT INTO `{$dbprefix}config` (`nom`, `type`, `valeur`, `valeurs`, `
 $sql[] = "INSERT INTO `{$dbprefix}config` (`nom`, `type`, `valeur`, `valeurs`, `categorie`, `commentaires`, `ordre` ) VALUES ('Conges-Mode', 'enum2', 'heures', '[[\"heures\",\"Heures\"],[\"jours\",\"Jours\"]]', 'Congés', 'Décompte des congés en heures ou en jours', '2');";
 $sql[] = "INSERT IGNORE INTO `{$dbprefix}config` ( `nom`, `type`, `valeur`, `commentaires`, `categorie`, `valeurs`, `extra`, `ordre`) VALUES ('Conges-transfer-comp-time', 'boolean', '0', 'Transférer les récupérations restantes sur le reliquat', 'Congés', '', NULL, '16');";
 $sql[]="INSERT INTO `{$dbprefix}config` (`nom`, `type`, `valeur`, `commentaires`, `categorie`, `ordre`) VALUES ('Absences-validation','boolean','0','Les absences doivent &ecirc;tre valid&eacute;es par un administrateur avant d&apos;&ecirc;tre prises en compte','Absences','30');";
+$sql[] = "INSERT IGNORE INTO `{$dbprefix}config` (`nom`, `type`, `valeur`, `commentaires`, `categorie`, `valeurs`, `extra`, `ordre`) VALUES ('Absences-blocage', 'boolean', '0', 'Permettre le blocage des absences et congés sur une période définie par les gestionnaires. Ce paramètre empêchera les agents qui n\'ont pas le droits de gérer les absences d\'enregistrer absences et congés sur les périodes définies. En configuration multi-sites, les agents de tous les sites seront bloqués sans distinction.', 'Absences', '', NULL, 5);";
 // Affichage absences non validées
 $sql[]="INSERT INTO `{$dbprefix}config` (`nom`, `type`, `valeur`, `categorie`, `commentaires`, `ordre` ) VALUES
   ('Absences-non-validees','boolean','1','Absences', 'Dans les plannings, afficher en rouge les agents pour lesquels une absence non-valid&eacute;e est enregistr&eacute;e','35');";
@@ -380,6 +381,7 @@ $sql[]="INSERT INTO `{$dbprefix}menu` (`niveau1`,`niveau2`,`titre`,`url`,`condit
   ('10','0','Absences','/absence',NULL),
   ('10','10','Voir les absences','/absence',NULL),
   ('10','20','Ajouter une absence','/absence/add',NULL),
+  ('10','25','Bloquer les absences','/absence/block','config=Absences-blocage'),
   ('10','30','Informations','/absences/info', 'config!=Plannok'),
   ('15','0','Congés','/holiday/index','config=Conges-Enable'),
   ('15','10','Liste des cong&eacute;s','/holiday/index','config=Conges-Enable'),

--- a/public/setup/db_structure.php
+++ b/public/setup/db_structure.php
@@ -49,6 +49,14 @@ $sql[]="CREATE TABLE `{$dbprefix}absences` (
   KEY `groupe`(`groupe`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci;";
 
+$sql[]="CREATE TABLE `{$dbprefix}absence_blocks` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `start` date NOT NULL DEFAULT '0000-00-00',
+  `end` date NOT NULL DEFAULT '0000-00-00',
+  `comment` text COLLATE utf8mb4_unicode_ci NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;";
+
 $sql[]="CREATE TABLE `{$dbprefix}absences_infos` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `debut` date NOT NULL DEFAULT '0000-00-00',

--- a/src/Controller/AbsenceBlockController.php
+++ b/src/Controller/AbsenceBlockController.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace App\Controller;
+
+use App\Controller\BaseController;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\Routing\Annotation\Route;
+
+use App\Model\AbsenceBlock;
+
+class AbsenceBlockController extends BaseController
+{
+    /**
+     * @Route("/absence/block", name="absence.block.index", methods={"GET"})
+     */
+    public function index(Request $request, Session $session)
+    {
+        $today = date('Y-m-d');
+
+        $queryBuilder = $this->entityManager->createQueryBuilder();
+
+        $query = $queryBuilder->select(array('a'))
+            ->from(AbsenceBlock::class, 'a')
+            ->orderBy('a.start', 'ASC', 'a.end', 'ASC')
+            ->getQuery();
+
+        $this->templateParams( array('block' => $query->getResult()) );
+
+        return $this->output('absenceBlock/index.html.twig');
+    }
+
+    /**
+     * @Route("/absence/block/add", name="absence.block.add", methods={"GET"})
+     */
+    public function add(Request $request)
+    {
+        $this->templateParams(array(
+            'id'    => null,
+            'start' => null,
+            'end'   => null,
+            'text'  => null,
+        ));
+
+        return $this->output('absenceBlock/edit.html.twig');
+    }
+
+    /**
+     * @Route("/absence/block/{id}", name="absence.block.edit", methods={"GET"})
+     */
+    public function edit(Request $request)
+    {
+        $id = $request->get('id');
+
+        $block = $this->entityManager->getRepository(AbsenceBlock::class)->findOneById($id);
+
+        $this->templateParams(array(
+            'id'    => $id,
+            'start' => date_format($block->start(), "d/m/Y"),
+            'end'   => date_format($block->end(), "d/m/Y"),
+            'text'  => $block->comment()
+        ));
+
+        return $this->output('absenceBlock/edit.html.twig');
+    }
+
+    /**
+     * @Route("/absence/block", name="absence.block.update", methods={"POST"})
+     */
+    public function update(Request $request, Session $session)
+    {
+        if (!$this->csrf_protection($request)) {
+            $session->getFlashBag()->add('error', 'CSRF Token Error');
+            return $this->redirectToRoute('absence.block.index');
+        }
+
+        $id = $request->get('id');
+        $start = \DateTime::createFromFormat("d/m/Y", $request->get('start'));
+        $end = \DateTime::createFromFormat("d/m/Y", $request->get('end'));
+
+        if (empty($end)) {
+          $end = $start;
+        }
+
+        $text = trim($request->get('text'));
+
+        if ($id) {
+            $block = $this->entityManager->getRepository(AbsenceBlock::class)->find($id);
+            $block->start($start);
+            $block->end($end);
+            $block->comment($text);
+            $flash = "Le blocage a bien été modifié.";
+        } else {
+            // Store a new block
+            $block = new AbsenceBlock();
+            $block->start($start);
+            $block->end($end);
+            $block->comment($text);
+            $flash = "Le blocage a bien été enregistré.";
+        }
+
+        $this->entityManager->persist($block);
+        $this->entityManager->flush();
+
+        $session->getFlashBag()->add('notice', $flash);
+        return $this->redirectToRoute('absence.block.index');
+    }
+
+    /**
+     * @Route("/absence/block", name="absence.block.delete", methods={"DELETE"})
+     */
+    public function delete(Request $request, Session $session)
+    {
+        if (!$this->csrf_protection($request)) {
+            $session->getFlashBag()->add('error', 'CSRF Token Error');
+            return $this->redirectToRoute('absence.block.index');
+        }
+
+        $id = $request->get('id');
+
+        $block = $this->entityManager->getRepository(AbsenceBlock::class)->find($id);
+        $this->entityManager->remove($block);
+        $this->entityManager->flush();
+
+        $flash = "Le blocage a bien été supprimé.";
+
+        $session->getFlashBag()->add('notice', $flash);
+        return $this->redirectToRoute('absence.block.index');
+    }
+}

--- a/src/Controller/AbsenceBlockController.php
+++ b/src/Controller/AbsenceBlockController.php
@@ -17,16 +17,13 @@ class AbsenceBlockController extends BaseController
      */
     public function index(Request $request, Session $session)
     {
-        $today = date('Y-m-d');
+        $blocks = $this->entityManager->getRepository(AbsenceBlock::class)
+            ->findBy(
+                array(),
+                array('start' => 'ASC', 'end' => 'ASC'),
+            );
 
-        $queryBuilder = $this->entityManager->createQueryBuilder();
-
-        $query = $queryBuilder->select(array('a'))
-            ->from(AbsenceBlock::class, 'a')
-            ->orderBy('a.start', 'ASC', 'a.end', 'ASC')
-            ->getQuery();
-
-        $this->templateParams( array('block' => $query->getResult()) );
+        $this->templateParams( array('block' => $blocks) );
 
         return $this->output('absenceBlock/index.html.twig');
     }
@@ -47,13 +44,13 @@ class AbsenceBlockController extends BaseController
     }
 
     /**
-     * @Route("/absence/block/{id}", name="absence.block.edit", methods={"GET"})
+     * @Route("/absence/block/{id<\d+>}", name="absence.block.edit", methods={"GET"})
      */
     public function edit(Request $request)
     {
         $id = $request->get('id');
 
-        $block = $this->entityManager->getRepository(AbsenceBlock::class)->findOneById($id);
+        $block = $this->entityManager->getRepository(AbsenceBlock::class)->find($id);
 
         $this->templateParams(array(
             'id'    => $id,

--- a/src/Controller/AbsenceController.php
+++ b/src/Controller/AbsenceController.php
@@ -300,7 +300,7 @@ class AbsenceController extends BaseController
     }
 
     /**
-     * @Route("/absence/{id}", name="absence.edit", methods={"GET"})
+     * @Route("/absence/{id<\d+>}", name="absence.edit", methods={"GET"})
      */
     public function edit(Request $request)
     {

--- a/src/Controller/AjaxController.php
+++ b/src/Controller/AjaxController.php
@@ -5,6 +5,7 @@ namespace App\Controller;
 use App\Controller\BaseController;
 use App\Model\AbsenceReason;
 use App\Model\Agent;
+use App\PlanningBiblio\Helper\AbsenceBlockHelper;
 
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
@@ -291,6 +292,11 @@ class AjaxController extends BaseController
           ->getValidationLevelFor($_SESSION['login_id']);
 
       $result['admin'] = ($adminN1 or $adminN2);
+
+      if ($this->config('Absences-blocage') == 1) {
+          $absenceBlockHelper = new AbsenceBlockHelper();
+          $result['has_block'] = $absenceBlockHelper->hasBlock($debut, $fin);
+      }
 
       $result = json_encode($result);
 

--- a/src/Model/AbsenceBlock.php
+++ b/src/Model/AbsenceBlock.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Model;
+
+use Doctrine\ORM\Mapping\{Entity, Table, Id, Column, GeneratedValue};
+
+/**
+ * @Entity @Table(name="absence_blocks")
+ **/
+class AbsenceBlock extends PLBEntity
+{
+    /** @Id @Column(type="integer") @GeneratedValue **/
+    protected $id;
+
+    /** @Column(type="date") **/
+    protected $start;
+
+    /** @Column(type="date") **/
+    protected $end;
+
+    /** @Column(type="text") **/
+    protected $comment;
+
+}

--- a/src/PlanningBiblio/Helper/AbsenceBlockHelper.php
+++ b/src/PlanningBiblio/Helper/AbsenceBlockHelper.php
@@ -21,18 +21,19 @@ class AbsenceBlockHelper extends BaseHelper
         }
 
         $queryBuilder = $this->entityManager->createQueryBuilder();
+
         $query = $queryBuilder->select('COUNT(b.id) AS blockscount')
             ->from(AbsenceBlock::class,'b')
-            ->where('b.start <= :start AND b.end >= :end') // OUTSIDE
-            ->orWhere('b.start <= :start AND b.end <= :end') // "ON THE LEFT"
-            ->orWhere('b.start >= :start AND b.end <= :end') // INSIDE
-            ->orWhere('b.start >= :start AND b.end >= :end') // "ON THE RIGHT"
+            ->where('b.start <= :end AND b.end >= :start')
             ->setParameters(array('start' => $start, 'end' => $end))
             ->getQuery();
+
         $result = $query->getResult();
-        foreach ($result as $elem) {
-            return $elem['blockscount'];
+
+        if (!empty($result)) {
+            return $result[0]['blockscount'];
         }
+
         return -1;
     }
 }

--- a/src/PlanningBiblio/Helper/AbsenceBlockHelper.php
+++ b/src/PlanningBiblio/Helper/AbsenceBlockHelper.php
@@ -20,11 +20,11 @@ class AbsenceBlockHelper extends BaseHelper
             return -1;
         }
 
-        $queryBuilder = $this->entityManager->createQueryBuilder();
+        $qb = $this->entityManager->createQueryBuilder();
 
-        $query = $queryBuilder->select('COUNT(b.id) AS blockscount')
+        $query = $qb->select('COUNT(b.id) AS blockscount')
             ->from(AbsenceBlock::class,'b')
-            ->where('b.start <= :end AND b.end >= :start')
+            ->where('b.start <= :end AND ' . $qb->expr()->concat('b.end', $qb->expr()->literal(' 23:59:59')) . ' >= :start')
             ->setParameters(array('start' => $start, 'end' => $end))
             ->getQuery();
 

--- a/src/PlanningBiblio/Helper/AbsenceBlockHelper.php
+++ b/src/PlanningBiblio/Helper/AbsenceBlockHelper.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\PlanningBiblio\Helper;
+
+use App\PlanningBiblio\Helper\BaseHelper;
+
+use App\Model\AbsenceBlock;
+
+class AbsenceBlockHelper extends BaseHelper
+{
+
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    public function hasBlock($start, $end)
+    {
+        if (!$start || !$end) {
+            return -1;
+        }
+
+        $queryBuilder = $this->entityManager->createQueryBuilder();
+        $query = $queryBuilder->select('COUNT(b.id) AS blockscount')
+            ->from(AbsenceBlock::class,'b')
+            ->where('b.start <= :start AND b.end >= :end') // OUTSIDE
+            ->orWhere('b.start <= :start AND b.end <= :end') // "ON THE LEFT"
+            ->orWhere('b.start >= :start AND b.end <= :end') // INSIDE
+            ->orWhere('b.start >= :start AND b.end >= :end') // "ON THE RIGHT"
+            ->setParameters(array('start' => $start, 'end' => $end))
+            ->getQuery();
+        $result = $query->getResult();
+        foreach ($result as $elem) {
+            return $elem['blockscount'];
+        }
+        return -1;
+    }
+}

--- a/templates/absenceBlock/edit.html.twig
+++ b/templates/absenceBlock/edit.html.twig
@@ -1,0 +1,59 @@
+{# absenceBlock/edit.html.twig #}
+
+{% extends 'base.html.twig' %}
+
+{% block page %}
+    <div id="content-form">
+        <h3>Blocage d'absences</h3>
+
+        <div class="admin-div">
+            {% if id %}
+                <h4>Modifications des blocages d'absences</h4>
+            {% else %}
+                <h4>Ajout d'un blocage d'absence</h4>
+            {% endif %}
+
+            <form id='form' method='POST' action='{{ asset('absence/block') }}' name='form' onsubmit='return verif_form("start=date1;end=date2;text");'>
+                <input type="hidden" name="_token" id="_token" value="{{ csrf_token('') }}"/>
+                <input type='hidden' name='id' value='{{ id }}'/>
+
+                <table class='tableauFiches'>
+                <tr>
+                    <td><label >Date de début</label> </td>
+                    <td>
+                    <input type='text' name='start' value='{{ start }}' style='width:100%;' class='datepicker'/>
+                    </td>
+                </tr>
+
+                <tr>
+                    <td><label>Date de fin</label></td>
+                    <td>
+                    <input type='text' name='end' value='{{ end }}' style='width:100%;' class='datepicker'/>
+                    </td>
+                </tr>
+
+                <tr>
+                    <td><label>Commentaire</label></td>
+                    <td>
+                    <textarea name='text' rows='3' cols='25' class='ui-widget-content ui-corner-all'>{{ text }}</textarea>
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>&nbsp;</td>
+                </tr>
+
+                <tr>
+                    <td colspan='2' style='text-align:center;'>
+                    <a href='{{ asset('absence/block') }}' class='ui-button ui-button-type2' style='margin-left:30px;'>Annuler</a>
+                    {% if id %}
+                        <a href='javascript:deleteAbsenceBlock({{ id }});' class='ui-button ui-button-type3' style='margin-left:30px;'>Supprimer</a>
+                    {% endif %}
+                    <input type='submit' value='Valider' class='ui-button' style='margin-left:30px;'/>
+                    </td>
+                </tr>
+                </table>
+            </form>
+        </div>
+    </div>
+{% endblock %}

--- a/templates/absenceBlock/edit.html.twig
+++ b/templates/absenceBlock/edit.html.twig
@@ -13,29 +13,29 @@
                 <h4>Ajout d'un blocage d'absence</h4>
             {% endif %}
 
-            <form id='form' method='POST' action='{{ asset('absence/block') }}' name='form' onsubmit='return verif_form("start=date1;end=date2;text");'>
+            <form id="form" method="POST" action="{{ asset("absence/block") }}" name="form" onsubmit="return verif_form('start=date1;end=date2');">
                 <input type="hidden" name="_token" id="_token" value="{{ csrf_token('') }}"/>
-                <input type='hidden' name='id' value='{{ id }}'/>
+                <input type="hidden" name="id" value="{{ id }}"/>
 
-                <table class='tableauFiches'>
+                <table class="tableauFiches">
                 <tr>
                     <td><label >Date de début</label> </td>
                     <td>
-                    <input type='text' name='start' value='{{ start }}' style='width:100%;' class='datepicker'/>
+                    <input type="text" name="start" value="{{ start }}" style="width:100%;" class="datepicker"/>
                     </td>
                 </tr>
 
                 <tr>
                     <td><label>Date de fin</label></td>
                     <td>
-                    <input type='text' name='end' value='{{ end }}' style='width:100%;' class='datepicker'/>
+                    <input type="text" name="end" value="{{ end }}" style="width:100%;" class="datepicker"/>
                     </td>
                 </tr>
 
                 <tr>
                     <td><label>Commentaire</label></td>
                     <td>
-                    <textarea name='text' rows='3' cols='25' class='ui-widget-content ui-corner-all'>{{ text }}</textarea>
+                    <textarea name="text" rows="3" cols="25" class="ui-widget-content ui-corner-all">{{ text }}</textarea>
                     </td>
                 </tr>
 
@@ -44,12 +44,12 @@
                 </tr>
 
                 <tr>
-                    <td colspan='2' style='text-align:center;'>
-                    <a href='{{ asset('absence/block') }}' class='ui-button ui-button-type2' style='margin-left:30px;'>Annuler</a>
+                    <td colspan="2" style="text-align:center;">
+                    <a href="{{ asset('absence/block') }}" class="ui-button ui-button-type2" style="margin-left:30px;">Annuler</a>
                     {% if id %}
-                        <a href='javascript:deleteAbsenceBlock({{ id }});' class='ui-button ui-button-type3' style='margin-left:30px;'>Supprimer</a>
+                        <a href="javascript:deleteAbsenceBlock({{ id }});" class="ui-button ui-button-type3" style="margin-left:30px;">Supprimer</a>
                     {% endif %}
-                    <input type='submit' value='Valider' class='ui-button' style='margin-left:30px;'/>
+                    <input type="submit" value="Valider" class="ui-button" style="margin-left:30px;"/>
                     </td>
                 </tr>
                 </table>

--- a/templates/absenceBlock/index.html.twig
+++ b/templates/absenceBlock/index.html.twig
@@ -1,0 +1,44 @@
+{# absenceBlock/index.html.twig #}
+
+{% extends 'base.html.twig' %}
+
+{% block page %}
+    <h3>Blocage d'absences</h3>
+
+    <div class='top-button-div'>
+        <a href='{{ asset("absence/block/add") }}' class='ui-button'>Ajouter</a>
+    </div>
+
+    {% if block %}
+        <form id="form" method="POST">
+            <input type="hidden" name="_token" value="{{ csrf_token('') }}"/>
+            <table class='CJDataTable' data-sort='[[1,"asc"],[2,"asc"]]' id='AbsenceBlockTable'>
+                <thead>
+                    <tr>
+                        <th class='dataTableNoSort'></th>
+                        <th class='dataTableDateFR'>Début</th>
+                        <th class='dataTableDateFR'>Fin</th>
+                        <th>Commentaire</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {%for elem in block %}
+                        <tr>
+                            <td>
+                                <a href='{{ asset('absence/block/') }}{{elem.id}}'>
+                                    <span class='pl-icon pl-icon-edit' title='Éditer'></span>
+                                </a>
+                                <a href='javascript:deleteAbsenceBlock({{elem.id}});'><span class='pl-icon pl-icon-dropblack' title='Supprimer' /></a>
+                            </td>
+                            <td>{{ elem.start | date("d/m/Y") }}</td>
+                            <td>{{ elem.end | date("d/m/Y")  }}</td>
+                            <td>{{ elem.comment | nl2br }}</td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </form>
+    {% else %}
+        <p>Aucun blocage enregistré.</p>
+    {% endif %}
+{% endblock %}

--- a/templates/absenceBlock/index.html.twig
+++ b/templates/absenceBlock/index.html.twig
@@ -5,19 +5,19 @@
 {% block page %}
     <h3>Blocage d'absences</h3>
 
-    <div class='top-button-div'>
-        <a href='{{ asset("absence/block/add") }}' class='ui-button'>Ajouter</a>
+    <div class="top-button-div">
+        <a href="{{ asset('absence/block/add') }}" class="ui-button">Ajouter</a>
     </div>
 
     {% if block %}
         <form id="form" method="POST">
             <input type="hidden" name="_token" value="{{ csrf_token('') }}"/>
-            <table class='CJDataTable' data-sort='[[1,"asc"],[2,"asc"]]' id='AbsenceBlockTable'>
+            <table class="CJDataTable" data-sort='[[1,"asc"],[2,"asc"]]' id="AbsenceBlockTable">
                 <thead>
                     <tr>
-                        <th class='dataTableNoSort'></th>
-                        <th class='dataTableDateFR'>Début</th>
-                        <th class='dataTableDateFR'>Fin</th>
+                        <th class="dataTableNoSort"></th>
+                        <th class="dataTableDateFR">Début</th>
+                        <th class="dataTableDateFR">Fin</th>
                         <th>Commentaire</th>
                     </tr>
                 </thead>
@@ -25,13 +25,13 @@
                     {%for elem in block %}
                         <tr>
                             <td>
-                                <a href='{{ asset('absence/block/') }}{{elem.id}}'>
-                                    <span class='pl-icon pl-icon-edit' title='Éditer'></span>
+                                <a href="{{ asset('absence/block/') }}{{elem.id}}">
+                                    <span class="pl-icon pl-icon-edit" title="Éditer"></span>
                                 </a>
-                                <a href='javascript:deleteAbsenceBlock({{elem.id}});'><span class='pl-icon pl-icon-dropblack' title='Supprimer' /></a>
+                                <a href="javascript:deleteAbsenceBlock({{elem.id}});"><span class="pl-icon pl-icon-dropblack" title="Supprimer" /></a>
                             </td>
-                            <td>{{ elem.start | date("d/m/Y") }}</td>
-                            <td>{{ elem.end | date("d/m/Y")  }}</td>
+                            <td>{{ elem.start | date('d/m/Y') }}</td>
+                            <td>{{ elem.end | date('d/m/Y')  }}</td>
                             <td>{{ elem.comment | nl2br }}</td>
                         </tr>
                     {% endfor %}

--- a/templates/conges/add.html.twig
+++ b/templates/conges/add.html.twig
@@ -357,9 +357,9 @@
       </tr>
     </table>
     <div class="red align-info">
-      {% if holifay_info %}
+      {% if holiday_info %}
         <b>Informations sur les congés :</b><br/>
-        {% for i in holifay_info %}
+        {% for i in holiday_info %}
           Du {{ i.start }} au {{ i.end }} :<br/>{{ i.texte|nl2br }}<br/><br/>
         {% endfor %}
       {% endif %}


### PR DESCRIPTION
A new configuration option "Absences-blocage" allows to define periods during which absences and holidays will be prevented from being added.

Administrators, however, will be warned with a message and will be able to override the blocking.

Test plan:

 1) Enable "Absences-blocage" configuration option
 2) Go to /absence/block (Absences -> Bloquer les absences)
 3) Define one or more new periods
 4) Check that you can edit and delete periods
 5) Try to add or edit an absence or an holiday which overlaps in any way one
    of the previoulsy defined periods
 6) Check that, as a user, you cannot add or edit the absence or holiday
 7) Check that, as an administrator, you have a warning message and are able to
    override the blocking