### PR TITLE
MT50216: Check hour format in working hours (client side)

### DIFF
--- a/public/js/planno-timepicker.js
+++ b/public/js/planno-timepicker.js
@@ -10,6 +10,17 @@ plannoTimepickerParams = {
   }
 };
 
+$( document ).ready(function() {
+
+  $('body').on('blur',".planno-timepicker", function(){
+    str = $(this).val();
+
+    if (!str.match(/^(?:[01]\d|2[0-3]):[0-5]\d$/)) {
+      $(this).val('');
+    }
+  });
+});
+
 (function( $ ) {
   $.fn.plannoTimepicker = function(params) {
     params = $.extend(plannoTimepickerParams, params);
@@ -21,6 +32,11 @@ plannoTimepickerParams = {
 })( jQuery );
 
 function timePickerChange(date, obj) {
+
+  if (date == false) {
+    $(obj).val('');
+    $(obj).focus();
+  }
   if ($(obj).hasClass('checkdate')) {
     dateChange(obj);
   }


### PR DESCRIPTION
In order to prevent the user from entering incorrect values in the working hours table, the input is now checked in javascript.

Note: "MT50212: Check the integrity of working hours" does the server-side control.

Test plan:

 - Edit or create working hours

 - For each of the following, test validating with different methods:
    - pressing tab
    - pressing enter
    - clicking on another cell

 - Enter an incorrect alphabetical value ("aaa") in a cell (empty or with a valid hour)
 - Check that the value is emptied

 - In an empty cell, enter an incorrect hour ("25:12")
 - Check that the value is emptied

 - In a cell with a valid hour, enter an incorrect hour ("25:12") and click in another cell
 - Check that the value is set to the closest valid hour