### PR TITLE
MT43946: Add unsubscribe link in Planno's emails headers.

### DIFF
--- a/public/include/function.php
+++ b/public/include/function.php
@@ -260,7 +260,7 @@ class CJMail implements NotificationTransporterInterface
     }
 
 
-    public function setPHPMailer()
+    public function setPHPMailer($to)
     {
         $mail = new PHPMailer();
         $mail->setLanguage('fr');
@@ -283,10 +283,11 @@ class CJMail implements NotificationTransporterInterface
         $mail->Sender = $GLOBALS['config']['Mail-From'];
         $mail->From = $GLOBALS['config']['Mail-From'];
         $mail->FromName = $GLOBALS['config']['Mail-FromName'];
+        $mail->AddAddress($to);
         $mail->IsHTML();
     
         $mail->addCustomHeader("List-Unsubscribe-Post", "List-Unsubscribe=One-Click");
-        $mail->addCustomHeader("List-Unsubscribe", $GLOBALS['config']['URL'] . '/unsubscribe');
+        $mail->addCustomHeader("List-Unsubscribe", $GLOBALS['config']['URL'] . '/unsubscribe/' . encrypt($to));
 
         $mail->Subject = $this->subject;
         $mail->Body = $this->message;
@@ -303,8 +304,7 @@ class CJMail implements NotificationTransporterInterface
         $errors = array();
 
         foreach ($this->to as $elem) {
-            $mail = $this->setPHPMailer();
-            $mail->AddAddress($elem);
+            $mail = $this->setPHPMailer($elem);
 
             // notReally : for testing purposes
             if ($this->notReally) {

--- a/public/include/function.php
+++ b/public/include/function.php
@@ -285,6 +285,9 @@ class CJMail implements NotificationTransporterInterface
         $mail->FromName = $GLOBALS['config']['Mail-FromName'];
         $mail->IsHTML();
     
+        $mail->addCustomHeader("List-Unsubscribe-Post", "List-Unsubscribe=One-Click");
+        $mail->addCustomHeader("List-Unsubscribe", $GLOBALS['config']['URL'] . '/unsubscribe');
+
         $mail->Subject = $this->subject;
         $mail->Body = $this->message;
     

--- a/src/Controller/UnsubscribeController.php
+++ b/src/Controller/UnsubscribeController.php
@@ -11,15 +11,15 @@ use Symfony\Component\Routing\Annotation\Route;
 
 class UnsubscribeController extends BaseController
 {
-    #[Route(path: '/unsubscribe/{token}', name: 'unsubscribe.interactive', methods: ['GET'])]
-    public function interactiveUnsubscription(Request $request){
+    #[Route(path: '/unsubscribe/{token}', name: 'unsubscribe.interactive', requirements: ['token' => '.+'], methods: ['GET'])]
+    public function interactiveUnsubscription(Request $request, String $token){
 
         $session = $request->getSession();
 
         $show_menu = empty($session->get('loginId')) ? 0 : 1;
 
-        // TODO : decrypter le token
-        $mail = $request->get('token');
+        $mail = decrypt($token);
+        //error_log("Interactive unsubscription of $mail");
 
         $this->templateParams(array(
             'show_menu' => $show_menu,
@@ -29,12 +29,13 @@ class UnsubscribeController extends BaseController
         return $this->output('unsubscribe/index.html.twig');
     }
 
-    #[Route(path: '/unsubscribe', name: 'unsubscribe.nonInteractive', methods: ['POST'])]
-    public function nonInteractiveUnsubscription(Request $request) {
+    #[Route(path: '/unsubscribe/{token}', name: 'unsubscribe.nonInteractive', requirements: ['token' => '.+'], methods: ['POST'])]
+    public function nonInteractiveUnsubscription(Request $request, String $token) {
 
         // When the mail client uses List-Unsubscribe=One-Click
         if ($request->get('List-Unsubscribe') == 'One-Click') {
-            // Unsubscribe here
+            $mail = decrypt($token);
+            //error_log("Non-interactive unsubscription of $mail");
         }
 
         $response = new Response();
@@ -45,13 +46,14 @@ class UnsubscribeController extends BaseController
 
     }
 
-    #[Route(path: '/unsubscribe', name: 'unsubscribe.preflight', methods: ['OPTIONS'])]
+    #[Route(path: '/unsubscribe/{token}', name: 'unsubscribe.preflight', requirements: ['token' => '.+'],  methods: ['OPTIONS'])]
     public function returnPreflight(Request $request) {
         $response = new Response();
         $response->setStatusCode(200);
         $response->headers->set('Allow', 'OPTIONS, GET, POST');
         $response->headers->set('Access-Control-Allow-Origin', '*');
         $response->headers->set('Access-Control-Allow-Headers', '*');
+
         return $response;
 
     }

--- a/src/Controller/UnsubscribeController.php
+++ b/src/Controller/UnsubscribeController.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Controller;
+
+use App\Controller\BaseController;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+class UnsubscribeController extends BaseController
+{
+    #[Route(path: '/unsubscribe', name: 'unsubscribe.interactive', methods: ['GET'])]
+    public function interactiveUnsubscription(Request $request){
+
+        $session = $request->getSession();
+
+        $show_menu = empty($session->get('loginId')) ? 0 : 1;
+
+        $this->templateParams(array(
+            'show_menu' => $show_menu,
+        ));
+
+        return $this->output('unsubscribe/index.html.twig');
+    }
+
+    #[Route(path: '/unsubscribe', name: 'unsubscribe.nonInteractive', methods: ['POST'])]
+    public function nonInteractiveUnsubscription(Request $request) {
+
+        // When the mail client uses List-Unsubscribe=One-Click
+        if ($request->get('List-Unsubscribe') == 'One-Click') {
+            // Unsubscribe here
+        }
+
+        $response = new Response();
+        $response->headers->set('Access-Control-Allow-Origin', '*');
+        $response->headers->set('Access-Control-Allow-Headers', '*');
+        $response->setStatusCode(200);
+        return $response;
+
+    }
+
+    #[Route(path: '/unsubscribe', name: 'unsubscribe.preflight', methods: ['OPTIONS'])]
+    public function returnPreflight(Request $request) {
+        $response = new Response();
+        $response->setStatusCode(200);
+        $response->headers->set('Allow', 'OPTIONS, GET, POST');
+        $response->headers->set('Access-Control-Allow-Origin', '*');
+        $response->headers->set('Access-Control-Allow-Headers', '*');
+        return $response;
+
+    }
+
+}

--- a/src/Controller/UnsubscribeController.php
+++ b/src/Controller/UnsubscribeController.php
@@ -11,15 +11,19 @@ use Symfony\Component\Routing\Annotation\Route;
 
 class UnsubscribeController extends BaseController
 {
-    #[Route(path: '/unsubscribe', name: 'unsubscribe.interactive', methods: ['GET'])]
+    #[Route(path: '/unsubscribe/{token}', name: 'unsubscribe.interactive', methods: ['GET'])]
     public function interactiveUnsubscription(Request $request){
 
         $session = $request->getSession();
 
         $show_menu = empty($session->get('loginId')) ? 0 : 1;
 
+        // TODO : decrypter le token
+        $mail = $request->get('token');
+
         $this->templateParams(array(
             'show_menu' => $show_menu,
+            'mail' => $mail,
         ));
 
         return $this->output('unsubscribe/index.html.twig');

--- a/src/EventListener/ControllerAuthorizationListener.php
+++ b/src/EventListener/ControllerAuthorizationListener.php
@@ -42,7 +42,11 @@ class ControllerAuthorizationListener
         $page = rtrim($page, '/add');
         $page = rtrim($page, '/');
 
-        if (in_array($page, ['/login', '/logout', '/legal-notices', '/ical', '/unsubscribe'])) {
+        if (in_array($page, ['/login', '/logout', '/legal-notices', '/ical'])) {
+            return;
+        }
+
+        if (substr($page, 0, 12) == '/unsubscribe') {
             return;
         }
 

--- a/src/EventListener/ControllerAuthorizationListener.php
+++ b/src/EventListener/ControllerAuthorizationListener.php
@@ -42,7 +42,7 @@ class ControllerAuthorizationListener
         $page = rtrim($page, '/add');
         $page = rtrim($page, '/');
 
-        if (in_array($page, ['/login', '/logout', '/legal-notices', '/ical'])) {
+        if (in_array($page, ['/login', '/logout', '/legal-notices', '/ical', '/unsubscribe'])) {
             return;
         }
 

--- a/src/EventListener/LoginListener.php
+++ b/src/EventListener/LoginListener.php
@@ -35,7 +35,11 @@ class LoginListener
 
         // Redirect to the login page if there is no session
         // Except for the following routes
-        if (in_array($route, ['login', 'logout', 'legal-notices', 'ical', 'unsubscribe'])) {
+        if (in_array($route, ['login', 'logout', 'legal-notices', 'ical'])) {
+            return;
+        }
+
+        if (substr($route, 0, 11) == 'unsubscribe') {
             return;
         }
 

--- a/src/EventListener/LoginListener.php
+++ b/src/EventListener/LoginListener.php
@@ -35,7 +35,7 @@ class LoginListener
 
         // Redirect to the login page if there is no session
         // Except for the following routes
-        if (in_array($route, ['login', 'logout', 'legal-notices', 'ical'])) {
+        if (in_array($route, ['login', 'logout', 'legal-notices', 'ical', 'unsubscribe'])) {
             return;
         }
 

--- a/templates/unsubscribe/index.html.twig
+++ b/templates/unsubscribe/index.html.twig
@@ -13,7 +13,7 @@
     <h3>Désinscription</h3>
     <div class="admin-div">
       <p id="unsubscribe-text">Désinscrire {{ mail }}?</p>
-      <input type="button" value="Désinscription" />
+      <input type="button" value="Désinscription" class="ui-button"/>
     </div>
   </div>
 

--- a/templates/unsubscribe/index.html.twig
+++ b/templates/unsubscribe/index.html.twig
@@ -12,7 +12,7 @@
   <div id="content-form">
     <h3>Désinscription</h3>
     <div class="admin-div">
-      <p>{{ mail }}</p>
+      <p id="unsubscribe-text">Désinscrire {{ mail }}?</p>
       <input type="button" value="Désinscription" />
     </div>
   </div>

--- a/templates/unsubscribe/index.html.twig
+++ b/templates/unsubscribe/index.html.twig
@@ -1,0 +1,25 @@
+{# unsubscribe/index.html.twig #}
+
+{% extends 'base.html.twig' %}
+
+{% block page %}
+  {% if not show_menu %}
+    <p style="text-align:center;">
+      <div id='auth-logo'></div>
+    </p>
+  {% endif %}
+
+  <div id="content-form">
+    <h3>Désinscription</h3>
+    <div class="admin-div">
+      <input type="button" value="Désinscription" />
+    </div>
+  </div>
+
+  {% if not show_menu %}
+    <p style="text-align:center; margin-top:30px;">
+      <a style="font-size:1.5em;" href="{{ asset('login') }}">Retour</a>
+    </p>
+  {% endif %}
+
+{% endblock %}

--- a/templates/unsubscribe/index.html.twig
+++ b/templates/unsubscribe/index.html.twig
@@ -12,6 +12,7 @@
   <div id="content-form">
     <h3>Désinscription</h3>
     <div class="admin-div">
+      <p>{{ mail }}</p>
       <input type="button" value="Désinscription" />
     </div>
   </div>

--- a/tests/Controller/UnsubscribeControllerTest.php
+++ b/tests/Controller/UnsubscribeControllerTest.php
@@ -26,19 +26,37 @@ class UnsubscribeControllerTest extends PLBWebTestCase
         $client = static::createClient();
         $builder = new FixtureBuilder();
         $builder->delete(Agent::class);
+        $email = 'johndoe@example.org';
+        $token = encrypt($email);
 
-        $crawler = $client->request('GET', '/unsubscribe');
+        $crawler = $client->request('GET', "/unsubscribe/$token");
 
         $result = $crawler->filterXPath('//h3');
         $this->assertEquals($result->text(null,false),'Désinscription','h3 is Désinscription unlogged');
+        $result = $crawler->filterXPath('//p[@id="unsubscribe-text"]');
+        $this->assertEquals($result->text(null,false),'Désinscrire johndoe@example.org?','mail is retrieved unlogged');
+
+        $crawler = $client->request('OPTIONS', "/unsubscribe/$token");
+        $this->assertEquals($client->getResponse()->getStatusCode(), 200, 'OPTIONS returns 200 unlogged');
+
+        $crawler = $client->request('POST', "/unsubscribe/$token");
+        $this->assertEquals($client->getResponse()->getStatusCode(), 200, 'POST returns 200 unlogged');
 
         $agent = $builder->build(Agent::class, array('login' => 'jdevoe'));
         $this->logInAgent($agent, array(99,100));
 
-        $crawler = $client->request('GET', '/unsubscribe');
+        $crawler = $client->request('GET', "/unsubscribe/$token");
 
         $result = $crawler->filterXPath('//h3');
         $this->assertEquals($result->text(null,false),'Désinscription','h3 is Désinscription logged-in');
+        $result = $crawler->filterXPath('//p[@id="unsubscribe-text"]');
+        $this->assertEquals($result->text(null,false),'Désinscrire johndoe@example.org?','mail is retrieved logged-in');
+
+        $crawler = $client->request('OPTIONS', "/unsubscribe/$token");
+        $this->assertEquals($client->getResponse()->getStatusCode(), 200, 'OPTIONS returns 200 logged-in');
+
+        $crawler = $client->request('POST', "/unsubscribe/$token");
+        $this->assertEquals($client->getResponse()->getStatusCode(), 200, 'POST returns 200 logged-in');
 
     }
 }

--- a/tests/Controller/UnsubscribeControllerTest.php
+++ b/tests/Controller/UnsubscribeControllerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use App\Model\Agent;
+use App\Model\Skill;
+use App\Model\ConfigParam;
+use App\Model\Manager;
+
+use Symfony\Component\DomCrawler\Crawler;
+
+use Tests\PLBWebTestCase;
+use Tests\FixtureBuilder;
+
+
+class UnsubscribeControllerTest extends PLBWebTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->builder->delete(Agent::class);
+    }
+
+    public function testUnsubscribe()
+    {
+        global $entityManager;
+        $client = static::createClient();
+        $builder = new FixtureBuilder();
+        $builder->delete(Agent::class);
+
+        $crawler = $client->request('GET', '/unsubscribe');
+
+        $result = $crawler->filterXPath('//h3');
+        $this->assertEquals($result->text(null,false),'Désinscription','h3 is Désinscription unlogged');
+
+        $agent = $builder->build(Agent::class, array('login' => 'jdevoe'));
+        $this->logInAgent($agent, array(99,100));
+
+        $crawler = $client->request('GET', '/unsubscribe');
+
+        $result = $crawler->filterXPath('//h3');
+        $this->assertEquals($result->text(null,false),'Désinscription','h3 is Désinscription logged-in');
+
+    }
+}


### PR DESCRIPTION
This patch adds both List-Unsubscribe and List-Unsubscribe-Post in the emails sent by Planno.

List-Unsubscribe:
https://datatracker.ietf.org/doc/html/rfc2369

When present, this header allows the mail client to redirect the user to an unsubscription page on the application. This page will allow the user to interactively unsubscribe.

List-Unsubscribe-Post: List-Unsubscribe=One-Click
https://datatracker.ietf.org/doc/html/rfc8058

When present, this header allows the mail client to send a POST request to an unsubscription page on the application. This will allow non-interactive unsubscription.

Please note that this development does not actually unsubscribe users. This will be done in a future development.

Test plan:

 1) Install the BetterUnsubscribe addon for Mozilla Thunderbird
    https://addons.thunderbird.net/en-us/thunderbird/addon/betterunsubscribe/

 2) Send a test email from Planno (Administration > Configuration > Messagerie)

 3) In Thunderbird, you should see an "Unsubscribe" button.

 4) Click on it, then Unsubscribe. The addon should display: "Done".

(Since the List-Unsubscribe-Post header is present, the addon only offers non-interactive unsubscription)

 5) Go to planno/unsubscribe, and check that the interactive unsubscription
    page is available, both logged-in and unlogged.