### PR TITLE
MT47502: Apply Absences-Exclusion to statistics: agent/service/status

### DIFF
--- a/public/absences/class.absences.php
+++ b/public/absences/class.absences.php
@@ -950,7 +950,8 @@ class absences
         //	Select All
         $req="SELECT `{$dbprefix}absences`.`perso_id` AS `perso_id`, "
         ."`{$dbprefix}absences`.`id` AS `id`, `{$dbprefix}absences`.`debut` AS `debut`, "
-        ."`{$dbprefix}absences`.`fin` AS `fin`, `{$dbprefix}absences`.`motif` AS `motif` "
+        ."`{$dbprefix}absences`.`fin` AS `fin`, `{$dbprefix}absences`.`motif` AS `motif`, "
+        ."`{$dbprefix}absences`.`valide` AS `valide` "
         ."FROM `{$dbprefix}absences` "
         ."WHERE $dates $filter;";
 

--- a/src/Controller/StatisticController.php
+++ b/src/Controller/StatisticController.php
@@ -335,6 +335,12 @@ class StatisticController extends BaseController
                             if ( !empty($absencesDB[$elem['perso_id']]) ) {
                                 foreach ($absencesDB[$elem['perso_id']] as $a) {
 
+                                    if (($this->config('Absences-Exclusion') == 1 and $a['valide'] == 99999)
+                                        or $this->config('Absences-Exclusion') == 2)
+                                    {
+                                        continue;
+                                    }
+
                                     // Ignore teleworking absences for compatible positions
                                     if (in_array($a['motif'], $teleworking_absence_reasons) and $elem['teleworking']) {
                                         continue;


### PR DESCRIPTION
MT46229: Allow the assignment of absent agents to schedules introduced the new Absences-Exclusion parameter.

However, it was only applied to statistics/absence.

This patch applies it to:

 - statistics/agent
 - statistics/service
 - statistics/status

through the common function of the StatisticsController