### PR TITLE
MT44329: When multiple recipents are given, Mail-From is used as TO

### DIFF
--- a/public/include/function.php
+++ b/public/include/function.php
@@ -257,13 +257,8 @@ class CJMail implements NotificationTransporterInterface
         $this->message = $message;
     }
 
-  
-    public function send()
+    public function setPHPMailer()
     {
-        if ($this->prepare() === false) {
-            return false;
-        }
-    
         $mail = new PHPMailer();
         $mail->setLanguage('fr');
         $mail->CharSet="utf-8";
@@ -293,11 +288,23 @@ class CJMail implements NotificationTransporterInterface
             foreach ($this->to as $elem) {
                 $mail->addBCC($elem);
             }
+            $mail->addAddress($mail->From);
         } else {
             $mail->AddAddress($this->to[0]);
         }
     
         $mail->Subject = $this->subject;
+
+        return $mail;
+    }
+
+    public function send()
+    {
+        if ($this->prepare() === false) {
+            return false;
+        }
+
+        $mail = $this->setPHPMailer();
 
         if (!$mail->Send()) {
             $this->error.=$mail->ErrorInfo ."\n";

--- a/tests/PlanningBiblio/NotifierTest.php
+++ b/tests/PlanningBiblio/NotifierTest.php
@@ -78,10 +78,26 @@ class NotifierTest extends TestCase
 
         $notifier = new Notifier();
 
-	$notifier->setRecipients('joe@bar.com');
+        $notifier->setRecipients('joe@bar.com');
         $notifier->setMessageCode('create_account');
-	$this->assertEquals('CJMail', get_class($notifier->getTransporter()), 'Default transporter is CJMail');
+        $this->assertEquals('CJMail', get_class($notifier->getTransporter()), 'Default transporter is CJMail');
         $this->assertEquals('', $notifier->getError(), 'No transporter error');
+    }
+
+    public function testMailRecipients()
+    {
+        $GLOBALS['config']['Mail-IsEnabled'] = 1;
+        $GLOBALS['config']['Mail-From'] = 'notifications@planno.fr';
+        $m = new CJMail();
+        $destinataires = ['alice@example.com', 'bob@example.com', 'eve@example.com'];
+        $m->to = $destinataires;
+        $mail = $m->setPHPMailer();
+        $bccAddresses = $mail->getBCCAddresses();
+        $this->assertEquals('alice@example.com', $bccAddresses[0][0], 'When multiple recipients are given, they are all in BCC (Alice)');
+        $this->assertEquals('bob@example.com', $bccAddresses[1][0], 'When multiple recipients are given, they are all in BCC (Bob)');
+        $this->assertEquals('eve@example.com', $bccAddresses[2][0], 'When multiple recipients are given, they are all in BCC (Eve)');
+        $toAddresses = $mail->getToAddresses();
+        $this->assertEquals('notifications@planno.fr', $toAddresses[0][0], 'When multiple recipients are given, Mail-From is used as TO');
     }
 
 }


### PR DESCRIPTION
When multiple recipients are given to CJMail, they are all set to BCC for PHPMailer.

This led to TO being empty, which we want to avoid.

This patchs adds system configuration Mail-From as TO when all recipients are set to BCC.

Unit tests: tests/PlanningBiblio/NotifierTest.php