### PR TITLE
MT41411: Use utf8-aware function mb_substr (instead of substr) in plannings

### DIFF
--- a/public/planning/poste/class.planning.php
+++ b/public/planning/poste/class.planning.php
@@ -278,7 +278,7 @@ class planning
         
                 $nom = $elem['nom'];
                 if ($elem['prenom']) {
-                    $nom.=" ".substr($elem['prenom'], 0, 1).".";
+                    $nom.=" ".mb_substr($elem['prenom'], 0, 1).".";
                 }
 
                 // Si sans repas, on ajoute (SR) à l'affichage


### PR DESCRIPTION
Test plan:

 - Without the patch, a right-click on a planning will not work if one of the agents in the right-click list has an utf8 first character (like an accent, "é" for example).

 - With the patch, the right-click list will be shown, and the agent first name will be correctly shortened ("Émile" will become "É." for example).