### PR TITLE
MT48793: Improve missing category A display

### DIFF
--- a/public/planning/poste/js/planning.js
+++ b/public/planning/poste/js/planning.js
@@ -1353,6 +1353,9 @@ function bataille_navale(poste,date,debut,fin,perso_id,barrer,ajouter,site,tout,
         majPersoOrigine(0);
       }
 
+      // Affiche un message en haut du planning si pas de catégorie A en fin de service
+      verif_categorieA();
+
       // Cellule grisée depuis le menudiv
       if(result != 'grise'){
         $("#td"+cellule).removeClass('cellule_grise');
@@ -1481,8 +1484,6 @@ function bataille_navale(poste,date,debut,fin,perso_id,barrer,ajouter,site,tout,
       }
     });
 
-  // Affiche un message en haut du planning si pas de catégorie A en fin de service 
-  verif_categorieA();
   
   /*
   Exemple de valeur pour la variable result :

--- a/public/planning/poste/js/planning.js
+++ b/public/planning/poste/js/planning.js
@@ -1705,7 +1705,13 @@ function verif_categorieA(){
     success: function(result) {
       result = JSON.parse(result);
       if(result == "false") {
-        CJInfo("Attention, pas d'agent de catégorie A en fin de service.", 'error');
+        if (!$(".missingCategoryA")[0]) {
+            CJInfo("Attention, pas d'agent de catégorie A en fin de service.", 'error', 82, 999999, 'missingCategoryA');
+        }
+      } else {
+        if ($(".missingCategoryA")[0]) {
+            $(".missingCategoryA")[0].remove();
+        }
       }
     }
   });


### PR DESCRIPTION
The "missing category A" warning is currently displayed if needed every time a cell is updated in the planning, and removed after a timeout.

This can lead to multiple identical warnings displayed at the same time.

This patch displays the warning only once, and removes it after a cell update (and not based on a timeout)

Test plan:

 1) Edit a planning without category A agent at the end of service
 2) Check that the warning is displayed
 3) Make an edit to the planning, still without category A agent
    at the end of service
 4) Check that the warning is not displayed twice
 5) Add a category A agent at the end of service
 6) Check that the warning is removed