### PR TITLE
MT52853: Resolve broken display dataTable select

### DIFF
--- a/public/themes/default/default.css
+++ b/public/themes/default/default.css
@@ -1575,6 +1575,11 @@ div.dt-container div.dt-layout-row {
   flex-flow: row wrap;
 }
 
+div.dt-container select.dt-input option {
+  color: white;
+  background-color: #29495C;
+}
+
 div.dt-container div.dt-layout-row:first-child {
   border-top-left-radius : 4px;
   border-top-right-radius : 4px;


### PR DESCRIPTION
- The display on chrome and vivaldi is fixed
- The display on firefox stays the same ( white on black bg). Custom css doesn't work but text is still readable.
  -  Apparently this is a known issue with firefox browser, where option tag can't be styled through CSS.