### PR TITLE
MT44528: Fix weekly average in statistics

### DIFF
--- a/src/Controller/StatisticController.php
+++ b/src/Controller/StatisticController.php
@@ -1604,7 +1604,7 @@ class StatisticController extends BaseController
         $nbAgents = array();  // Nombre d'agents pour chaque jour
         $tab = array();
         $nb = count($dates);  // Nombre de dates
-        $nbSemaines = $nb/($this->config('Dimanche')? 7 : 6);   // Nombre de semaines
+        $nbSemaines = $nb / 7;  // Nombre de semaines
         $totalAgents = 0;        // Les totaux
         $totalHeures = 0;
         $siteHeures = array(0,0);   // Heures par site


### PR DESCRIPTION
Like what is done in the commit 823c8615320f1486019d59eb1f312ff3b63be065 (MT44490: Fix weekly average in statistics #1058), always use 7 days per week to compute average in statistics/bytime