### PR TITLE
MT41650: Use utf8-aware function mb_substr (instead of substr) in plannings

### DIFF
--- a/public/planning/poste/fonctions.php
+++ b/public/planning/poste/fonctions.php
@@ -37,7 +37,7 @@ function cellule_poste($date, $debut, $fin, $colspan, $output, $poste, $site)
                 $nom_affiche=$elem['nom'];
                 $title = $elem['nom'];
                 if ($elem['prenom']) {
-                    $nom_affiche.=" ".substr($elem['prenom'], 0, 1).".";
+                    $nom_affiche.=" ".mb_substr($elem['prenom'], 0, 1).".";
                     $title .= ' ' . $elem['prenom'];
                 }
 


### PR DESCRIPTION
Test plan:

 - Without the patch, reloading a planning page having an already added agent with an utf8 first character in his first name (like an accent, "é" for example) will display the Unicode Replacement Character: �

 - With the patch, the agent first name will be correctly shortened ("Émile" will become "É." for example).

See Also:
MT41411: Use utf8-aware function mb_substr (instead of substr) in plannings #934