### PR TITLE
MT40009: Fix comp time display in 'My Account' when negative

### DIFF
--- a/public/include/function.php
+++ b/public/include/function.php
@@ -1038,6 +1038,11 @@ function heure4($heure, $return0=false)
         $heure = number_format($hre, 2, '.', '');
     } else {
         if (is_numeric($heure)) {
+            $negative = false;
+            if ($heure < 0) {
+                $negative = true;
+                $heure = abs($heure);
+            }
             $hre = floor($heure);
             $centiemes = $heure - $hre;
             $minutes = $centiemes * 0.6;
@@ -1051,6 +1056,9 @@ function heure4($heure, $return0=false)
                 $hre -= $minutes;
             }
             $heure = number_format($hre, 2, 'h', ' ');
+            if ($negative == true) {
+                $heure = '-' . $heure;
+            }
         }
     }
     return $heure;

--- a/tests/Include/IncludeFunctionTest.php
+++ b/tests/Include/IncludeFunctionTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once(__DIR__ . '/../../public/include/function.php');
+
+class IncludeFunctionTest extends TestCase
+{
+    public function testHeure4()
+    {
+        // Numeric to string
+        $heure = heure4('0');
+        $this->assertEquals($heure, null, '0 == null');
+
+        $heure = heure4('0', true);
+        $this->assertEquals($heure, '0h00', '0 == 0h00');
+
+        $heure = heure4('0.5');
+        $this->assertEquals($heure, '0h30', '0.5 == 0h30');
+
+        // MT 40009
+        $heure = heure4('-0.5');
+        $this->assertEquals($heure, '-0h30', '-0.5 == -0h30');
+
+        // String to numeric
+        $heure = heure4('0h30');
+        $this->assertEquals($heure, '0.50', '0h30 == 0.50');
+    }
+}


### PR DESCRIPTION
Test plan:
 - Have a negative comp time credit of half an hour
 - Without the patch, the display in 'My Account' shows -1h30
 - With the patch, it correctly shows -0h30

Unit tests: tests/Include/IncludeFunctionTest.php