### PR TITLE
MT51289: Cast breaktime into float in PlanningJobTrait.php

### DIFF
--- a/src/Traits/PlanningJobTrait.php
+++ b/src/Traits/PlanningJobTrait.php
@@ -420,7 +420,7 @@ trait PlanningJobTrait
                         $hours_limit += strtotime($t[1]) - strtotime($t[0]);
                     }
 
-                    $breaktime = isset($breaktimes[$elem['id']][$jour]) ? $breaktimes[$elem['id']][$jour] * 3600 : 0;
+                    $breaktime = isset($breaktimes[$elem['id']][$jour]) ? (float) $breaktimes[$elem['id']][$jour] * 3600 : 0;
                     $hours_limit = $hours_limit - $breaktime;
 
                     if ($day_hour + $requested_hours > $hours_limit) {


### PR DESCRIPTION
Fixes the following error:
Uncaught PHP Exception TypeError: "Unsupported operand types: string * int" at PlanningJobTrait.php line 42