### PR TITLE
MT45507: Add position parameter to include it in public service quota

### DIFF
--- a/public/planning/poste/class.planning.php
+++ b/public/planning/poste/class.planning.php
@@ -112,7 +112,7 @@ class planning
     }
 
     // Affiche la liste des agents dans le menudiv
-    public function menudivAfficheAgents($poste, $agents, $date, $debut, $fin, $deja, $stat, $nbAgents, $sr_init, $hide, $deuxSP, $motifExclusion, $absences_non_validees, $journey, $absences_journey)
+    public function menudivAfficheAgents($poste, $agents, $date, $debut, $fin, $deja, $quotaSP, $nbAgents, $sr_init, $hide, $deuxSP, $motifExclusion, $absences_non_validees, $journey, $absences_journey)
     {
         $config=$GLOBALS['config'];
         $dbprefix=$config['dbprefix'];
@@ -141,7 +141,7 @@ class planning
 
         // Nombre d'heures de la cellule choisie
         $hres_cellule = 0;
-        if ($stat) {    // vérifier si le poste est compté dans les stats
+        if ($quotaSP) {    // vérifier si le poste est compté dans les stats
             $hres_cellule = diff_heures($debut, $fin, "decimal");
         }
     

--- a/public/planning/poste/class.planning.php
+++ b/public/planning/poste/class.planning.php
@@ -189,7 +189,7 @@ class planning
                     'absent'   => "<>1",
                     'date'     => "BETWEEN {$date1} AND {$date2}",
                 ),
-                array("statistiques"=>"1")
+                array('quota_sp' => '1')
       );
 
             if ($db_heures->result) {

--- a/public/setup/atomicupdate/MT45507.php
+++ b/public/setup/atomicupdate/MT45507.php
@@ -1,0 +1,3 @@
+<?php
+
+$sql[] = "ALTER TABLE postes ADD column quota_sp tinyint(1) NOT NULL DEFAULT 1;";

--- a/src/Controller/PlanningJobController.php
+++ b/src/Controller/PlanningJobController.php
@@ -86,14 +86,14 @@ class PlanningJobController extends BaseController
         }
 
         // Position's name and related skills
-        $db = new \db;
-        $db->select2('postes', null, array('id' => $poste));
-        $posteNom = $db->result[0]['nom'];
-        $activites = json_decode(html_entity_decode($db->result[0]['activites'], ENT_QUOTES|ENT_IGNORE, 'UTF-8'), true);
-        $stat = $db->result[0]['statistiques'];
-        $teleworking = $db->result[0]['teleworking'];
-        $bloquant = $db->result[0]['bloquant'];
-        $categories = $db->result[0]['categories'] ? json_decode(html_entity_decode($db->result[0]['categories'], ENT_QUOTES|ENT_IGNORE, 'UTF-8'), true) : array();
+        $position = $positions->find($poste);
+        $posteNom = $position->nom();
+        $activites = $position->activites();
+        $stat = $position->statistiques();
+        $quotaSP = $position->quota_sp();
+        $teleworking = $position->teleworking();
+        $bloquant = $position->bloquant();
+        $categories = $position->categories() ? $position->categories() : array();
 
         // Site's name
         $siteNom = null;
@@ -712,7 +712,7 @@ class PlanningJobController extends BaseController
             $p = new \planning();
             $p->site = $site;
             $p->CSRFToken = $CSRFToken;
-            $p->menudivAfficheAgents($poste, $agents_dispo, $date, $debut, $fin, $deja, $stat, $nbAgents, $sr_init, $hide, $deuxSP, $motifExclusion, $absences_non_validees, $journey, $absences_journey);
+            $p->menudivAfficheAgents($poste, $agents_dispo, $date, $debut, $fin, $deja, $quotaSP, $nbAgents, $sr_init, $hide, $deuxSP, $motifExclusion, $absences_non_validees, $journey, $absences_journey);
             $tableaux['menu1'] = $p->menudiv;
         }
 
@@ -757,7 +757,7 @@ class PlanningJobController extends BaseController
             $p = new \planning();
             $p->site = $site;
             $p->CSRFToken = $CSRFToken;
-            $p->menudivAfficheAgents($poste, $agents_tous, $date, $debut, $fin, $deja, $stat, $nbAgents, $sr_init, $hide, $deuxSP, $motifExclusion, $absences_non_validees, $journey, $absences_journey);
+            $p->menudivAfficheAgents($poste, $agents_tous, $date, $debut, $fin, $deja, $quotaSP, $nbAgents, $sr_init, $hide, $deuxSP, $motifExclusion, $absences_non_validees, $journey, $absences_journey);
             $tableaux['menu2'] = $p->menudiv;
         }
 
@@ -767,7 +767,7 @@ class PlanningJobController extends BaseController
             $p = new \planning();
             $p->site = $site;
             $p->CSRFToken = $CSRFToken;
-            $p->menudivAfficheAgents($poste, $autres_agents, $date, $debut, $fin, $deja, $stat, $nbAgents, $sr_init, $hide, $deuxSP, $motifExclusion, $absences_non_validees, $journey, $absences_journey);
+            $p->menudivAfficheAgents($poste, $autres_agents, $date, $debut, $fin, $deja, $quotaSP, $nbAgents, $sr_init, $hide, $deuxSP, $motifExclusion, $absences_non_validees, $journey, $absences_journey);
             $tableaux['menu2'] = $p->menudiv;
         }
 

--- a/src/Controller/PlanningJobController.php
+++ b/src/Controller/PlanningJobController.php
@@ -93,7 +93,7 @@ class PlanningJobController extends BaseController
         $quotaSP = $position->quota_sp();
         $teleworking = $position->teleworking();
         $bloquant = $position->bloquant();
-        $categories = $position->categories() ? $position->categories() : array();
+        $categories = $position->categories() ?? [];
 
         // Site's name
         $siteNom = null;

--- a/src/Controller/PositionController.php
+++ b/src/Controller/PositionController.php
@@ -130,6 +130,8 @@ class PositionController extends BaseController
             $renfort = $position->obligatoire() == "Renfort"?"checked='checked'":"";
             $stat1 = $position->statistiques()?"checked='checked'":"";
             $stat2 = !$position->statistiques()?"checked='checked'":"";
+            $quota_sp1 = $position->quota_sp() ? "checked='checked'" : "";
+            $quota_sp2 = !$position->quota_sp() ? "checked='checked'" : "";
             $bloq1 = $position->bloquant()?"checked='checked'":"";
             $bloq2 = !$position->bloquant()?"checked='checked'":"";
             $teleworking1 = $position->teleworking() ? "checked='checked'" : "";
@@ -149,6 +151,8 @@ class PositionController extends BaseController
             $renfort = null;
             $stat1 = 'checked';
             $stat2 = null;
+            $quota_sp1 = 'checked';
+            $quota_sp2 = null;
             $bloq1 = 'checked';
             $bloq2 = null;
             $teleworking1 = null;
@@ -235,6 +239,8 @@ class PositionController extends BaseController
             'lunch2'        => $lunch2,
             'bloq1'         => $bloq1,
             'bloq2'         => $bloq2,
+            'quota_sp1'     => $quota_sp1,
+            'quota_sp2'     => $quota_sp2,
             'floors'        => $floors,
             'groups'        => $groups,
             'nbSites'       => $nbSites,
@@ -270,6 +276,7 @@ class PositionController extends BaseController
             $categories = $request->get('categories', []);
             $site = $request->get('site', 1);
             $bloquant = $request->get('bloquant', 1);
+            $quota_sp = $request->get('quota_sp', 1);
             $lunch = $request->get('lunch', 0);
             $statistiques = $request->get('statistiques', 1);
             $teleworking = $request->get('teleworking', 0);
@@ -285,6 +292,7 @@ class PositionController extends BaseController
                 $position->activites($activites);
                 $position->categories($categories);
                 $position->bloquant($bloquant);
+                $position->quota_sp($quota_sp);
                 $position->statistiques($statistiques);
                 $position->teleworking($teleworking);
                 $position->lunch($lunch);
@@ -315,6 +323,7 @@ class PositionController extends BaseController
                 $position->activites($activites);
                 $position->categories($categories);
                 $position->bloquant($bloquant);
+                $position->quota_sp($quota_sp);
                 $position->statistiques($statistiques);
                 $position->teleworking($teleworking);
                 $position->lunch($lunch);

--- a/src/Controller/StatisticController.php
+++ b/src/Controller/StatisticController.php
@@ -1776,7 +1776,7 @@ class StatisticController extends BaseController
         $req.="`{$dbprefix}postes`.`teleworking` AS `teleworking` ";
         $req.="FROM `{$dbprefix}pl_poste` INNER JOIN `{$dbprefix}personnel` ON `{$dbprefix}pl_poste`.`perso_id`=`{$dbprefix}personnel`.`id` ";
         $req.="INNER JOIN `{$dbprefix}postes` ON `{$dbprefix}postes`.`id`=`{$dbprefix}pl_poste`.`poste` ";
-        $req.="WHERE `date`>='$debutREQ' AND `date`<='$finREQ' AND `{$dbprefix}pl_poste`.`absent`<>'1' AND `{$dbprefix}pl_poste`.`supprime`<>'1' AND `{$dbprefix}postes`.`statistiques`='1' ";
+        $req.="WHERE `date`>='$debutREQ' AND `date`<='$finREQ' AND `{$dbprefix}pl_poste`.`absent`<>'1' AND `{$dbprefix}pl_poste`.`supprime`<>'1' AND `{$dbprefix}postes`.`quota_sp`='1' ";
         $req.="ORDER BY `nom`,`prenom`;";
 
         $db->query($req);

--- a/src/Model/Position.php
+++ b/src/Model/Position.php
@@ -50,4 +50,7 @@ class Position extends PLBEntity
 
     /** @Column(type="datetime")**/
     protected $supprime;
+
+    /** @Column(type="boolean")**/
+    protected $quota_sp = true;
 }

--- a/templates/position/edit.html.twig
+++ b/templates/position/edit.html.twig
@@ -92,6 +92,13 @@
                     </td>
                   </tr>
                   <tr>
+                    <td>Compter les heures dans le quota de service public :</td>
+                    <td>
+                      <input type='radio' name='quota_sp' value='1' {{ quota_sp1 }}/> Oui
+                      <input type='radio' name='quota_sp' value='0' {{ quota_sp2 }}/> Non
+                    </td>
+                  </tr>
+                  <tr>
                     <td>Statistiques :</td>
                     <td>
                       <input type='radio' name='statistiques' value='1' {{ stat1 }}/> Oui

--- a/templates/statistics/time.html.twig
+++ b/templates/statistics/time.html.twig
@@ -4,6 +4,7 @@
 
 {% block page %}
   <h3>Feuille de temps</h3>
+  <p>Les heures affichées sur cette page sont les heures comptées en service public.</p>
   <table>
     <tr>
       <td style='width:350px;'><b>Du {{ debutFr }} au {{ finFr }}</b></td>

--- a/tests/Controller/PositionControllerTest.php
+++ b/tests/Controller/PositionControllerTest.php
@@ -69,6 +69,7 @@ class PositionControllerTest extends PLBWebTestCase
         $this->assertStringContainsString('Groupe:', $result->text('Node does not exist', false), 'label is Groupe');
         $this->assertStringContainsString('Obligatoire / renfort :',$result->text('Node does not exist', false), 'label is Obligatoire / renfort : ');
         $this->assertStringContainsString('Bloquant :',$result->text('Node does not exist', false), 'label is Bloquant : ');
+        $this->assertStringContainsString('Compter les heures dans le quota de service public :',$result->text('Node does not exist', false), 'label is Compter les heures dans le quota de service public : ');
         $this->assertStringContainsString('Statistiques :',$result->text('Node does not exist', false), 'label is Statistiques: ');
         $this->assertStringContainsString('Compatible télétravail :',$result->text('Node does not exist', false), 'label is Compatible télétravail');
 
@@ -168,6 +169,7 @@ class PositionControllerTest extends PLBWebTestCase
         $this->assertStringContainsString('Groupe:', $result->text('Node does not exist', false), 'label is Groupe');
         $this->assertStringContainsString('Obligatoire / renfort :',$result->text('Node does not exist', false), 'label is Obligatoire / renfort : ');
         $this->assertStringContainsString('Bloquant :',$result->text('Node does not exist', false), 'label is Bloquant : ');
+        $this->assertStringContainsString('Compter les heures dans le quota de service public :',$result->text('Node does not exist', false), 'label is Compter les heures dans le quota de service public : ');
         $this->assertStringContainsString('Statistiques :',$result->text('Node does not exist', false), 'label is Statistiques: ');
         $this->assertStringContainsString('Compatible télétravail :',$result->text('Node does not exist', false), 'label is Compatible télétravail');
 
@@ -197,16 +199,17 @@ class PositionControllerTest extends PLBWebTestCase
         $this->assertEquals($result->attr('value'),'Obligatoire','input obligatoire value is Obligatoire');
         $this->assertEquals($result->eq(1)->attr('value'),'Renfort','input obligatoire value is Obligatoire Renfort');
 
-
         $result = $crawler->filterXPath('//input[@name="bloquant"]');
         $this->assertEquals($result->attr('value'),'1','input bloquant value is 1');
         $this->assertEquals($result->eq(1)->attr('value'),'0','input bloquant value is 0');
-
 
         $result = $crawler->filterXPath('//input[@name="statistiques"]');
         $this->assertEquals($result->attr('value'),'1','input statistiques value is 1');
         $this->assertEquals($result->eq(1)->attr('value'),'0','input statistiques value is 0');
 
+        $result = $crawler->filterXPath('//input[@name="quota_sp"]');
+        $this->assertEquals($result->attr('value'),'1','input quota_sp value is 1');
+        $this->assertEquals($result->eq(1)->attr('value'),'0','input quota_sp value is 0');
 
         $result = $crawler->filterXPath('//input[@name="teleworking"]');
         $this->assertEquals($result->attr('value'),'1','input teleworking value is 1');

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -44,8 +44,26 @@ if ($dbconn) {
     foreach ($sql as $elem) {
         mysqli_multi_query($dblink, $elem);
     }
+
+    $atomic_dir = __DIR__ . '/../public/setup/atomicupdate/*.php';
+
+    $sql = array();
+    foreach (glob($atomic_dir) as $file) {
+        try {
+            require_once($file);
+        } catch (Exception $e) {
+            print $e->getMessage() . "\n";
+            continue;
+        }
+    }
+
+    foreach ($sql as $elem) {
+        mysqli_multi_query($dblink, $elem);
+    }
+
     mysqli_close($dblink);
 }
+
 
 include_once(__DIR__ . '/../init/init.php');
 include_once(__DIR__.'/../init/init_templates.php');


### PR DESCRIPTION
 - A new parameter is added to the position page "take hours into account for public service quota"

 - The bootstrap for unit tests now processes the atomicupdates before running the tests

Test plan:

 - On a planning, add an hour with a position that have the new parameter enabled
 - Check that the time statistics (/statistics/time) take this new hour into account
 - On a planning, add an hour with position that doesn't have the new parameter enabled
 - Check that the time statistics don't take this new hour into account