### PR TITLE
MT49914: Simplified absence validation schema for meetings

### DIFF
--- a/public/absences/js/modif.js
+++ b/public/absences/js/modif.js
@@ -207,6 +207,9 @@ $(function() {
     
   });
 
+  $("#motif").change(function(){
+    update_validation_statuses();
+  });
   
   $("#absence-bouton-supprimer").click(function(){
 
@@ -668,9 +671,12 @@ function update_validation_statuses() {
 
   absence_id = $('input[name="id"]').val();
 
+
+  var workflow = $("select[name=motif] option:selected").attr("data-workflow") || 'A';
+
   $.ajax({
     url: url('absence-statuses'),
-    data: { ids: perso_ids, module: 'absence', id: absence_id },
+    data: { ids: perso_ids, module: 'absence', id: absence_id, workflow: workflow },
     dataType: 'html',
     success: function(result){
       $("#validation-statuses").html(result);

--- a/public/setup/db_data.php
+++ b/public/setup/db_data.php
@@ -614,7 +614,7 @@ $sql[]="INSERT INTO `{$dbprefix}select_abs` (`valeur`,`rang`, `notification_work
 $sql[]="INSERT INTO `{$dbprefix}select_abs` (`valeur`,`rang`, `notification_workflow`) VALUES ('Formation', '7', 'A');";
 $sql[]="INSERT INTO `{$dbprefix}select_abs` (`valeur`,`rang`, `notification_workflow`) VALUES ('Concours', '8', 'A');";
 $sql[]="INSERT INTO `{$dbprefix}select_abs` (`valeur`,`rang`, `notification_workflow`) VALUES ('Stage', '9', 'A');";
-$sql[]="INSERT INTO `{$dbprefix}select_abs` (`valeur`,`rang`, `notification_workflow`) VALUES ('Réunion', '10', 'B');";
+$sql[]="INSERT INTO `{$dbprefix}select_abs` (`valeur`,`rang`, `notification_workflow`) VALUES ('Réunion', '10', 'A');";
 $sql[]="INSERT INTO `{$dbprefix}select_abs` (`valeur`,`rang`, `notification_workflow`) VALUES ('Entretien', '11', 'A');";
 $sql[]="INSERT INTO `{$dbprefix}select_abs` (`valeur`,`rang`, `notification_workflow`) VALUES ('Autre', '12', 'A');";
 

--- a/public/setup/db_data.php
+++ b/public/setup/db_data.php
@@ -614,7 +614,7 @@ $sql[]="INSERT INTO `{$dbprefix}select_abs` (`valeur`,`rang`, `notification_work
 $sql[]="INSERT INTO `{$dbprefix}select_abs` (`valeur`,`rang`, `notification_workflow`) VALUES ('Formation', '7', 'A');";
 $sql[]="INSERT INTO `{$dbprefix}select_abs` (`valeur`,`rang`, `notification_workflow`) VALUES ('Concours', '8', 'A');";
 $sql[]="INSERT INTO `{$dbprefix}select_abs` (`valeur`,`rang`, `notification_workflow`) VALUES ('Stage', '9', 'A');";
-$sql[]="INSERT INTO `{$dbprefix}select_abs` (`valeur`,`rang`, `notification_workflow`) VALUES ('Réunion', '10', 'A');";
+$sql[]="INSERT INTO `{$dbprefix}select_abs` (`valeur`,`rang`, `notification_workflow`) VALUES ('Réunion', '10', 'B');";
 $sql[]="INSERT INTO `{$dbprefix}select_abs` (`valeur`,`rang`, `notification_workflow`) VALUES ('Entretien', '11', 'A');";
 $sql[]="INSERT INTO `{$dbprefix}select_abs` (`valeur`,`rang`, `notification_workflow`) VALUES ('Autre', '12', 'A');";
 

--- a/src/Controller/AbsenceController.php
+++ b/src/Controller/AbsenceController.php
@@ -318,8 +318,6 @@ class AbsenceController extends BaseController
             $workflow = $reason->getNotificationWorkflow();
         }
 
-        $absence['workflow'] = $workflow;
-
         $adminN1 = true;
         $adminN2 = true;
         foreach ($agents as $agent) {
@@ -371,7 +369,7 @@ class AbsenceController extends BaseController
         $absence['status'] = 'ASKED';
         $absence['status_editable'] = ($adminN1 or $adminN2) ? true : false;
         if ($valide == 0 && $valideN1 > 0) {
-                $absence['status'] = 'ACCEPTED_N1';
+            $absence['status'] = 'ACCEPTED_N1';
         }
         if ($valide > 0) {
             $absence['status'] = 'ACCEPTED_N2';
@@ -715,7 +713,7 @@ class AbsenceController extends BaseController
         $agent_ids = $request->get('ids') ?? array();
         $module = $request->get('module');
         $entity_id = $request->get('id');
-        $workflow = $request->get('workflow') ?? 'A';
+        $workflow = $request->get('workflow', 'A');
 
         $this->templateParams($this->getStatusesParams($agent_ids, $module, $entity_id, $workflow));
 

--- a/src/Controller/AbsenceController.php
+++ b/src/Controller/AbsenceController.php
@@ -311,6 +311,15 @@ class AbsenceController extends BaseController
         $absence['commentaires'] = html_entity_decode($a->elements['commentaires'], ENT_QUOTES);
         $agents=$a->elements['agents'];
 
+        // Get notification workflow
+        $workflow = 'A';
+        $reason = $this->entityManager->getRepository(AbsenceReason::class)->findoneBy(['valeur' => $absence['motif']]);
+        if ($reason) {
+            $workflow = $reason->getNotificationWorkflow();
+        }
+
+        $absence['workflow'] = $workflow;
+
         $adminN1 = true;
         $adminN2 = true;
         foreach ($agents as $agent) {
@@ -318,7 +327,7 @@ class AbsenceController extends BaseController
                 ->getRepository(Agent::class)
                 ->setModule('absence')
                 ->forAgent($agent['perso_id'])
-                ->getValidationLevelFor($session->get('loginId'));
+                ->getValidationLevelFor($session->get('loginId'), $workflow);
 
             $adminN1 = $N1 === false ? $N1 : $adminN1;
             $adminN2 = $N2 === false ? $N2 : $adminN2;
@@ -362,7 +371,7 @@ class AbsenceController extends BaseController
         $absence['status'] = 'ASKED';
         $absence['status_editable'] = ($adminN1 or $adminN2) ? true : false;
         if ($valide == 0 && $valideN1 > 0) {
-            $absence['status'] = 'ACCEPTED_N1';
+                $absence['status'] = 'ACCEPTED_N1';
         }
         if ($valide > 0) {
             $absence['status'] = 'ACCEPTED_N2';
@@ -466,6 +475,14 @@ class AbsenceController extends BaseController
         $fin = $a->elements['fin'];
         $perso_id = $a->elements['perso_id'];
         $motif = $a->elements['motif'];
+
+        // Get the selected notification workflow in absence reason.
+        $workflow = 'A';
+        $reason = $this->entityManager->getRepository(AbsenceReason::class)->findoneBy(['valeur' => $motif]);
+        if ($reason) {
+            $workflow = $reason->getNotificationWorkflow();
+        }
+
         $commentaires = $a->elements['commentaires'];
         $valideN1 = $a->elements['valide_n1'];
         $valideN2 = $a->elements['valide_n2'];
@@ -479,12 +496,19 @@ class AbsenceController extends BaseController
         // If "Absences-notifications-agent-par-agent" is enabled,
         // check if logged in agent can manage all agents in absence.
         // Else, admin = false.
+        $logged_in = $this->entityManager->find(Agent::class, $session->get('loginId'));
         if ($this->config('Absences-notifications-agent-par-agent') and $this->admin) {
-            $logged_in = $this->entityManager->find(Agent::class, $session->get('loginId'));
             $this->admin = $logged_in->isManagerOf($perso_ids);
         }
 
         $acces = false;
+
+        // Simplified absence validation schema with workflow B
+        if ($this->config('Absences-notifications-agent-par-agent') == 1 &&
+            $logged_in->isManagerOf($perso_ids, 'level1') && 
+            $workflow == 'B') {
+            $acces = true;
+        }
 
         if ($this->adminN2) {
             $acces = true;
@@ -557,13 +581,6 @@ class AbsenceController extends BaseController
             $a->getRecipients2(null, $agents, 2, 500, $debut, $fin);
             $destinataires = $a->recipients;
         } else {
-            // Get the selected notification workflow in absence reason.
-            $workflow = 'A';
-            $reason = $this->entityManager->getRepository(AbsenceReason::class)->findoneBy(['valeur' => $motif]);
-            if ($reason) {
-                $workflow = $reason->getNotificationWorkflow();
-            }
-
             // Foreach agent, search for agents in charge of absences.
             $responsables=array();
             foreach ($agents as $agent) {
@@ -698,8 +715,9 @@ class AbsenceController extends BaseController
         $agent_ids = $request->get('ids') ?? array();
         $module = $request->get('module');
         $entity_id = $request->get('id');
+        $workflow = $request->get('workflow') ?? 'A';
 
-        $this->setStatusesParams($agent_ids, $module, $entity_id);
+        $this->templateParams($this->getStatusesParams($agent_ids, $module, $entity_id, $workflow));
 
         return $this->output('/common/validation-statuses.html.twig');
     }
@@ -855,7 +873,7 @@ class AbsenceController extends BaseController
 
         $baseurl = $this->config('URL');
 
-        // Absence with sevearl agents.
+        // Absence with several agents.
         $perso_ids = $request->get('perso_ids');
         $perso_ids = filter_var_array($perso_ids, FILTER_SANITIZE_NUMBER_INT);
 
@@ -1498,6 +1516,8 @@ class AbsenceController extends BaseController
         // If Absences-notifications-agent-par-agent is true,
         // delete all agents the logged in user cannot create absences for.
         if ($this->config('Absences-notifications-agent-par-agent') and !$this->adminN2) {
+
+            #TODO: Replace this with isManagerOf ?
             $logged_in = $this->entityManager->find(Agent::class, $session->get('loginId'));
             $accepted_ids = array_map(function($m) { return $m->getUser()->getId(); }, $logged_in->getManaged());
             $accepted_ids[] = $session->get('loginId');

--- a/src/Controller/OvertimeController.php
+++ b/src/Controller/OvertimeController.php
@@ -216,7 +216,7 @@ class OvertimeController extends BaseController
             return $this->output('access-denied.html.twig');
         }
 
-        $this->setStatusesParams(array($perso_id), 'overtime', $id);
+        $this->templateParams($this->getStatusesParams(array($perso_id), 'overtime', $id));
 
 
         // Initialisation des variables (suite)

--- a/src/Controller/WorkingHourController.php
+++ b/src/Controller/WorkingHourController.php
@@ -276,7 +276,7 @@ class WorkingHourController extends BaseController
             ->forAgent($perso_id)
             ->getValidationLevelFor($session->get('loginId'));
 
-        $this->setStatusesParams(array($perso_id), 'workinghour');
+        $this->templateParams($this->getStatusesParams(array($perso_id), 'workinghour'));
 
         $notAdmin = !($adminN1 or $adminN2);
         $admin = ($adminN1 or $adminN2);
@@ -414,7 +414,7 @@ class WorkingHourController extends BaseController
             ->getValidationLevelFor($session->get('loginId'));
         $admin = ($this->adminN1 or $this->adminN2);
 
-        $this->setStatusesParams(array($perso_id), 'workinghour', $id);
+        $this->templateParams($this->getStatusesParams(array($perso_id), 'workinghour', $id));
 
         if (!$admin && $perso_id != $session->get('loginId')) {
             return $this->redirectToRoute('access-denied');

--- a/src/Repository/AgentRepository.php
+++ b/src/Repository/AgentRepository.php
@@ -267,7 +267,7 @@ class AgentRepository extends EntityRepository
         return array($loggedin);
     }
 
-    public function getValidationLevelFor($loggedin_id)
+    public function getValidationLevelFor($loggedin_id, String $workflow = 'A')
     {
 
         $entityManager = $this->getEntityManager();
@@ -305,6 +305,10 @@ class AgentRepository extends EntityRepository
             }
 
             if ($loggedin->isManagerOf(array($this->agent_id), 'level2')) {
+                $l2 = true;
+            }
+
+            if ($l1 and $workflow == 'B') {
                 $l2 = true;
             }
 

--- a/src/Traits/EntityValidationStatuses.php
+++ b/src/Traits/EntityValidationStatuses.php
@@ -7,10 +7,10 @@ use App\Entity\Agent;
 
 trait EntityValidationStatuses
 {
-    public function setStatusesParams($agent_ids, $module, $entity_id = null)
+    public function getStatusesParams($agent_ids, $module, $entity_id = null, String $workflow = 'A')
     {
         if (!$agent_ids) {
-            throw new \Exception("EntityValidationStatuses::setStatusesParams: No agent");
+            throw new \Exception("EntityValidationStatuses::getStatusesParams: No agent");
         }
 
         $show_select = false;
@@ -20,7 +20,7 @@ trait EntityValidationStatuses
 
         // At this point, overtime entities
         // and holiday are treated the same.
-        // This was not the cas in ValidationAwareEntity.
+        // This was not the case in ValidationAwareEntity.
         $module = $module == 'overtime' ? 'holiday' : $module;
 
         $adminN1 = true;
@@ -30,38 +30,42 @@ trait EntityValidationStatuses
                 ->getRepository(Agent::class)
                 ->setModule($module)
                 ->forAgent($id)
-                ->getValidationLevelFor($_SESSION['login_id']);
+                ->getValidationLevelFor($_SESSION['login_id'], $workflow);
 
             $adminN1 = $N1 ? $adminN1 : false;
             $adminN2 = $N2 ? $adminN2 : false;
         }
-
         $show_select = $adminN1 || $adminN2;
         $show_n1 = $adminN1 || $adminN2;
         $show_n2 = $adminN2;
 
+        // Simplified absence validation schema for workflow B
+        if ($workflow == 'B' && $module == 'absence') {
+            $show_n1 = false;
+        } 
+
         // Only adminN2 can change statuses of
         // validated N2 entities.
         if (in_array($entity_state, [1, -1]) && !$adminN2) {
-            $show_select = 0;
+            $show_select = false;
         }
 
         // Prevent user without right L1 to directly validate l2
         if (!$adminN1 && $entity_state == 0 && $entity->needsValidationL1()) {
-            $show_select = 0;
+            $show_select = false;
         }
 
-        // Accepted N2 hildays cannot be changed.
+        // Accepted N2 holidays cannot be changed.
         if ($entity_state == 1 && $module == 'holiday') {
-            $show_select = 0;
+            $show_select = false;
         }
-
-        $this->templateParams(array(
+        $params = array(
             'entity_state_desc' => $entity_state_desc,
             'entity_state'      => $entity_state,
             'show_select'       => $show_select,
             'show_n1'           => $show_n1,
             'show_n2'           => $show_n2,
-        ));
+        );
+        return $params;
     }
 }

--- a/src/Traits/EntityValidationStatuses.php
+++ b/src/Traits/EntityValidationStatuses.php
@@ -4,6 +4,7 @@ namespace App\Traits;
 
 use App\PlanningBiblio\ValidationAwareEntity;
 use App\Entity\Agent;
+use App\Entity\ConfigParam;
 
 trait EntityValidationStatuses
 {
@@ -40,7 +41,12 @@ trait EntityValidationStatuses
         $show_n2 = $adminN2;
 
         // Simplified absence validation schema for workflow B
-        if ($workflow == 'B' && $module == 'absence') {
+        $configByAgent = $this->entityManager
+            ->getRepository(ConfigParam::class)
+            ->findOneBy(['nom' => 'Absences-notifications-agent-par-agent'])
+            ->getValue();
+
+        if ($module == 'absence' && $configByAgent && $workflow == 'B') {
             $show_n1 = false;
         } 
 

--- a/templates/absences/add.html.twig
+++ b/templates/absences/add.html.twig
@@ -170,16 +170,16 @@
                       <option value=''></option>
                       {% for r in reasons %}
                         {% if r.type == 2 %}
-                          <option value="{{ r.valeur }}" class="padding20">
+                          <option value="{{ r.valeur }}" data-workflow="{{ r.notification_workflow }}" class="padding20">
                             &nbsp;&nbsp;&nbsp;{{ r.valeur }}
                           </option>
                         {% else %}
                           {% if r.type == 1 %}
-                            <option value="{{ r.valeur }}" class="bold" disabled="disabled">
+                            <option value="{{ r.valeur }}" data-workflow="{{ r.notification_workflow }}" class="bold" disabled="disabled">
                               {{ r.valeur }}
                             </option>
                           {% else %}
-                            <option value="{{ r.valeur }}" class="bold">
+                            <option value="{{ r.valeur }}" data-workflow="{{ r.notification_workflow }}" class="bold">
                               {{ r.valeur }}
                             </option>
                           {% endif %}

--- a/templates/absences/edit.html.twig
+++ b/templates/absences/edit.html.twig
@@ -31,7 +31,6 @@
           <input type='hidden' name='rrule' id='rrule' value='{{ absence.rrule }}' />
           <input type='hidden' name='recurrence-modif' id='recurrence-modif' value='' />
           <input type='hidden' name='absence_status' id='absence_status' value="{{ absence.status }}" />
-          <input type='hidden' name='workflow' id='workflow' value="{{ absence.workflow }}" />
 
           <table class='tableauFiches'>
             {% for agent in agents %}

--- a/templates/absences/edit.html.twig
+++ b/templates/absences/edit.html.twig
@@ -31,6 +31,7 @@
           <input type='hidden' name='rrule' id='rrule' value='{{ absence.rrule }}' />
           <input type='hidden' name='recurrence-modif' id='recurrence-modif' value='' />
           <input type='hidden' name='absence_status' id='absence_status' value="{{ absence.status }}" />
+          <input type='hidden' name='workflow' id='workflow' value="{{ absence.workflow }}" />
 
           <table class='tableauFiches'>
             {% for agent in agents %}
@@ -159,22 +160,22 @@
                       {% for r in reasons %}
                         {% if r.type == 2 %}
                           {% if r.valeur == absence.motif %}
-                          <option value="{{ r.valeur }}" class="padding20" selected="selected">
+                          <option value="{{ r.valeur }}" data-workflow="{{ r.notification_workflow }}" class="padding20" selected="selected">
                           {% else %}
-                          <option value="{{ r.valeur }}" class="padding20">
+                          <option value="{{ r.valeur }}" data-workflow="{{ r.notification_workflow }}" class="padding20">
                           {% endif %}
                             &nbsp;&nbsp;&nbsp;{{ r.valeur }}
                           </option>
                         {% else %}
                           {% if r.type == 1 %}
-                            <option value="{{ r.valeur }}" class="bold" disabled="disabled">
+                            <option value="{{ r.valeur }}" data-workflow="{{ r.notification_workflow }}" class="bold" disabled="disabled">
                               {{ r.valeur }}
                             </option>
                           {% else %}
                             {% if r.valeur == absence.motif %}
-                            <option value="{{ r.valeur }}" class="bold" selected="selected">
+                            <option value="{{ r.valeur }}" data-workflow="{{ r.notification_workflow }}" class="bold" selected="selected">
                             {% else %}
-                            <option value="{{ r.valeur }}" class="bold">
+                            <option value="{{ r.valeur }}" data-workflow="{{ r.notification_workflow }}" class="bold">
                             {% endif %}
                               {{ r.valeur }}
                             </option>

--- a/tests/Class/ClassAbsencesTest.php
+++ b/tests/Class/ClassAbsencesTest.php
@@ -3,11 +3,15 @@
 use PHPUnit\Framework\TestCase;
 
 use App\Entity\Agent;
+use App\Entity\AbsenceReason;
 use App\Entity\ConfigParam;
+use App\Entity\Manager;
+use Tests\FixtureBuilder;
+use Tests\PLBWebTestCase;
 
 require_once(__DIR__ . '/../../public/absences/class.absences.php');
 
-class ClassAbsencesTest extends TestCase
+class ClassAbsencesTest extends PLBWebTestCase
 {
     public function testBuildICSContent()
     {
@@ -69,9 +73,126 @@ class ClassAbsencesTest extends TestCase
         $absence->getRecipients("-A2", $responsables, $member);
         $destinataires = $absence->recipients;
         $this->assertEmpty($destinataires, 'When all Absences-notification* are empty arrays, recipients is empty');
+    }
 
+    public function testGetRecipients2()
+    {
+        $this->setParam('Absences-notifications-agent-par-agent', 1);
+        $this->setParam('Absences-validation', 1);
+        # Absence must be validated at level1 first
+        $this->setParam('Absences-Validation-N2', 1);
 
+        # Absence reason with workflow B
+        $workflow_b_reason = 'Reason with workflow B';
+        $ar = new AbsenceReason();
+        $ar->setValue($workflow_b_reason);
+        $ar->setRank(1);
+        $ar->setType(1);
+        $ar->setTeleworking(0);
+        $ar->setNotificationWorkflow('B');
+        $this->entityManager->persist($ar);
 
+        $builder = new FixtureBuilder();
+        $builder->delete(Agent::class);
+        $agent1 = $builder->build(Agent::class, array('mail' => 'agent@example.com'));
+        $manager_level1_for_agent1 = $builder->build(Agent::class, array('mail' => 'managerlevel1@example.com'));
+        $manager_level2_for_agent1 = $builder->build(Agent::class, array('mail' => 'managerlevel2@example.com'));
+
+        $managed1 = new Manager();
+        $managed1->setUser($agent1);
+        $managed1->setLevel1(1);
+        $managed1->setLevel1Notification(1);
+        $managed1->setLevel2(0);
+        $manager_level1_for_agent1->addManaged($managed1);
+
+        $managed2 = new Manager();
+        $managed2->setUser($agent1);
+        $managed2->setLevel1(0);
+        $managed2->setLevel2(1);
+        $managed2->setLevel2Notification(1);
+        $manager_level2_for_agent1->addManaged($managed2);
+
+        $this->entityManager->persist($managed1);
+        $this->entityManager->persist($managed2);
+        $this->entityManager->persist($manager_level1_for_agent1);
+        $this->entityManager->persist($manager_level2_for_agent1);
+        $this->entityManager->persist($agent1);
+        $this->entityManager->flush();
+
+        $this->assertTrue( $manager_level1_for_agent1->isManagerOf(array($agent1->getId()), 'level1'));
+        $this->assertFalse($manager_level1_for_agent1->isManagerOf(array($agent1->getId()), 'level2'));
+
+        $this->assertFalse($manager_level2_for_agent1->isManagerOf(array($agent1->getId()), 'level1'));
+        $this->assertTrue( $manager_level2_for_agent1->isManagerOf(array($agent1->getId()), 'level2'));
+
+        $id = $this->createAbsenceFor($agent1, 0);
+        $this->assertEquals('managerlevel1@example.com', $this->getRecipients($id, 1)[0], "creating a workflow A absence notifies manager level1");
+        $this->assertEquals('managerlevel2@example.com', $this->getRecipients($id, 3)[0], "validating a workflow A absence at level 1 notifies manager level2");
+        $this->assertEquals('agent@example.com', $this->getRecipients($id, 4)[0], "validating a workflow A absence at level 2 notifies agent");
+
+        $id = $this->createAbsenceFor($agent1, 0, $workflow_b_reason);
+        $this->assertEquals('managerlevel1@example.com', $this->getRecipients($id, 1)[0], "creating a workflow B absence notifies manager level1");
+        # getRecipients2 on workflow B will never be called with notifications = 3, because it is directly validated at level 2
+        $this->assertEquals('agent@example.com', $this->getRecipients($id, 4)[0], "validating a workflow B absence at level 2 notifies agent");
+
+        # Revert params
+        $this->setParam('Absences-notifications-agent-par-agent', 0);
+        $this->setParam('Absences-validation', 0);
+        $this->setParam('Absences-Validation-N2', 0);
+
+    }
+
+    private function getRecipients($absence_id, $notifications) {
+        $a = new \absences();
+        $a->fetchById($absence_id);
+        $agents = $a->elements['agents'];
+        $debut = $a->elements['debut'];
+        $fin = $a->elements['fin'];
+        $a->getRecipients2(null, $agents, $notifications, 500, $debut, $fin);
+        return $a->recipients;
+    }
+
+    private function createAbsenceFor($agent, $status = 0, $motif = 'default')
+    {
+        $date = new DateTime('now');
+
+        $absence = new \absences();
+        $absence->debut = $date->format('Y-m-d');
+        $absence->fin = $date->format('Y-m-d');
+        $absence->hre_debut = '00:00:00';
+        $absence->hre_fin = '23:59:59';
+        $absence->perso_ids = array($agent->getId());
+        $absence->commentaires = '';
+        $absence->motif = $motif;
+
+        # Note:
+
+        # In database:
+        # valide = 0  and valide_n1 = 0  when the absence is asked for
+        # valide = 0  and valide_n1 = id when the absence is approved (waiting for hierarchy approval)
+        # valide = id and valide_n1 = id when the absence is approved
+
+        # In absence object:
+        # valide = 0 when is the absence is asked for
+        # valide = 1 when is the absence is approved
+        # valide = 2 when the absence is approved (waiting for hierarchy approval)
+
+        # In a nutshell:
+        # database valide    = object valide_n1
+        # database valide_n1 = object valide_n2
+
+        $absence->valide = $status;
+        $absence->valide_n1 = $status;
+        $absence->valide_n2 = $status;
+        $absence->CSRFToken = $this->CSRFToken;
+        $absence->pj1 = '';
+        $absence->pj2 = '';
+        $absence->so = '';
+
+        $absence->add();
+#        print_r($absence->recipients);
+
+        return $absence->id;
     }
 
     protected function setParam($name, $value)

--- a/tests/Controller/AbsenceControllerDeleteTest.php
+++ b/tests/Controller/AbsenceControllerDeleteTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Entity\Absence;
+use App\Entity\AbsenceReason;
 use App\Entity\Agent;
 use App\Entity\Manager;
 use Tests\FixtureBuilder;
@@ -24,6 +25,11 @@ class AbsenceControllerDeleteTest extends PLBWebTestCase
         $agents[2] = $this->builder->build(Agent::class, array('login' => 'kboivin'));
 
         $this->agents = $agents;
+
+        $absenceReason = $this->entityManager->getRepository(AbsenceReason::class)->findOneBy(['valeur' => 'Réunion']);
+        $absenceReason->setNotificationWorkflow('B');
+        $this->entityManager->persist($absenceReason);
+        $this->entityManager->flush();
     }
 
     public function test1()

--- a/tests/Controller/AbsenceControllerDeleteTest.php
+++ b/tests/Controller/AbsenceControllerDeleteTest.php
@@ -2,6 +2,7 @@
 
 use App\Entity\Absence;
 use App\Entity\Agent;
+use App\Entity\Manager;
 use Tests\FixtureBuilder;
 use Tests\PLBWebTestCase;
 
@@ -402,6 +403,34 @@ class AbsenceControllerDeleteTest extends PLBWebTestCase
         $this->createAndTest($acl, $nbAgent, $validations, $result, 1);
     }
 
+    public function test19()
+    {
+        /**
+         * Absences-validation enabled
+         * Agent is admin level 1 (right 201)
+         * Absence is not his own
+         * Absence workflow is B
+         * The absence can be deleted
+         */
+
+        $this->setParam('Absences-validation', 1);
+        $this->setParam('Absences-notifications-agent-par-agent', 1);
+        $agents = $this->agents;
+        $managed1 = new Manager();
+        $managed1->setUser($agents[0]);
+        $managed1->setLevel1(1);
+        $managed1->setLevel2(0);
+        $agents[1]->addManaged($managed1);
+
+        $acl = [201];
+        $nbAgent = 1;
+        $result = 'empty';
+
+        $validations = [0,1];
+        $this->createAndTest($acl, $nbAgent, $validations, $result, 1);
+    }
+
+
 
 
     private function createAndTest($acl, $nbAgents = 1, $validations = [1,1], $result = 'empty', $loggedInAgentId = 0)
@@ -450,9 +479,9 @@ class AbsenceControllerDeleteTest extends PLBWebTestCase
         $test = $this->entityManager->getRepository(Absence::class)->findBy(['id' => $absence->getId()]);
 
         if ($result == 'empty') {
-            $this->assertEmpty($test, 'Absence not deleted');
+            $this->assertEmpty($test, 'Absence was not been deleted (it should have been deleted)');
         } else {
-            $this->assertNotEmpty($test, 'Absence deleted');
+            $this->assertNotEmpty($test, 'Absence was deleted (it should\'nt have been deleted)');
         }
     }
 }

--- a/tests/Traits/EntityValidationStatusesTest.php
+++ b/tests/Traits/EntityValidationStatusesTest.php
@@ -1,0 +1,453 @@
+<?php 
+use App\Entity\AbsenceReason;
+use App\Entity\Agent;
+use App\Entity\Model;
+use App\Entity\Manager;
+
+use Tests\FixtureBuilder;
+use Tests\PLBWebTestCase;
+
+use PHPUnit\Framework\TestCase;
+
+#class EntityValidationStatusesTest extends TestCase
+class EntityValidationStatusesTest extends PLBWebTestCase
+{
+    use \App\Traits\EntityValidationStatuses;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->builder->delete(Agent::class);
+    }
+
+
+    public function testGetStatusesParams()
+    {
+        $this->setUpPantherClient();
+        $this->setParam('Absences-notifications-agent-par-agent', 1);
+        $this->setParam('Absences-validation', 1);
+        # Absence must be validated at level1 first
+        $this->setParam('Absences-Validation-N2', 1);
+
+        global $entityManager;
+        $builder = new FixtureBuilder();
+        $builder->delete(Agent::class);
+
+        # descriptions
+        $desc_state_0 = "Demandée";
+        $desc_state_1 = "Acceptée";
+        $desc_state_2 = "Acceptée (En attente de validation hiérarchique)";
+        $refused_state_1 = "Refusée";
+        $refused_state_2 = "Refusée (En attente de validation hiérarchique)";
+
+        $workflow_b_reason = 'Reason with workflow B';
+
+        # Absence reason with workflow B
+        $ar = new AbsenceReason();
+        $ar->setValue($workflow_b_reason);
+        $ar->setRank(1);
+        $ar->setType(1);
+        $ar->setTeleworking(0);
+        $ar->setNotificationWorkflow('B');
+        $this->entityManager->persist($ar);
+
+        # Logged-in user
+        # Scenarios: logged in as: myself, no-rights, level1, level2, admin
+
+        # Agents
+        $agent1 = $builder->build(Agent::class);
+        $manager_level1_for_agent1 = $builder->build(Agent::class);
+        $manager_level2_for_agent1 = $builder->build(Agent::class);
+        $manager_level1_level2_for_agent1 = $builder->build(Agent::class);
+
+        $managed1 = new Manager();
+        $managed1->setUser($agent1);
+        $managed1->setLevel1(1);
+        $managed1->setLevel2(0);
+        $manager_level1_for_agent1->addManaged($managed1);
+
+        $managed2 = new Manager();
+        $managed2->setUser($agent1);
+        $managed2->setLevel1(0);
+        $managed2->setLevel2(1);
+        $manager_level2_for_agent1->addManaged($managed2);
+
+        $managed3 = new Manager();
+        $managed3->setUser($agent1);
+        $managed3->setLevel1(1);
+        $managed3->setLevel2(1);
+        $manager_level1_level2_for_agent1->addManaged($managed3);
+
+
+        $this->assertTrue( $manager_level1_for_agent1->isManagerOf(array($agent1->getId()), 'level1'));
+        $this->assertFalse($manager_level1_for_agent1->isManagerOf(array($agent1->getId()), 'level2'));
+
+        $this->assertFalse($manager_level2_for_agent1->isManagerOf(array($agent1->getId()), 'level1'));
+        $this->assertTrue( $manager_level2_for_agent1->isManagerOf(array($agent1->getId()), 'level2'));
+
+        $this->assertTrue($manager_level1_level2_for_agent1->isManagerOf(array($agent1->getId()), 'level1'));
+        $this->assertTrue($manager_level1_level2_for_agent1->isManagerOf(array($agent1->getId()), 'level2'));
+
+        $this->login($agent1);
+        $_SESSION['login_id'] = $agent1->getId();
+
+        $agents_ids = array($agent1->getId());
+        $module = 'absence';
+
+        # MYSELF
+        ## CREATION
+        ### Logged-in as myself
+        $params = $this->getStatusesParams($agents_ids, $module);
+        $this->assertEquals($desc_state_0, $params['entity_state_desc'], 'entity state description is Asked for');
+        $this->assertEquals(0, $params['entity_state'], 'entity state');
+        $this->assertFalse($params['show_select'], 'showing select');
+        $this->assertFalse($params['show_n1'], 'Show n1');
+        $this->assertFalse($params['show_n2'], 'Show n2');
+
+        ## EDITION
+        ### Logged-in as myself, editing an absence for myself
+        $absence_id = $this->createAbsenceFor($agent1);
+        $params = $this->getStatusesParams($agents_ids, $module, $absence_id);
+        $this->assertEquals($desc_state_0, $params['entity_state_desc'], 'entity state description is Asked for');
+        $this->assertEquals(0, $params['entity_state'], 'entity state');
+        $this->assertFalse($params['show_select'], 'showing select');
+        $this->assertFalse($params['show_n1'], 'Show n1');
+        $this->assertFalse($params['show_n2'], 'Show n2');
+
+        # MANAGER LEVEL1
+        $this->login($manager_level1_for_agent1);
+        $_SESSION['login_id'] = $manager_level1_for_agent1->getId();
+
+        ## CREATION
+        $params = $this->getStatusesParams($agents_ids, $module);
+        $this->assertEquals($desc_state_0, $params['entity_state_desc'], 'entity state description is Asked for');
+        $this->assertEquals(0, $params['entity_state'], 'entity state');
+        $this->assertTrue($params['show_select'], 'showing select');
+        $this->assertTrue($params['show_n1'], 'Show n1');
+        $this->assertFalse($params['show_n2'], 'Show n2');
+
+        ## EDITION
+        ### Logged-in as manager level1, editing an unvalidated workflow A absence for agent1
+        $absence_id = $this->createAbsenceFor($agent1);
+        $params = $this->getStatusesParams($agents_ids, $module, $absence_id);
+        $this->assertEquals($desc_state_0, $params['entity_state_desc'], 'entity state description is Asked for');
+        $this->assertEquals(0, $params['entity_state'], 'entity state');
+        $this->assertTrue($params['show_select'], 'showing select');
+        $this->assertTrue($params['show_n1'], 'Show n1');
+        $this->assertFalse($params['show_n2'], 'Show n2');
+
+        ### Logged-in as manager level1, editing a level1 validated workflow A absence for agent1
+        $absence_id = $this->createAbsenceFor($agent1, 2);
+        $params = $this->getStatusesParams($agents_ids, $module, $absence_id);
+        $this->assertEquals($desc_state_2, $params['entity_state_desc'], 'entity state description is Accepted (waiting for hierarchy approval)');
+        $this->assertEquals(2, $params['entity_state'], 'entity state');
+        $this->assertTrue($params['show_select'], 'showing select');
+        $this->assertTrue($params['show_n1'], 'Show n1');
+        $this->assertFalse($params['show_n2'], 'Show n2');
+
+        ### Logged-in as manager level1, editing a level1 refused workflow A absence for agent1
+        $absence_id = $this->createAbsenceFor($agent1, -2);
+        $params = $this->getStatusesParams($agents_ids, $module, $absence_id);
+        $this->assertEquals($refused_state_2, $params['entity_state_desc'], 'entity state description is Refused (waiting for hierarchy approval)');
+        $this->assertEquals(-2, $params['entity_state'], 'entity state');
+        $this->assertTrue($params['show_select'], 'showing select');
+        $this->assertTrue($params['show_n1'], 'Show n1');
+        $this->assertFalse($params['show_n2'], 'Show n2');
+
+        ### Logged-in as manager level1, editing a level2 validated workflow A absence for agent1
+        $absence_id = $this->createAbsenceFor($agent1, 1);
+        $params = $this->getStatusesParams($agents_ids, $module, $absence_id);
+        $this->assertEquals($desc_state_1, $params['entity_state_desc'], 'entity state description is Accepted');
+        $this->assertEquals(1, $params['entity_state'], 'entity state');
+        $this->assertFalse($params['show_select'], 'level1 manager cannot change level2 decision');
+        $this->assertTrue($params['show_n1'], 'Show n1');
+        $this->assertFalse($params['show_n2'], 'Show n2');
+
+        ### Logged-in as manager level1, editing a level2 refused workflow A absence for agent1
+        $absence_id = $this->createAbsenceFor($agent1, -1);
+        $params = $this->getStatusesParams($agents_ids, $module, $absence_id);
+        $this->assertEquals($refused_state_1, $params['entity_state_desc'], 'entity state description is Refused');
+        $this->assertEquals(-1, $params['entity_state'], 'entity state');
+        $this->assertFalse($params['show_select'], 'level1 manager cannot change level2 decision');
+        $this->assertTrue($params['show_n1'], 'Show n1');
+        $this->assertFalse($params['show_n2'], 'Show n2');
+
+        ### Logged-in as manager level1, editing an unvalidated workflow B absence for agent1
+        $absence_id = $this->createAbsenceFor($agent1, 1, $workflow_b_reason);
+        $params = $this->getStatusesParams($agents_ids, $module, $absence_id, 'B');
+        $this->assertEquals($desc_state_1, $params['entity_state_desc'], 'entity state description is Accepted');
+        $this->assertEquals(1, $params['entity_state'], 'entity state');
+        $this->assertTrue($params['show_select'], 'showing select');
+        $this->assertFalse($params['show_n1'], 'Don\'t show n1 when editing a workflow B absence');
+        $this->assertTrue($params['show_n2'], 'Show n2');
+
+        ### Logged-in as manager level1, editing a level1 validated workflow B absence for agent1
+        #### In theory, this shouldn't happen, since validating a worflow B absence at level1 means validating it completely
+        $absence_id = $this->createAbsenceFor($agent1, 2, $workflow_b_reason);
+        $params = $this->getStatusesParams($agents_ids, $module, $absence_id, 'B');
+        $this->assertEquals($desc_state_2, $params['entity_state_desc'], 'entity state description is Accepted (waiting for hierarchy approval)');
+        $this->assertEquals(2, $params['entity_state'], 'entity state');
+        $this->assertTrue($params['show_select'], 'showing select');
+        $this->assertFalse($params['show_n1'], 'show n1');
+        $this->assertTrue($params['show_n2'], 'Show n2');
+
+        ### Logged-in as manager level1, editing a level1 refused workflow B absence for agent1
+        #### In theory, this shouldn't happen, since refusing a worflow B absence at level1 means refusing it completely
+        $absence_id = $this->createAbsenceFor($agent1, -2, $workflow_b_reason);
+        $params = $this->getStatusesParams($agents_ids, $module, $absence_id, 'B');
+        $this->assertEquals($refused_state_2, $params['entity_state_desc'], 'entity state description is Refused (waiting for hierarchy approval)');
+        $this->assertEquals(-2, $params['entity_state'], 'entity state');
+        $this->assertTrue($params['show_select'], 'showing select');
+        $this->assertFalse($params['show_n1'], 'Don\'t show n1 when editing a workflow B absence');
+        $this->assertTrue($params['show_n2'], 'Show n2');
+
+        ### Logged-in as manager level1, editing a level2 validated workflow B absence for agent1
+        $absence_id = $this->createAbsenceFor($agent1, 1, $workflow_b_reason);
+        $params = $this->getStatusesParams($agents_ids, $module, $absence_id, 'B');
+        $this->assertEquals($desc_state_1, $params['entity_state_desc'], 'entity state description is Accepted');
+        $this->assertEquals(1, $params['entity_state'], 'entity state');
+        $this->assertTrue($params['show_select'], 'showing select');
+        $this->assertFalse($params['show_n1'], 'Don\'t show n1 when editing a workflow B absence');
+        $this->assertTrue($params['show_n2'], 'Show n2');
+
+        ### Logged-in as manager level1, editing a level2 validated workflow B absence for agent1
+        $absence_id = $this->createAbsenceFor($agent1, -1, $workflow_b_reason);
+        $params = $this->getStatusesParams($agents_ids, $module, $absence_id, 'B');
+        $this->assertEquals($refused_state_1, $params['entity_state_desc'], 'entity state description is Refused');
+        $this->assertEquals(-1, $params['entity_state'], 'entity state');
+        $this->assertTrue($params['show_select'], 'showing select');
+        $this->assertFalse($params['show_n1'], 'show n1 when editing a workflow B absence');
+        $this->assertTrue($params['show_n2'], 'Show n2');
+
+
+        # MANAGER LEVEL2
+        $this->login($manager_level2_for_agent1);
+        $_SESSION['login_id'] = $manager_level2_for_agent1->getId();
+
+        ## CREATION
+        $this->setParam('Absences-Validation-N2', 1);
+        $params = $this->getStatusesParams($agents_ids, $module);
+        $this->assertEquals($desc_state_0, $params['entity_state_desc'], 'entity state description is Asked for');
+        $this->assertEquals(0, $params['entity_state'], 'entity state');
+        $this->assertFalse($params['show_select'], 'showing select');
+        $this->assertTrue($params['show_n1'], 'Show n1');
+        $this->assertTrue($params['show_n2'], 'Show n2');
+
+        $this->setParam('Absences-Validation-N2', 0);
+        $params = $this->getStatusesParams($agents_ids, $module);
+        $this->assertEquals($desc_state_0, $params['entity_state_desc'], 'entity state description is Asked for');
+        $this->assertEquals(0, $params['entity_state'], 'entity state');
+        $this->assertTrue($params['show_select'], 'showing select');
+        $this->assertTrue($params['show_n1'], 'Show n1');
+        $this->assertTrue($params['show_n2'], 'Show n2');
+
+        ## EDITION
+        ### Logged-in as manager level2, editing an unvalidated workflow A absence for agent1
+        #### Absence must be validated at level1 first
+        $this->setParam('Absences-Validation-N2', 1);
+        $absence_id = $this->createAbsenceFor($agent1);
+        $params = $this->getStatusesParams($agents_ids, $module, $absence_id);
+        $this->assertEquals($desc_state_0, $params['entity_state_desc'], 'entity state description is Asked for');
+        $this->assertEquals(0, $params['entity_state'], 'entity state');
+        $this->assertFalse($params['show_select'], 'showing select');
+        $this->assertTrue($params['show_n1'], 'Show n1');
+        $this->assertTrue($params['show_n2'], 'Show n2');
+
+        #### Absence can be validated at level 2 directly
+        $this->setParam('Absences-Validation-N2', 0);
+        $absence_id = $this->createAbsenceFor($agent1);
+        $params = $this->getStatusesParams($agents_ids, $module, $absence_id);
+        $this->assertEquals($desc_state_0, $params['entity_state_desc'], 'entity state description is Asked for');
+        $this->assertEquals(0, $params['entity_state'], 'entity state');
+        $this->assertTrue($params['show_select'], 'showing select');
+        $this->assertTrue($params['show_n1'], 'Show n1');
+        $this->assertTrue($params['show_n2'], 'Show n2');
+
+        ### Logged-in as manager level2, editing a level1 validated workflow A absence for agent1
+        $this->setParam('Absences-Validation-N2', 1);
+        $absence_id = $this->createAbsenceFor($agent1, 2);
+        $params = $this->getStatusesParams($agents_ids, $module, $absence_id);
+        $this->assertEquals($desc_state_2, $params['entity_state_desc'], 'entity state description is Accepted (waiting for hierarchy approval)');
+        $this->assertEquals(2, $params['entity_state'], 'entity state');
+        $this->assertTrue($params['show_select'], 'showing select');
+        $this->assertTrue($params['show_n1'], 'Show n1');
+        $this->assertTrue($params['show_n2'], 'Show n2');
+
+        ### Logged-in as manager level2, editing a level2 validated workflow A absence for agent1
+        $absence_id = $this->createAbsenceFor($agent1, 1);
+        $params = $this->getStatusesParams($agents_ids, $module, $absence_id);
+        $this->assertEquals($desc_state_1, $params['entity_state_desc'], 'entity state description is Accepted');
+        $this->assertEquals(1, $params['entity_state'], 'entity state');
+        $this->assertTrue($params['show_select'], 'level2 manager can change level2 decision');
+        $this->assertTrue($params['show_n1'], 'Show n1');
+        $this->assertTrue($params['show_n2'], 'Show n2');
+
+        ### Logged-in as manager level2, editing an unvalidated workflow B absence for agent1
+        $absence_id = $this->createAbsenceFor($agent1, 1, $workflow_b_reason);
+        $params = $this->getStatusesParams($agents_ids, $module, $absence_id, 'B');
+        $this->assertEquals($desc_state_1, $params['entity_state_desc'], 'entity state description is Accepted');
+        $this->assertEquals(1, $params['entity_state'], 'entity state');
+        $this->assertTrue($params['show_select'], 'showing select');
+        $this->assertFalse($params['show_n1'], 'Don\'t show n1 when editing a workflow B absence');
+        $this->assertTrue($params['show_n2'], 'Show n2');
+
+        ### Logged-in as manager level2, editing a level1 validated workflow B absence for agent1
+        $absence_id = $this->createAbsenceFor($agent1, 2, $workflow_b_reason);
+        $params = $this->getStatusesParams($agents_ids, $module, $absence_id, 'B');
+        $this->assertEquals($desc_state_2, $params['entity_state_desc'], 'entity state description is Accepted (waiting for hierarchy approval)');
+        $this->assertEquals(2, $params['entity_state'], 'entity state');
+        $this->assertTrue($params['show_select'], 'showing select');
+        $this->assertFalse($params['show_n1'], 'Don\'t show n1 when editing a workflow B absence');
+        $this->assertTrue($params['show_n2'], 'Show n2');
+
+        ### Logged-in as manager level2, editing a level2 validated workflow B absence for agent1
+        $absence_id = $this->createAbsenceFor($agent1, 1, $workflow_b_reason);
+        $params = $this->getStatusesParams($agents_ids, $module, $absence_id, 'B');
+        $this->assertEquals($desc_state_1, $params['entity_state_desc'], 'entity state description is Accepted');
+        $this->assertEquals(1, $params['entity_state'], 'entity state');
+        $this->assertTrue($params['show_select'], 'showing select');
+        $this->assertFalse($params['show_n1'], 'Don\'t show n1 when editing a workflow B absence');
+        $this->assertTrue($params['show_n2'], 'Show n2');
+
+
+        # MANAGER LEVEL1 & LEVEL2
+        $this->login($manager_level1_level2_for_agent1);
+        $_SESSION['login_id'] = $manager_level1_level2_for_agent1->getId();
+
+        ## CREATION
+        $this->setParam('Absences-Validation-N2', 1);
+        $params = $this->getStatusesParams($agents_ids, $module);
+        $this->assertEquals($desc_state_0, $params['entity_state_desc'], 'entity state description is Asked for');
+        $this->assertEquals(0, $params['entity_state'], 'entity state');
+        $this->assertTrue($params['show_select'], 'showing select');
+        $this->assertTrue($params['show_n1'], 'Show n1');
+        $this->assertTrue($params['show_n2'], 'Show n2');
+
+        $this->setParam('Absences-Validation-N2', 0);
+        $params = $this->getStatusesParams($agents_ids, $module);
+        $this->assertEquals($desc_state_0, $params['entity_state_desc'], 'entity state description is Asked for');
+        $this->assertEquals(0, $params['entity_state'], 'entity state');
+        $this->assertTrue($params['show_select'], 'showing select');
+        $this->assertTrue($params['show_n1'], 'Show n1');
+        $this->assertTrue($params['show_n2'], 'Show n2');
+
+        ## EDITION
+        ### Logged-in as manager level 1 and 2, editing an unvalidated workflow A absence for agent1
+        #### Absence must be validated at level1 first
+        $this->setParam('Absences-Validation-N2', 1);
+        $absence_id = $this->createAbsenceFor($agent1);
+        $params = $this->getStatusesParams($agents_ids, $module, $absence_id);
+        $this->assertEquals($desc_state_0, $params['entity_state_desc'], 'entity state description is Asked for');
+        $this->assertEquals(0, $params['entity_state'], 'entity state');
+        $this->assertTrue($params['show_select'], 'level 1 & 2 manager can edit an unvalidated absence when absence must be validated at level1 first');
+        $this->assertTrue($params['show_n1'], 'Show n1');
+        $this->assertTrue($params['show_n2'], 'Show n2');
+
+        #### Absence can be validated at level 2 directly
+        $this->setParam('Absences-Validation-N2', 0);
+        $absence_id = $this->createAbsenceFor($agent1);
+        $params = $this->getStatusesParams($agents_ids, $module, $absence_id);
+        $this->assertEquals($desc_state_0, $params['entity_state_desc'], 'entity state description is Asked for');
+        $this->assertEquals(0, $params['entity_state'], 'entity state');
+        $this->assertTrue($params['show_select'], 'showing select');
+        $this->assertTrue($params['show_n1'], 'Show n1');
+        $this->assertTrue($params['show_n2'], 'Show n2');
+
+        ### Logged-in as manager level 1 and 2, editing a level1 validated workflow A absence for agent1
+        $this->setParam('Absences-Validation-N2', 1);
+        $absence_id = $this->createAbsenceFor($agent1, 2);
+        $params = $this->getStatusesParams($agents_ids, $module, $absence_id);
+        $this->assertEquals($desc_state_2, $params['entity_state_desc'], 'entity state description is Accepted (waiting for hierarchy approval)');
+        $this->assertEquals(2, $params['entity_state'], 'entity state');
+        $this->assertTrue($params['show_select'], 'showing select');
+        $this->assertTrue($params['show_n1'], 'Show n1');
+        $this->assertTrue($params['show_n2'], 'Show n2');
+
+        ### Logged-in as manager level 1 and 2, editing a level2 validated workflow A absence for agent1
+        $absence_id = $this->createAbsenceFor($agent1, 1);
+        $params = $this->getStatusesParams($agents_ids, $module, $absence_id);
+        $this->assertEquals($desc_state_1, $params['entity_state_desc'], 'entity state description is Accepted');
+        $this->assertEquals(1, $params['entity_state'], 'entity state');
+        $this->assertTrue($params['show_select'], 'level2 manager can change level2 decision');
+        $this->assertTrue($params['show_n1'], 'Show n1');
+        $this->assertTrue($params['show_n2'], 'Show n2');
+
+        ### Logged-in as manager level 1 and 2, editing an unvalidated workflow B absence for agent1
+        $absence_id = $this->createAbsenceFor($agent1, 1, $workflow_b_reason);
+        $params = $this->getStatusesParams($agents_ids, $module, $absence_id, 'B');
+        $this->assertEquals($desc_state_1, $params['entity_state_desc'], 'entity state description is Accepted');
+        $this->assertEquals(1, $params['entity_state'], 'entity state');
+        $this->assertTrue($params['show_select'], 'showing select');
+        $this->assertFalse($params['show_n1'], 'Don\'t show n1 when editing a workflow B absence');
+        $this->assertTrue($params['show_n2'], 'Show n2');
+
+        ### Logged-in as manager level 1 and 2, editing a level1 validated workflow B absence for agent1
+        $absence_id = $this->createAbsenceFor($agent1, 2, $workflow_b_reason);
+        $params = $this->getStatusesParams($agents_ids, $module, $absence_id, 'B');
+        $this->assertEquals($desc_state_2, $params['entity_state_desc'], 'entity state description is Accepted (waiting for hierarchy approval)');
+        $this->assertEquals(2, $params['entity_state'], 'entity state');
+        $this->assertTrue($params['show_select'], 'showing select');
+        $this->assertFalse($params['show_n1'], 'Don\'t show n1 when editing a workflow B absence');
+        $this->assertTrue($params['show_n2'], 'Show n2');
+
+        ### Logged-in as manager level 1 and 2, editing a level2 validated workflow B absence for agent1
+        $absence_id = $this->createAbsenceFor($agent1, 1, $workflow_b_reason);
+        $params = $this->getStatusesParams($agents_ids, $module, $absence_id, 'B');
+        $this->assertEquals($desc_state_1, $params['entity_state_desc'], 'entity state description is Accepted');
+        $this->assertEquals(1, $params['entity_state'], 'entity state');
+        $this->assertTrue($params['show_select'], 'showing select');
+        $this->assertFalse($params['show_n1'], 'Don\'t show n1 when editing a workflow B absence');
+        $this->assertTrue($params['show_n2'], 'Show n2');
+    }
+
+    private function debug_absence($id) {
+        $absence = new \absences();
+        $absence->fetchById($id);
+        print_r($absence->elements);
+    }
+
+    private function createAbsenceFor($agent, $status = 0, $motif = 'default')
+    {
+        $date = new DateTime('now');
+
+        $absence = new \absences();
+        $absence->debut = $date->format('Y-m-d');
+        $absence->fin = $date->format('Y-m-d');
+        $absence->hre_debut = '00:00:00';
+        $absence->hre_fin = '23:59:59';
+        $absence->perso_ids = array($agent->getId());
+        $absence->commentaires = '';
+        $absence->motif = $motif;
+
+        # Note:
+
+        # In database:
+        # valide = 0  and valide_n1 = 0  when the absence is asked for
+        # valide = 0  and valide_n1 = id when the absence is approved (waiting for hierarchy approval)
+        # valide = id and valide_n1 = id when the absence is approved
+
+        # In absence object:
+        # valide = 0 when is the absence is asked for
+        # valide = 1 when is the absence is approved
+        # valide = 2 when the absence is approved (waiting for hierarchy approval)
+
+        # In a nutshell:
+        # database valide    = object valide_n1
+        # database valide_n1 = object valide_n2
+
+        $absence->valide = $status;
+        $absence->valide_n1 = $status;
+        $absence->valide_n2 = $status;
+        $absence->CSRFToken = $this->CSRFToken;
+        $absence->pj1 = '';
+        $absence->pj2 = '';
+        $absence->so = '';
+
+        $absence->add();
+
+        return $absence->id;
+    }
+
+}
+


### PR DESCRIPTION
This allows to use a new validation schema (workflow 'B') for absences.

The following configuration options must be enabled:
     Absences-notifications-agent-par-agent
     Absences-validation

Test plan:
 1) Enable Absences-notifications-agent-par-agent and Absences-validation
 2) Set an absence reason notification workflow to 'B'
 3) Create an absence with that reason
 4) Check that the absence status can be among the following:
  - Asked for
  - Validated
  - Denied

 Note that the following options are no longer available:
 => Validated (waiting for hierarchy approval)
 => Denied (waiting for hierarchy approval)

 5) Edit that absence and check that
 "Validated (waiting for hierarchy approval)" and
 "Denied (waiting for hierarchy approval)" are still no longer displayed

 See tests/Traits/EntityValidationStatusesTest.php for unit tests

 6) Check that the absence status list is updated when changing the absence
    reason, both in absence creation and edition.

 7) As a level 1 manager, check that you can:
     - validate a workflow B absence (without hierarchy approval)
     - edit a validated workflow B absence - delete a validated workflow B absence

 8) When manipulating a workflow B absence, check that level 2 managers don't
    get notified

 See tests/Class/ClassAbsencesTest.php for unit tests