### PR TITLE
MT45706: Use a helper to convert durations from decimal to hh:mm and vice-versa

### DIFF
--- a/public/conges/class.conges.php
+++ b/public/conges/class.conges.php
@@ -27,6 +27,7 @@ require_once __DIR__."/../absences/class.absences.php";
 use App\PlanningBiblio\WorkingHours;
 use App\PlanningBiblio\ClosingDay;
 use App\PlanningBiblio\Helper\HolidayHelper;
+use App\PlanningBiblio\Helper\HourHelper;
 use App\Model\Agent;
 
 class conges
@@ -788,7 +789,7 @@ class conges
             $this->elements=array("annuel"=>null,"anticipation"=>null,"credit"=>null,"recup"=>null,"reliquat"=>null,
     "annuelHeures"=>null, "anticipationHeures"=>null, "creditHeures"=>null, "recupHeures"=>null, "reliquatHeures"=>null,
     "annuelMinutes"=>null, "anticipationMinutes"=>null, "creditMinutes"=>null, "recupMinutes"=>null, "reliquatMinutes"=>null,
-    "annuelCents"=>null, "anticipationCents"=>null, "creditCents"=>null, "recupCents"=>null, "reliquatCents"=>null );
+    "annuelCents"=>null, "anticipationCents"=>null, "creditCents"=>null, "reliquatCents"=>null );
         } else {
             $db=new db();
             $db->select("personnel", "conges_credit,conges_reliquat,conges_anticipation,comp_time,conges_annuel", "`id`='{$this->perso_id}'");
@@ -796,53 +797,59 @@ class conges
                 $annuel = $db->result[0]['conges_annuel'] ? $db->result[0]['conges_annuel'] : 0;
                 $anticipation = $db->result[0]['conges_anticipation'] ? $db->result[0]['conges_anticipation'] : 0;
                 $credit = $db->result[0]['conges_credit'] ? $db->result[0]['conges_credit'] : 0;
-                $recup = $db->result[0]['comp_time'] ? $db->result[0]['comp_time'] : 0;
+                $decimal_comp_time = $db->result[0]['comp_time'] ? $db->result[0]['comp_time'] : 0;
                 $reliquat = $db->result[0]['conges_reliquat'] ? $db->result[0]['conges_reliquat'] : 0;
 
                 // Take into account negative anticipation.
+                // TODO: Use HourHelper::decimalToHourMinutes also for anticipations?
                 $anticipationNegative = false;
                 if ($anticipation < 0) {
                     $anticipationNegative = true;
                     $anticipation = abs($anticipation);
                 }
 
-                // Take into account negative compensatory time.
-                $negative = false;
-                if ($recup < 0) {
-                    $negative = true;
-                    $recup = abs($recup);
-                }
+                $comp_time = HourHelper::decimalToHoursMinutes($decimal_comp_time);
 
                 $annuelHeures=floor($annuel);
                 $anticipationHeures=floor($anticipation);
                 $creditHeures=floor($credit);
-                $recupHeures=floor($recup);
                 $reliquatHeures=floor($reliquat);
 
                 $annuelCents=(round(($annuel-$annuelHeures)*60)/2)*2;
                 $anticipationCents=(round(($anticipation-$anticipationHeures)*60)/2)*2;
                 $creditCents=(round(($credit-$creditHeures)*60)/2)*2;
-                $recupCents=(round(($recup-$recupHeures)*60)/2)*2;
                 $reliquatCents=(round(($reliquat-$reliquatHeures)*60)/2)*2;
 
                 $annuelMinutes=$annuelCents*0.6;
                 $anticipationMinutes=$anticipationCents*0.6;
                 $creditMinutes=$creditCents*0.6;
-                $recupMinutes=$recupCents*0.6;
                 $reliquatMinutes=$reliquatCents*0.6;
 
                 if ($anticipationNegative) {
                     $anticipationHeures = "-$anticipationHeures";
                 }
 
-                if ($negative) {
-                    $recupHeures = "-$recupHeures";
-                }
-
-                $this->elements=array("annuel"=>$annuel, "anticipation"=>$anticipation, "credit"=>$credit, "recup"=>$recup, "reliquat"=>$reliquat,
-      "annuelHeures"=>$annuelHeures, "anticipationHeures"=>$anticipationHeures, "creditHeures"=>$creditHeures, "recupHeures"=>$recupHeures, "reliquatHeures"=>$reliquatHeures,
-      "annuelMinutes"=>$annuelMinutes, "anticipationMinutes"=>$anticipationMinutes, "creditMinutes"=>$creditMinutes, "recupMinutes"=>$recupMinutes, "reliquatMinutes"=>$reliquatMinutes,
-      "annuelCents"=>$annuelCents, "anticipationCents"=>$anticipationCents, "creditCents"=>$creditCents, "recupCents"=>$recupCents, "reliquatCents"=>$reliquatCents );
+                $this->elements = array(
+                    "annuel"              => $annuel,
+                    "annuelHeures"        => $annuelHeures,
+                    "annuelMinutes"       => $annuelMinutes,
+                    "annuelCents"         => $annuelCents,
+                    "anticipation"        => $anticipation,
+                    "anticipationHeures"  => $anticipationHeures,
+                    "anticipationMinutes" => $anticipationMinutes,
+                    "anticipationCents"   => $anticipationCents,
+                    "credit"              => $credit,
+                    "creditHeures"        => $creditHeures,
+                    "creditMinutes"       => $creditMinutes,
+                    "creditCents"         => $creditCents,
+                    "reliquat"            => $reliquat,
+                    "recup"               => $decimal_comp_time,
+                    "recupHeures"         => $comp_time['hours'],
+                    "recupMinutes"        => $comp_time['minutes'],
+                    "reliquatHeures"      => $reliquatHeures,
+                    "reliquatMinutes"     => $reliquatMinutes,
+                    "reliquatCents"       => $reliquatCents
+                );
             }
         }
     }

--- a/public/personnel/js/modif.js
+++ b/public/personnel/js/modif.js
@@ -198,31 +198,60 @@ function sendICSURL(){
 
 // Contrôle des champs lors de la validation
 function verif_form_agent(){
-  erreur=false;
-  message="Les champs suivants sont obligatoires :";
-  if(!document.form.nom.value){
-    erreur=true;
-    message=message+"\n- Nom";
+
+  erreur = false;
+  message = "Les champs suivants sont obligatoires :";
+
+  if(!document.form.nom.value) {
+    erreur = true;
+    message = message + "\n- Nom";
   }
-  if(!document.form.prenom.value){
-    erreur=true;
-    message=message+"\n- prénom";
+  if(!document.form.prenom.value) {
+    erreur = true;
+    message = message + "\n- prénom";
   }
-  if(!document.form.mail.value){
-    erreur=true;
-    message=message+"\n- E-mail";
+  if(!document.form.mail.value) {
+    erreur = true;
+    message = message + "\n- E-mail";
   }
   
-  if(erreur)
-    alert(message);
-  else{
-    if(!verif_mail(document.form.mail.value)){
-      alert("Adresse e-mail invalide");
-    }
-    else{
-      document.form.submit();
-    }
+  if(erreur) {
+    CJInfo(message);
+    return false;
   }
+
+  if(!verif_mail(document.form.mail.value)) {
+    CJInfo("Adresse e-mail invalide");
+    return false;
+  }
+
+  comp_time_min = $("#comp_time_min").val();
+  if (comp_time_min) {
+    comp_time_min = Number(comp_time_min);
+    if (
+        !Number.isInteger(comp_time_min) ||
+        comp_time_min < 0 ||
+        comp_time_min > 59
+       ) {
+        CJInfo("Le nombre de minutes des récupérations doit être un entier compris entre 0 et 59");
+        return false;
+    }
+  } else {
+    $("#comp_time_min").val(0);
+  }
+  comp_time_hours = $("#comp_time_hours").val();
+  if (comp_time_hours) {
+    comp_time_hours = Number(comp_time_hours);
+    console.log(comp_time_hours);
+    if (!Number.isInteger(comp_time_hours)) {
+        CJInfo("Le nombre d'heures des récupérations doit être un entier");
+        return false;
+    }
+  } else {
+    $("#comp_time_hours").val(0);
+  }
+
+  document.form.submit();
 }
 
 $(function() {
@@ -500,5 +529,8 @@ $(document).ready(function(){
   // Met à jour les select site des emplois du temps si les sites ont changé dans les infos générales
   $("#personnel-a-li3").click(function(){
     changeSelectSites();
+  });
+  $("#post_form_agent").click(function() {
+    verif_form_agent();
   });
 });

--- a/src/Controller/AgentController.php
+++ b/src/Controller/AgentController.php
@@ -1729,11 +1729,12 @@ class AgentController extends BaseController
                 );
             }
         } else {
+            $comp_time = HourHelper::hoursMinutesToDecimal(trim($params['comp_time_hours']), trim($params['comp_time_min']));
             $credits = array(
                 'conges_credit' => $params['conges_credit'] + $params['conges_credit_min'],
                 'conges_reliquat' => $params['conges_reliquat'] + $params['conges_reliquat_min'],
                 'conges_anticipation' => $params['conges_anticipation'] + $params['conges_anticipation_min'],
-                'comp_time' => $params['comp_time'] + $params['comp_time_min'],
+                'comp_time' => $comp_time,
                 'conges_annuel' => $params['conges_annuel'] + $params['conges_annuel_min'],
             );
         }

--- a/src/Controller/AgentController.php
+++ b/src/Controller/AgentController.php
@@ -685,7 +685,6 @@ class AgentController extends BaseController
             $anticipationString = heure4($conges['anticipation']);
 
             $recupHeures = $conges['recupHeures'] ? $conges['recupHeures'] : 0;
-            $recupString = heure4($conges['recup']);
 
             if ($this->config('Conges-Mode') == 'jours' ) {
                 $event = new OnTransformLeaveHours($conges);
@@ -731,8 +730,7 @@ class AgentController extends BaseController
                 'anticipation_min'      => $conges['anticipationCents'],
                 'anticipation_string'   => $anticipationString,
                 'recup_heures'          => $recupHeures,
-                'recup_min'             => $conges['recupCents'],
-                'recup_string'          => $recupString,
+                'recup_min'             => $conges['recupMinutes'],
                 'lang_comp_time'        => $lang['comp_time'],
                 'show_hours_to_days'    => $holiday_helper->showHoursToDays(),
             );
@@ -1720,20 +1718,13 @@ class AgentController extends BaseController
                 $credits = $event->response();
             } else {
 
-                $comptime_hours = trim($params['comp_time']);
-                $negative = false;
-                if (strstr($comptime_hours, '-')) {
-                    $negative = true;
-                    $comptime_hours = abs($comptime_hours);
-                }
-
-                $comp_time = $comptime_hours + $params['comp_time_min'];
+                $comp_time = HourHelper::hoursMinutesToDecimal(trim($params['comp_time_hours']), trim($params['comp_time_min']));
 
                 $credits = array(
                     'conges_credit' => $params['conges_credit'] *= 7,
                     'conges_reliquat' => $params['conges_reliquat'] *= 7,
                     'conges_anticipation' => $params['conges_anticipation'] *= 7,
-                    'comp_time' => $negative ? 0 - $comp_time : $comp_time,
+                    'comp_time' => $comp_time,
                     'conges_annuel' => $params['conges_annuel'] *= 7,
                 );
             }

--- a/src/PlanningBiblio/Helper/HourHelper.php
+++ b/src/PlanningBiblio/Helper/HourHelper.php
@@ -39,13 +39,24 @@ class HourHelper extends BaseHelper
             $result['minutes'] = 0;
         }
 
+        if ($result['hours'] == 0 && $negative) {
+            $result['hours'] = '-0';
+        } else {
+            $result['hours'] = (string) $result['hours'];
+        }
+
         return $result;
     }
 
-    public static function hoursMinutesToDecimal($hours, $minutes)
+    public static function hoursMinutesToDecimal(string $hours, int $minutes)
     {
+
+        if (!is_int($minutes) || $minutes < 0 || $minutes > 59) {
+            throw new \InvalidArgumentException('hoursMinutesToDecimal only accepts integers between 0 and 59 included for minutes. Input was: ' . $minutes);
+        }
+
         $negative = false;
-        if ($hours < 0) {
+        if (strstr($hours, '-')) {
             $negative = true;
             $hours = abs($hours);
         }

--- a/src/PlanningBiblio/Helper/HourHelper.php
+++ b/src/PlanningBiblio/Helper/HourHelper.php
@@ -10,6 +10,56 @@ class HourHelper extends BaseHelper
 
     private static $end_default = '23:59:59';
 
+
+    public static function decimalToHoursMinutes($decimal_duration)
+    {
+        $result = array();
+
+        $negative = false;
+        if ($decimal_duration < 0) {
+            $negative = true;
+            $decimal_duration = abs($decimal_duration);
+        }
+        $result['hours'] = (int) floor($decimal_duration);
+        if ($negative) {
+            $result['hours'] = 0 - $result['hours'];
+        }
+
+        # Considering minutes only from now:
+        $decimal_duration = $decimal_duration - floor($decimal_duration);
+
+        $result['minutes'] = round($decimal_duration * 60);
+
+        if ($result['minutes'] == 60) {
+            if ($negative) {
+                $result['hours'] -= 1;
+            } else {
+                $result['hours'] += 1;
+            }
+            $result['minutes'] = 0;
+        }
+
+        return $result;
+    }
+
+    public static function hoursMinutesToDecimal($hours, $minutes)
+    {
+        $negative = false;
+        if ($hours < 0) {
+            $negative = true;
+            $hours = abs($hours);
+        }
+
+        $result = $hours + round($minutes / 60, 9);
+
+        if ($negative) {
+            $result = 0 - $result;
+        }
+
+        # Working with 9 decimals is enough for minute precision
+        return sprintf("%.9f", $result);
+    }
+
     public static function StartEndFromRequest($request)
     {
         $start = $request->get('hre_debut');

--- a/src/Twig/AppExtension.php
+++ b/src/Twig/AppExtension.php
@@ -25,6 +25,7 @@ class AppExtension extends AbstractExtension
         return [
             new TwigFilter('datefull', [$this, 'dateFull'], ['is_safe' => ['html']]),
             new TwigFilter('datefr', [$this, 'dateFr']),
+            new TwigFilter('digit', [$this, 'digit']),
             new TwigFilter('hours', [$this, 'hours']),
             new TwigFilter('hour_from_his', [$this, 'hourFromHis']),
             new TwigFilter('hoursToDays', [$this, 'hoursToDays']),
@@ -54,6 +55,11 @@ class AppExtension extends AbstractExtension
     public function dateFr($date)
     {
         return dateFr($date, true);
+    }
+
+    public function digit($number, $digits)
+    {
+        return sprintf('%0' . $digits . 'd', $number);
     }
 
     public function hours($hours)

--- a/templates/agents/edit.html.twig
+++ b/templates/agents/edit.html.twig
@@ -86,7 +86,7 @@
 
       {% if can_manage_agent %}
         <li id="admin" class='ui-tab-cancel'><a href='{{ asset("agent") }}'>Annuler</a></li>
-        <li id="admin" class='ui-tab-submit'><a href='javascript:verif_form_agent();'>Valider</a></li>
+        <li id="admin" class='ui-tab-submit'><a id="post_form_agent" href="">Valider</a></li>
       {% else %}
         <li id="admin" class='ui-tab-cancel'><a href='{{ asset("agent") }}'>Fermer</a></li>
       {% endif %}

--- a/templates/agents/holidays.html.twig
+++ b/templates/agents/holidays.html.twig
@@ -56,10 +56,10 @@
         {% if can_manage_agent %}
           <input type='text' name='comp_time_hours' id='comp_time_hours' value='{{ recup_heures }}' style='width:60px;text-align:right;'>
           <label style='text-align:center;padding:5px;'>h</label>
-          <input type='text' name='comp_time_min' id='comp_time_min' value='{{ recup_min }}' style='width:60px;text-align:left;'>
+          <input type='text' name='comp_time_min' id='comp_time_min' value='{{ recup_min | digit(2) }}' style='width:60px;text-align:left;'>
         {% else %}
           <p style='padding-right: 18px;'>
-          {{ recup_heures }}h{{ recup_min }}
+          {{ recup_heures }}h{{ recup_min | digit(2) }}
           </p>
         {% endif %}
       </td>

--- a/templates/agents/holidays.html.twig
+++ b/templates/agents/holidays.html.twig
@@ -54,12 +54,12 @@
       <td>{{ lang_comp_time }} :</td>
       <td style='text-align:right; padding-right: 45px;'>
         {% if can_manage_agent %}
-          <input type='text' name='comp_time_hours' value='{{ recup_heures }}' style='width:60px;text-align:right;'>
+          <input type='text' name='comp_time_hours' id='comp_time_hours' value='{{ recup_heures }}' style='width:60px;text-align:right;'>
           <label style='text-align:center;padding:5px;'>h</label>
-          <input type='text' name='comp_time_min' value='{{ recup_min }}' style='width:60px;text-align:left;'>
+          <input type='text' name='comp_time_min' id='comp_time_min' value='{{ recup_min }}' style='width:60px;text-align:left;'>
         {% else %}
           <p style='padding-right: 18px;'>
-          {{ recup_heures }} heures {{ recup_min }}
+          {{ recup_heures }}h{{ recup_min }}
           </p>
         {% endif %}
       </td>

--- a/templates/agents/holidays.html.twig
+++ b/templates/agents/holidays.html.twig
@@ -54,12 +54,12 @@
       <td>{{ lang_comp_time }} :</td>
       <td style='text-align:right; padding-right: 45px;'>
         {% if can_manage_agent %}
-          <input type='text' name='comp_time' value='{{ recup_heures}}'  style='width:60px;text-align:right;'>
+          <input type='text' name='comp_time_hours' value='{{ recup_heures }}' style='width:60px;text-align:right;'>
           <label style='text-align:center;padding:5px;'>h</label>
-          {% include 'agents/elements/select_holiday_minutes.html.twig' with {'minutes': recup_min, 'name': 'comp_time_min' } %}
+          <input type='text' name='comp_time_min' value='{{ recup_min }}' style='width:60px;text-align:left;'>
         {% else %}
           <p style='padding-right: 18px;'>
-          {{ recup_string }}
+          {{ recup_heures }} heures {{ recup_min }}
           </p>
         {% endif %}
       </td>

--- a/templates/agents/holidays_hours.html.twig
+++ b/templates/agents/holidays_hours.html.twig
@@ -100,14 +100,13 @@ $(document).ready(function() {
       <td>{{ lang_comp_time }} :</td>
       <td style='text-align:right;'>
         {% if can_manage_agent %}
-          <input type='text' name='comp_time' value='{{ recup_heures}}'  style='width:70px;text-align:right;'>
+          <input type='text' name='comp_time_hours' id='comp_time_hours' value='{{ recup_heures }}' style='width:70px;text-align:right;'>
           <label style='text-align:center;padding:5px;'>h</label>
-          {% include 'agents/elements/select_holiday_minutes.html.twig' with {'minutes': recup_min, 'name': 'comp_time_min' } %}
+          <input type='text' name='comp_time_min' id='comp_time_min' value='{{ recup_min }}' style='width:70px;text-align:left;'>
         {% else %}
-          {{ recup_string }}
+          {{ recup_heures }}h{{ recup_min }}
         {% endif %}
       </td>
-      <td></td>
     </tr>
   </table>
   {% if show_hours_to_days %}Équivalence utilisée : 1 jour = <span id="hours_per_day">{{ hours_per_day }}</span> heures{% endif %}

--- a/templates/agents/holidays_hours.html.twig
+++ b/templates/agents/holidays_hours.html.twig
@@ -102,9 +102,9 @@ $(document).ready(function() {
         {% if can_manage_agent %}
           <input type='text' name='comp_time_hours' id='comp_time_hours' value='{{ recup_heures }}' style='width:70px;text-align:right;'>
           <label style='text-align:center;padding:5px;'>h</label>
-          <input type='text' name='comp_time_min' id='comp_time_min' value='{{ recup_min }}' style='width:70px;text-align:left;'>
+          <input type='text' name='comp_time_min' id='comp_time_min' value='{{ recup_min | digit(2) }}' style='width:70px;text-align:left;'>
         {% else %}
-          {{ recup_heures }}h{{ recup_min }}
+          {{ recup_heures }}h{{ recup_min | digit(2) }}
         {% endif %}
       </td>
     </tr>

--- a/tests/PlanningBiblio/Helper/HourHelper/HourHelperTest.php
+++ b/tests/PlanningBiblio/Helper/HourHelper/HourHelperTest.php
@@ -19,54 +19,72 @@ class HourHelperTest extends TestCase
 
         # A value right on a minute stays on this minute
         $result = $hh->decimalToHoursMinutes(8.966666667);
-        $this->assertEquals(8, $result['hours'], '8.966666667 gives 8 hours');
+        $this->assertSame('8', $result['hours'], '8.966666667 gives 8 hours');
         $this->assertEquals(58, $result['minutes'], '8.966666667 gives 58 minutes (a value exactly on a minute stays on this minute)');
 
         # A value right on a minute stays on this minute
         $result = $hh->decimalToHoursMinutes(8.983333333);
-        $this->assertEquals(8, $result['hours'], '8.983333333 gives 8 hours');
+        $this->assertSame('8', $result['hours'], '8.983333333 gives 8 hours');
         $this->assertEquals(59, $result['minutes'], '8.983333333 gives 59 minutes (a value exactly on a minute stays on this minute)');
 
         # 0 gives 0
         $result = $hh->decimalToHoursMinutes(0);
-        $this->assertEquals(0, $result['hours'], '0 gives 0 hours');
+        $this->assertSame('0', $result['hours'], '0 gives 0 hours');
         $this->assertEquals(0, $result['minutes'], '0 gives 0 minutes');
+
+        # Negative duration within an hour gives a negative hour value
+        $result = $hh->decimalToHoursMinutes(-0.25);
+        $this->assertSame('-0', $result['hours'], '-0.25 gives -0 hours');
+        $this->assertEquals(15, $result['minutes'], '-0.25 gives 15 minutes');
 
         # In case we have values inbetween minutes in the database:
         # A value betweeen minutes goes to the closest minute
         # Between 8h59 and 9h
         $result = $hh->decimalToHoursMinutes(8.9967);
-        $this->assertEquals(9, $result['hours'], '8.9967 gives 9 hours (a value betweeen minutes goes to the closest minute, positive test)');
+        $this->assertSame('9', $result['hours'], '8.9967 gives 9 hours (a value betweeen minutes goes to the closest minute, positive test)');
         $this->assertEquals(00, $result['minutes'], '8.9967 gives 00 minutes (a value between minutes goes to the closest minute, positive test)');
 
         # Between -8h59 and -9h
         $result = $hh->decimalToHoursMinutes(-8.9967);
-        $this->assertEquals(-9, $result['hours'], '-8.9967 gives -9 hours (a value betweeen minutes goes to the closest minute, negative test)');
+        $this->assertSame('-9', $result['hours'], '-8.9967 gives -9 hours (a value betweeen minutes goes to the closest minute, negative test)');
         $this->assertEquals(00, $result['minutes'], '-8.9967 gives 00 minutes (a value between minutes goes to the closest minute, negative test)');
 
         # Between 8h00 and 8h01, closer to 01
         $result = $hh->decimalToHoursMinutes(8.015);
-        $this->assertEquals(8, $result['hours'], '8.015 gives 8 hours (a value betweeen minutes goes to the closest minute, closer to the next minute)');
+        $this->assertSame('8', $result['hours'], '8.015 gives 8 hours (a value betweeen minutes goes to the closest minute, closer to the next minute)');
         $this->assertEquals(01, $result['minutes'], '8.015 gives 01 minutes (a value between minutes goes to the closest minute, closer to the next minute)');
 
         # Between 8h00 and 8h01, closer to 00
         $result = $hh->decimalToHoursMinutes(8.0015);
-        $this->assertEquals(8, $result['hours'], '8.0015 gives 8 hours (a value betweeen minutes goes to the closest minute, closer to the previous minute)');
+        $this->assertSame('8', $result['hours'], '8.0015 gives 8 hours (a value betweeen minutes goes to the closest minute, closer to the previous minute)');
         $this->assertEquals(0, $result['minutes'], '8.0015 gives 00 minutes (a value between minutes goes to the closest minute, closer to the previous minute)');
+
     }
 
     public function testHourMinutesToDecimal()
     {
         $hh = new HourHelper();
 
-        $result = $hh->hoursMinutesToDecimal(8, 59);
+        $result = $hh->hoursMinutesToDecimal('8', 59);
         $this->assertEquals(8.983333333, $result, '8h59 gives 8.983333333');
 
-        $result = $hh->hoursMinutesToDecimal(-8, 59);
+        $result = $hh->hoursMinutesToDecimal('-8', 59);
         $this->assertEquals(-8.983333333, $result, '8h59 gives -8.983333333');
 
-        $result = $hh->hoursMinutesToDecimal(0, 0);
+        $result = $hh->hoursMinutesToDecimal('0', 0);
         $this->assertEquals(0, $result, '0 hours 0 minutes gives 0');
+
+        $result = $hh->hoursMinutesToDecimal('-0', 15);
+        $this->assertEquals(-0.250000000, $result, 'Negative duration within an hour gives negative result');
+
+        $this->expectException(TypeError::class);
+        $result = $hh->hoursMinutesToDecimal('-0', 'aaa');
+
+        $this->expectException(InvalidArgumentException::class);
+        $result = $hh->hoursMinutesToDecimal('-0', -1);
+
+        $this->expectException(InvalidArgumentException::class);
+        $result = $hh->hoursMinutesToDecimal('-0', 60);
     }
 
     public function testHoursMinutesToDecimalAndDecimalToHoursMinutesBijection()
@@ -74,10 +92,19 @@ class HourHelperTest extends TestCase
         $hh = new HourHelper();
 
         # For every minute of an hour, we test that we get the same result going from hours minutes to decimal, and vice-versa.
-        for ($i = 0; $i < 60; $i++) {
-            $result = $hh->decimalToHoursMinutes($hh->hoursMinutesToDecimal(8, $i));
-            $this->assertEquals(8, $result['hours'], 'Hours and minutes to decimal to hours and minutes give the same input result (hours)');
-            $this->assertEquals($i, $result['minutes'], "Hours and minutes to decimal to hours and minutes give the same input result (minutes = $i)");
+        $hours = array('-1', '-0', '0', '1');
+        foreach ($hours as $hour) {
+            for ($i = 0; $i < 60; $i++) {
+
+                if ($hour == '-0' && $i == 0) {
+                    # There is no point in testing -0.0, as it is stricly equal to 0.0
+                    continue;
+                }
+
+                $result = $hh->decimalToHoursMinutes($hh->hoursMinutesToDecimal($hour, $i));
+                $this->assertSame($hour, $result['hours'], "Hours and minutes to decimal to hours and minutes give the same input result (hour = $hour)");
+                $this->assertEquals($i, $result['minutes'], "Hours and minutes to decimal to hours and minutes give the same input result (minutes = $i)");
+            }
         }
     }
 

--- a/tests/PlanningBiblio/Helper/HourHelper/HourHelperTest.php
+++ b/tests/PlanningBiblio/Helper/HourHelper/HourHelperTest.php
@@ -6,6 +6,81 @@ use App\PlanningBiblio\Helper\HourHelper;
 
 class HourHelperTest extends TestCase
 {
+
+
+    public function testDecimalToHoursMinutes()
+    {
+        $hh = new HourHelper();
+
+        # Note:
+        # We use the same constant as select_holiday_minutes.html.twig for conversion
+        # 0.966666667 = 58 minutes (58 * 0.016666666666667)
+        # 0.983333333 = 59 minutes (59 * 0.016666666666667)
+
+        # A value right on a minute stays on this minute
+        $result = $hh->decimalToHoursMinutes(8.966666667);
+        $this->assertEquals(8, $result['hours'], '8.966666667 gives 8 hours');
+        $this->assertEquals(58, $result['minutes'], '8.966666667 gives 58 minutes (a value exactly on a minute stays on this minute)');
+
+        # A value right on a minute stays on this minute
+        $result = $hh->decimalToHoursMinutes(8.983333333);
+        $this->assertEquals(8, $result['hours'], '8.983333333 gives 8 hours');
+        $this->assertEquals(59, $result['minutes'], '8.983333333 gives 59 minutes (a value exactly on a minute stays on this minute)');
+
+        # 0 gives 0
+        $result = $hh->decimalToHoursMinutes(0);
+        $this->assertEquals(0, $result['hours'], '0 gives 0 hours');
+        $this->assertEquals(0, $result['minutes'], '0 gives 0 minutes');
+
+        # In case we have values inbetween minutes in the database:
+        # A value betweeen minutes goes to the closest minute
+        # Between 8h59 and 9h
+        $result = $hh->decimalToHoursMinutes(8.9967);
+        $this->assertEquals(9, $result['hours'], '8.9967 gives 9 hours (a value betweeen minutes goes to the closest minute, positive test)');
+        $this->assertEquals(00, $result['minutes'], '8.9967 gives 00 minutes (a value between minutes goes to the closest minute, positive test)');
+
+        # Between -8h59 and -9h
+        $result = $hh->decimalToHoursMinutes(-8.9967);
+        $this->assertEquals(-9, $result['hours'], '-8.9967 gives -9 hours (a value betweeen minutes goes to the closest minute, negative test)');
+        $this->assertEquals(00, $result['minutes'], '-8.9967 gives 00 minutes (a value between minutes goes to the closest minute, negative test)');
+
+        # Between 8h00 and 8h01, closer to 01
+        $result = $hh->decimalToHoursMinutes(8.015);
+        $this->assertEquals(8, $result['hours'], '8.015 gives 8 hours (a value betweeen minutes goes to the closest minute, closer to the next minute)');
+        $this->assertEquals(01, $result['minutes'], '8.015 gives 01 minutes (a value between minutes goes to the closest minute, closer to the next minute)');
+
+        # Between 8h00 and 8h01, closer to 00
+        $result = $hh->decimalToHoursMinutes(8.0015);
+        $this->assertEquals(8, $result['hours'], '8.0015 gives 8 hours (a value betweeen minutes goes to the closest minute, closer to the previous minute)');
+        $this->assertEquals(0, $result['minutes'], '8.0015 gives 00 minutes (a value between minutes goes to the closest minute, closer to the previous minute)');
+    }
+
+    public function testHourMinutesToDecimal()
+    {
+        $hh = new HourHelper();
+
+        $result = $hh->hoursMinutesToDecimal(8, 59);
+        $this->assertEquals(8.983333333, $result, '8h59 gives 8.983333333');
+
+        $result = $hh->hoursMinutesToDecimal(-8, 59);
+        $this->assertEquals(-8.983333333, $result, '8h59 gives -8.983333333');
+
+        $result = $hh->hoursMinutesToDecimal(0, 0);
+        $this->assertEquals(0, $result, '0 hours 0 minutes gives 0');
+    }
+
+    public function testHoursMinutesToDecimalAndDecimalToHoursMinutesBijection()
+    {
+        $hh = new HourHelper();
+
+        # For every minute of an hour, we test that we get the same result going from hours minutes to decimal, and vice-versa.
+        for ($i = 0; $i < 60; $i++) {
+            $result = $hh->decimalToHoursMinutes($hh->hoursMinutesToDecimal(8, $i));
+            $this->assertEquals(8, $result['hours'], 'Hours and minutes to decimal to hours and minutes give the same input result (hours)');
+            $this->assertEquals($i, $result['minutes'], "Hours and minutes to decimal to hours and minutes give the same input result (minutes = $i)");
+        }
+    }
+
     public function testtoHis()
     {
         $hh = new HourHelper();


### PR DESCRIPTION
Such conversions were spread across the code and could cause inbetween minutes values stored in the database, as well as errors and discrepancies in displaying converted values between different places in the application.

Two function have been added to the HourHelper class:

    - decimalToHoursMinutes($decimal_duration)
    - hoursMinutesToDecimal($hours, $minutes)

decimalToHoursMinutes takes care of possible incorrect values (decimal value inbetween two minutes) by giving the closest minute.

More importantly, decimalToHoursMinutes and hoursMinutesToDecimal are bijective (after rounding to the closest minute): going back and forth from decimal to hh:mm and vice-versa will always give the same results.
The testHoursMinutesToDecimalAndDecimalToHoursMinutesBijection makes sure of that.

The agent profile now uses HourHelper to display and store comp times.

Test plan:

 1) Go to an agent profile and edit the comp time

 2) Check that it has been properly stored and can be displayed again.

 3) You can fiddle with the comp_time value in the personnel table in the
    database and insert incorrect inbetween minutes values to check that the
    closest minute is always selected. You can use tricky values like inbetween
    59 minutes and the next hour. See HourHelperTest.php for examples.

Next step, when this has been proven to work well: use it everywhere such conversion is made.