### PR TITLE
MT50321: Fix "My Account" access on 24.10.xx

### DIFF
--- a/src/Controller/AccountController.php
+++ b/src/Controller/AccountController.php
@@ -20,6 +20,7 @@ class AccountController extends BaseController
         // Initialisation des variables
         $CSRFSession = $GLOBALS['CSRFSession'];
         $credits = array();
+        $perso_id = $session->get('loginId');
 
         // Informations sur l'agent
         $p = new \personnel();


### PR DESCRIPTION
Unitialized variable $perso_id due to the presence of:

MT49108: we can change our password if we use local authentication

and the absence of:

MT48100: Improve hours to days conversions