### PR TITLE
MT46949: Fix getRecipients to handle empty values for Absences-notifications-*

### DIFF
--- a/public/absences/class.absences.php
+++ b/public/absences/class.absences.php
@@ -1161,6 +1161,9 @@ class absences
 
         $categories=$GLOBALS['config']["{$type}-notifications{$validation}"];
         $categories=json_decode(html_entity_decode(stripslashes($categories), ENT_QUOTES|ENT_IGNORE, 'UTF-8'), true);
+        if (!is_array($categories)) {
+            $categories = array();
+        }
         /*
         $categories : Catégories de personnes à qui les notifications doivent être envoyées
           tableau sérialisé issu de la config. : champ Absences-notifications, Absences-notifications2,

--- a/tools/set_planook_config.sql
+++ b/tools/set_planook_config.sql
@@ -24,14 +24,14 @@
 -- UPDATE config SET valeur='1', type='info' WHERE nom='Absences-agent-preselection';
 -- UPDATE config SET valeur='0', type='info' WHERE nom='Absences-tous';
 -- UPDATE config SET valeur='1', type='info' WHERE nom='Absences-journeeEntiere';
--- UPDATE config SET valeur='', type='info' WHERE nom='Absences-notifications-A1';
--- UPDATE config SET valeur='', type='info' WHERE nom='Absences-notifications-A2';
--- UPDATE config SET valeur='', type='info' WHERE nom='Absences-notifications-A3';
--- UPDATE config SET valeur='', type='info' WHERE nom='Absences-notifications-A4';
--- UPDATE config SET valeur='', type='info' WHERE nom='Absences-notifications-B1';
--- UPDATE config SET valeur='', type='info' WHERE nom='Absences-notifications-B2';
--- UPDATE config SET valeur='', type='info' WHERE nom='Absences-notifications-B3';
--- UPDATE config SET valeur='', type='info' WHERE nom='Absences-notifications-B4';
+-- UPDATE config SET valeur='[]', type='info' WHERE nom='Absences-notifications-A1';
+-- UPDATE config SET valeur='[]', type='info' WHERE nom='Absences-notifications-A2';
+-- UPDATE config SET valeur='[]', type='info' WHERE nom='Absences-notifications-A3';
+-- UPDATE config SET valeur='[]', type='info' WHERE nom='Absences-notifications-A4';
+-- UPDATE config SET valeur='[]', type='info' WHERE nom='Absences-notifications-B1';
+-- UPDATE config SET valeur='[]', type='info' WHERE nom='Absences-notifications-B2';
+-- UPDATE config SET valeur='[]', type='info' WHERE nom='Absences-notifications-B3';
+-- UPDATE config SET valeur='[]', type='info' WHERE nom='Absences-notifications-B4';
 -- UPDATE config SET valeur='0', type='info' WHERE nom='Absences-notifications-agent-par-agent';
 -- UPDATE config SET valeur='', type='info' WHERE nom='Absences-notifications-titre';
 -- UPDATE config SET valeur='', type='info' WHERE nom='Absences-notifications-message';
@@ -53,10 +53,10 @@
 -- -- Emploi du temps en semaines paires et impaires
 -- UPDATE config SET valeur='1', valeurs='1,2' WHERE nom='nb_semaine';
 -- UPDATE config SET valeur='0' , type='info' WHERE nom='EDTSamedi';
--- UPDATE config SET valeur='', type='info' WHERE nom='PlanningHebdo-notifications1';
--- UPDATE config SET valeur='', type='info' WHERE nom='PlanningHebdo-notifications2';
--- UPDATE config SET valeur='', type='info' WHERE nom='PlanningHebdo-notifications3';
--- UPDATE config SET valeur='', type='info' WHERE nom='PlanningHebdo-notifications4';
+-- UPDATE config SET valeur='[]', type='info' WHERE nom='PlanningHebdo-notifications1';
+-- UPDATE config SET valeur='[]', type='info' WHERE nom='PlanningHebdo-notifications2';
+-- UPDATE config SET valeur='[]', type='info' WHERE nom='PlanningHebdo-notifications3';
+-- UPDATE config SET valeur='[]', type='info' WHERE nom='PlanningHebdo-notifications4';
 -- UPDATE config SET valeur='0', type='info' WHERE nom='PlanningHebdo-notifications-agent-par-agent';
 -- -- Interdire la 2ème pause
 -- UPDATE config SET valeur='0', type='info' WHERE nom='PlanningHebdo-Pause2';


### PR DESCRIPTION
In planook, configuration values for Absences-notifications-* are empty strings (and not empty arrays in JSON)

This patch fixes the getRecipients function so it handles empty values for Absences-notifications-*

Test plan:

 1) disable Absences-notifications-agent-par-agent and set Absences-notifications-* to empty values:
 update config set valeur='' where nom='Absences-notifications-A1' limit 1;
 update config set valeur='' where nom='Absences-notifications-A2' limit 1;
 update config set valeur='' where nom='Absences-notifications-A3' limit 1;
 update config set valeur='' where nom='Absences-notifications-A4' limit 1;
 update config set valeur='' where nom='Absences-notifications-B1' limit 1;
 update config set valeur='' where nom='Absences-notifications-B2' limit 1;
 update config set valeur='' where nom='Absences-notifications-B3' limit 1;
 update config set valeur='' where nom='Absences-notifications-B4' limit 1;

 2) Try to add or delete an absence and check that you have an error

 3) Apply the patch

 4) Try to add or delete an absence and check that the error is gone