### PR TITLE
MT50093: Improve purge command speed

### DIFF
--- a/src/Repository/AbsenceRepository.php
+++ b/src/Repository/AbsenceRepository.php
@@ -10,13 +10,17 @@ use App\Entity\AbsenceDocument;
 
 class AbsenceRepository extends EntityRepository
 {
-    public function purge($id)
+    private function purge($id)
     {
         $entityManager = $this->getEntityManager();
-        $this->deleteAllDocuments($id);
+        $this->deleteAllDocuments($id, false);
         $absence = $entityManager->getRepository(Absence::class)->find($id);
         $entityManager->remove($absence);
-        $entityManager->flush();
+        /* If this function was to be made public, we probably would want to add a
+           parameter to flush here (like for deleteAllDocuments)
+           ie: called from purgeAll: don't flush (flush is done in purgeAll)
+               called from the outside: flush
+        */
     }
 
     public function purgeAll($limit_date) {
@@ -33,16 +37,19 @@ class AbsenceRepository extends EntityRepository
             $deleted_absences++;
         }
         return $deleted_absences;
+        $entityManager->flush();
     }
 
-    public function deleteAllDocuments($id) {
+    public function deleteAllDocuments($id, bool $flush = true) {
         $entityManager = $this->getEntityManager();
         $absdocs = $entityManager->getRepository(AbsenceDocument::class)->findBy(['absence_id' => $id]);
         foreach ($absdocs as $absdoc) {
             $absdoc->deleteFile();
             $entityManager->remove($absdoc);
         }
-        $entityManager->flush();
+        if ($flush == true) {
+            $entityManager->flush();
+        }
 
         $absenceDocument = new AbsenceDocument();
         if (is_dir($absenceDocument->upload_dir() . $id)) {

--- a/src/Repository/PlanningPositionTabRepository.php
+++ b/src/Repository/PlanningPositionTabRepository.php
@@ -17,7 +17,7 @@ class PlanningPositionTabRepository extends EntityRepository
     public function purge($id)
     {
         $planningPositionTab = $this->find($id);
-        $tableau = $planningPositionTab->tableau();
+        $tableau = $planningPositionTab->getTable();
         $entityManager = $this->getEntityManager();
 
         $objects = $entityManager->getRepository(PlanningPositionTabAffectation::class)->findBy(['tableau' => $tableau]); 


### PR DESCRIPTION
The purge command (php bin/console app:purge:data) has been proven to be very slow, the main bottleneck being the purge of absences.

This patch fixes that, by flushing through the entitymanager only at the end of absences deletion.

For instance, for 18711 absences:
before the patch:
real    35m1,631s
after the patch:
real    0m2,641s

Note: we could also optimize Skills in the same way, but there is no need given the very limited size of the table.

This patch also fixes the purge command itself, which crashed on planningPositionTab deletion since the following commit:

commit 17c7ac9d540fc7f5dd1868923c914d81a6be5370
Wed Jul 30 18:38:28 2025 +0200
MT45367: Migrate from annotations to php attributes