### PR TITLE
MT41028: Change the warning message for reccuring absences with end date

### DIFF
--- a/public/absences/js/modif.js
+++ b/public/absences/js/modif.js
@@ -386,8 +386,8 @@ $(function() {
 
   $("#recurrence-enddate-alert").dialog({
     autoOpen: false,
-    height: 200,
-    width: 650,
+    height: 180,
+    width: 600,
     modal: true,
     buttons: {
       "Oui": function() {

--- a/templates/absences/add.html.twig
+++ b/templates/absences/add.html.twig
@@ -281,9 +281,9 @@
         {% endif %}
 
       </div>
-      <div id="recurrence-enddate-alert" title="Date de fin de récurrence" class='noprint' style='display:none;'>Attention, vous vous apprêtez à enregistrer une absence récurrente. La fin de la série
-sera configurée dans la fenêtre de configuration de la récurrence et ne doit pas être saisie dans le formulaire d'absence.<br />
-Voulez-vous supprimer la date de fin choisie ?
+      <div id="recurrence-enddate-alert" title="Date de fin de récurrence" class='noprint' style='display:none;'>
+        Pour les absences récurrentes, la date de fin ne doit pas être saisie dans le formulaire d'absence mais dans la fenêtre de configuration de la récurrence.<br/>
+        Voulez-vous supprimer la date de fin choisie ?
       </div>
       <div id="recurrence-form" title="Récurrence" class='noprint' style='display:none;'>
         <p class="validateTips">&nbsp;</p>


### PR DESCRIPTION
MT41028: Change the warning message for recurring absences with end date

La PR change le message pour 
"
Pour les absences récurrentes, la date de fin ne doit pas être saisie dans le formulaire d'absence mais dans la fenêtre de configuration de la récurrence.
Voulez-vous supprimer la date de fin choisie ?"

Et réduit la taille de la fenêtre.