### PR TITLE
MT42596: Escape teleworking reasons on planning context menu

### DIFF
--- a/public/absences/class.absences.php
+++ b/public/absences/class.absences.php
@@ -659,11 +659,12 @@ class absences
         }
 
         // Don't look for teleworking absences if the position is compatible with
+        $db=new db();
         if ($this->teleworking == false ) {
             $absence_reasons = $entityManager->getRepository(AbsenceReason::class)->findBy(array('teleworking' => 1));
             $teleworking_reasons = array();
             foreach ($absence_reasons as $reason) {
-                $teleworking_reasons[] = $reason->valeur();
+                $teleworking_reasons[] = $db->escapeString($reason->valeur());
             }
 
             $filter .= " AND `motif` NOT IN ('" . implode("','", $teleworking_reasons) . "') ";
@@ -695,7 +696,6 @@ class absences
       ."FROM `{$dbprefix}absences` INNER JOIN `{$dbprefix}personnel` "
       ."ON `{$dbprefix}absences`.`perso_id`=`{$dbprefix}personnel`.`id` "
       ."WHERE $dates $filter ORDER BY $sort;";
-        $db=new db();
         $db->query($req);
 
         $all=array();

--- a/src/Controller/PlanningJobController.php
+++ b/src/Controller/PlanningJobController.php
@@ -285,6 +285,9 @@ class PlanningJobController extends BaseController
         if ($teleworking) {
             $teleworking_reasons = $this->entityManager->getRepository(AbsenceReason::class)
                                                        ->getRemoteWorkingDescriptions();
+            foreach ($teleworking_reasons as $key => $value) {
+                $teleworking_reasons[$key] = $db->escapeString($value);
+            }
             $teleworking_exception = (!empty($teleworking_reasons) and is_array($teleworking_reasons)) ? "AND `motif` NOT IN ('" . implode("','", $teleworking_reasons) . "')" : null;
         }
 


### PR DESCRIPTION
Test plan:

 1) Have a teleworking reason with a character that must be escaped
    Example: Garde d'enfants

 2) Check that the context menu fails on planning cells using this reason

 3) Apply the patch

 4) Check that the context menu works