### PR TITLE
MT47685: An level 1 admin can delete another agent absence when Absences-validation is disabled

### DIFF
--- a/src/Controller/AbsenceController.php
+++ b/src/Controller/AbsenceController.php
@@ -491,7 +491,7 @@ class AbsenceController extends BaseController
             $acces = true;
         }
 
-        if ($valideN2 == 0 and $this->admin) {
+        if ($this->admin && ($this->config('Absences-validation') == 0 || $valideN2 == 0)) {
             $acces = true;
         }
 

--- a/tests/Controller/AbsenceControllerDeleteTest.php
+++ b/tests/Controller/AbsenceControllerDeleteTest.php
@@ -373,12 +373,14 @@ class AbsenceControllerDeleteTest extends PLBWebTestCase
          * Absences-validation disabled
          * Agent is admin level 1 (right 201)
          * Absence is not his own
-         * The absence can not be deleted
+         * The absence can be deleted
          */
+
+        $this->setParam('Absences-validation', 0);
 
         $acl = [201];
         $nbAgent = 1;
-        $result = 'notEmpty';
+        $result = 'empty';
 
         $validations = [0,1];
         $this->createAndTest($acl, $nbAgent, $validations, $result, 1);

--- a/tests/Controller/AbsenceControllerDeleteTest.php
+++ b/tests/Controller/AbsenceControllerDeleteTest.php
@@ -367,7 +367,43 @@ class AbsenceControllerDeleteTest extends PLBWebTestCase
         $this->createAndTest($acl, $nbAgent, $validations, $result);
     }
 
-    private function createAndTest($acl, $nbAgents = 1, $validations = [1,1], $result = 'empty')
+    public function test17()
+    {
+        /**
+         * Absences-validation disabled
+         * Agent is admin level 1 (right 201)
+         * Absence is not his own
+         * The absence can not be deleted
+         */
+
+        $acl = [201];
+        $nbAgent = 1;
+        $result = 'notEmpty';
+
+        $validations = [0,1];
+        $this->createAndTest($acl, $nbAgent, $validations, $result, 1);
+    }
+
+    public function test18()
+    {
+        /**
+         * Absences-validation disabled
+         * Agent is admin level 2 (right 501)
+         * Absence is not his own
+         * The absence can be deleted
+         */
+
+        $acl = [501];
+        $nbAgent = 1;
+        $result = 'empty';
+
+        $validations = [0,1];
+        $this->createAndTest($acl, $nbAgent, $validations, $result, 1);
+    }
+
+
+
+    private function createAndTest($acl, $nbAgents = 1, $validations = [1,1], $result = 'empty', $loggedInAgentId = 0)
     {
         $acl = array_merge($acl, [99,100]);
         $agents = $this->agents;
@@ -406,7 +442,7 @@ class AbsenceControllerDeleteTest extends PLBWebTestCase
             );
         }
 
-        $this->logInAgent($agents[0], $acl);
+        $this->logInAgent($agents[$loggedInAgentId], $acl);
 
         $this->client->request('DELETE', '/absence', ['CSRFToken' => $this->CSRFToken, 'id' => $absence->id()]);
 


### PR DESCRIPTION
    Test plan:
    
     1) Disable Absences-validation
     2) Create an absence as agent1
     3) Try to delete the absence as a level 1 absence administrator
        (Gestion des congés, validation niveau 1 enabled,
         Gestion des congés, validation niveau 2 disabled)
     4) The absence can not be deleted (incorrect)
     5) Apply the patch
     6) The absence can be deleted (correct)
