### PR TITLE
MT48762: Remove the background color from printing

### DIFF
--- a/public/planning/poste/ajax.updateCell.php
+++ b/public/planning/poste/ajax.updateCell.php
@@ -327,9 +327,11 @@ for ($i=0;$i<count($tab);$i++) {
     $tab[$i]["service"]=removeAccents($tab[$i]["service"]);
 
     // Color the logged in agent.
-    $tab[$i]['color'] = null;
     if (!empty($config['Affichage-Agent']) and $tab[$i]['perso_id'] == $_SESSION['login_id']) {
-      $tab[$i]['color'] = filter_var($config['Affichage-Agent'], FILTER_CALLBACK, ['options' => 'sanitize_color']);
+        $tab[$i]['is_current_user'] = 1;
+    }
+    else{
+        $tab[$i]['is_current_user'] = 0;
     }
 
     // Ajout des Sans Repas (SR)

--- a/public/planning/poste/js/planning.js
+++ b/public/planning/poste/js/planning.js
@@ -1416,6 +1416,10 @@ function bataille_navale(poste,date,debut,fin,perso_id,barrer,ajouter,site,tout,
         // Qualifications (activités) de l'agent
         classes+=' '+result[i]['activites'];
 
+        if (result[i]['is_current_user']) {
+          classes += ' current-user-cell';
+        }
+
         // Sans Repas
         if(result[i]["sr"]){
           // Ajout du sans repas sur la cellule modifiée

--- a/src/Controller/PlanningController.php
+++ b/src/Controller/PlanningController.php
@@ -859,18 +859,16 @@ class PlanningController extends BaseController
                             $class_tmp[]='activite_'.strtolower(removeAccents(str_replace(array('/',' ',), '_', $a)));
                         }
                     }
-                    $classe[$i]=implode(" ", $class_tmp);
 
                     // Color the logged in agent.
-                    $color[$i] = null;
                     if (!empty($this->config('Affichage-Agent')) and $elem['perso_id'] == $_SESSION['login_id']) {
-                        $color[$i] = filter_var($this->config('Affichage-Agent'), FILTER_CALLBACK, ['options' => 'sanitize_color']);
-                        $color[$i] = "style='background-color:{$color[$i]};'";
+                        $class_tmp[] = 'current-user-cell';
                     }
+
+                    $classe[$i]=implode(' ', $class_tmp);
 
                     // Création d'une balise span avec les classes cellSpan, et agent_ de façon à les repérer et agir dessus à partir de la fonction JS bataille_navale.
                     $span="<span class='cellSpan agent_{$elem['perso_id']}' title='$title' >$resultat</span>";
-
                     $resultats[$i]=array("text"=>$span, "perso_id"=>$elem['perso_id']);
                     $i++;
                 }
@@ -879,11 +877,11 @@ class PlanningController extends BaseController
 
         $this->cellId++;
 
-        $cellule = "<td id='td{$this->cellId}' colspan='$colspan' style='text-align:center;' class='menuTrigger' oncontextmenu='cellule={$this->cellId}' 
+        $cellule = "<td id='td{$this->cellId}' colspan='$colspan' style='text-align:center;' class='menuTrigger' oncontextmenu='cellule={$this->cellId}'
             data-start='$debut' data-end='$fin' data-situation='$poste' data-cell='{$this->cellId}' data-perso-id='0'>";
 
         for ($i=0;$i<count($resultats);$i++) {
-            $cellule .= "<div id='cellule{$this->cellId}_$i' class='cellDiv {$classe[$i]} pl-cellule-perso-{$resultats[$i]['perso_id']}' {$color[$i]} 
+            $cellule .= "<div id='cellule{$this->cellId}_$i' class='cellDiv {$classe[$i]} pl-cellule-perso-{$resultats[$i]['perso_id']}'
                 data-perso-id='{$resultats[$i]['perso_id']}'>{$resultats[$i]['text']}</div>";
         }
 

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -29,6 +29,11 @@
     {% if theme != 'default' %}
     <link rel='StyleSheet' href='{{ asset("themes/" ~ theme ~ "/" ~ theme ~ ".css") }}' type='text/css' media='all'/>
     {% endif %}
+    <style media="screen">
+      .current-user-cell {
+        background-color: {{ config('Affichage-Agent') }};
+      }
+    </style>
     <link rel='icon' type='image/png' href='{{ asset("favicon.ico") }}' />
   </head>
   <body>


### PR DESCRIPTION
-Changed the "highlight current user" logic from using inline background color to adding the current-user-cell CSS class in the element and class list, so that the highlight is handled through frontend styling. -In public/planning/poste/ajax.updateCell.php, add a boolean flag field is_current_user to the $tab[$i] array and pass it to public/planning/poste/js/planning.js. If it is the current user, append ' current-user-cell' to classes.

TEST PLAN
-Create and validate a planning, then use a standard user accompte -Use data10 (terminal : mariadb planno < ~/planno_tools/data/data10.sql && composer install) -Load a model,lock the planning,add all the "plannings" rights of the "médiathèque" site to Aurelie -Logout and login with the following credentials : aurelie.aurelie / password -When you are logged in with this account, you can see Aurélie cells in yellow, that's OK. -Delete Aurelie from one cell and then add Aurelie again,the yellow highlight show still. -Configure Firefox to get background colors printed (ctrl + P, Options, check "Imprimer les arrières-plans". Do it only once.) -On the preview, check if Aurélie cells are in yellow(no yellow is correct)