### PR TITLE
MT51958: Do not display password in configuration page

### DIFF
--- a/migrations/2026/Version20260416071638.php
+++ b/migrations/2026/Version20260416071638.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260416071638 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'MT51958: Do not display password in configuration page';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $dbprefix = $_ENV['DATABASE_PREFIX'];
+        $this->addSql("UPDATE {$dbprefix}config SET commentaires = 'Mot de passe de connexion (ne sera pas modifié si laissé vide)' WHERE nom = 'LDAP-Password' LIMIT 1;");
+        $this->addSql("UPDATE {$dbprefix}config SET commentaires = 'Mot de passe pour le serveur SMTP (ne sera pas modifié si laissé vide)' WHERE nom = 'Mail-Password' LIMIT 1;");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $dbprefix = $_ENV['DATABASE_PREFIX'];
+        $this->addSql("UPDATE {$dbprefix}config SET commentaires = 'Mot de passe de connexion' WHERE nom = 'LDAP-Password' LIMIT 1;");
+        $this->addSql("UPDATE {$dbprefix}config SET commentaires = 'Mot de passe pour le serveur SMTP' WHERE nom = 'Mail-Password' LIMIT 1;");
+    }
+}

--- a/src/Controller/AjaxController.php
+++ b/src/Controller/AjaxController.php
@@ -6,6 +6,7 @@ use App\Controller\BaseController;
 use App\Entity\AbsenceReason;
 use App\Entity\Agent;
 use App\Planno\Helper\AbsenceBlockHelper;
+use App\Planno\Helper\ConfigHelper;
 
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
@@ -95,6 +96,11 @@ class AjaxController extends BaseController
         $fromName = $request->get('fromName');
         $signature = $request->get('signature');
         $planning = $request->get('planning');
+
+        if ($password == '') {
+            $configHelper = new ConfigHelper();
+            $password = decrypt($configHelper->getValue('Mail-Password'));
+        }
 
         // Connexion au serveur de messagerie
         if ($fp=@fsockopen($host, $port, $errno, $errstr, 5)) {

--- a/src/Controller/AjaxController.php
+++ b/src/Controller/AjaxController.php
@@ -4,9 +4,9 @@ namespace App\Controller;
 
 use App\Controller\BaseController;
 use App\Entity\AbsenceReason;
+use App\Entity\Config;
 use App\Entity\Agent;
 use App\Planno\Helper\AbsenceBlockHelper;
-use App\Planno\Helper\ConfigHelper;
 
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
@@ -98,8 +98,8 @@ class AjaxController extends BaseController
         $planning = $request->get('planning');
 
         if ($password == '') {
-            $configHelper = new ConfigHelper();
-            $password = decrypt($configHelper->getValue('Mail-Password'));
+            $configRepository = $this->entityManager->getRepository(Config::class);
+            $password = decrypt($configRepository->getValue('Mail-Password'));
         }
 
         // Connexion au serveur de messagerie

--- a/src/Controller/ConfigController.php
+++ b/src/Controller/ConfigController.php
@@ -140,8 +140,8 @@ class ConfigController extends BaseController
         $port = filter_var($port, FILTER_SANITIZE_NUMBER_INT);
 
         if ($password == '') {
-            $configHelper = new ConfigHelper();
-            $password = decrypt($configHelper->getValue('LDAP-Password'));
+            $configRepository = $this->entityManager->getRepository(Config::class);
+            $password = decrypt($configRepository->getValue('LDAP-Password'));
         }
 
         // Connexion au serveur LDAP

--- a/src/Controller/ConfigController.php
+++ b/src/Controller/ConfigController.php
@@ -4,6 +4,7 @@ namespace App\Controller;
 
 use App\Controller\BaseController;
 use App\Entity\Config;
+use App\Planno\Helper\ConfigHelper;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Session;
@@ -46,7 +47,7 @@ class ConfigController extends BaseController
             );
 
             if ($cp->getType() == 'password') {
-                $elem['valeur']=decrypt($elem['valeur']);
+                $elem['valeur'] = '';
             }
             switch ($elem['type']) {
                 case "checkboxes":
@@ -108,61 +109,18 @@ class ConfigController extends BaseController
             $error .= "#BR#Merci de votre compréhension";
         }
         elseif ($params !== []) {
-
-            $technical = $request->get('technical');
-
-            $configParams = $this->entityManager->getRepository(Config::class)->findBy(
-                array('technical' => $technical),
-                array('categorie' => 'ASC', 'ordre' => 'ASC', 'id' => 'ASC')
-            );
-
-            foreach ($configParams as $cp) {
-                if (in_array($cp->getType(), ['hidden', 'info'])) {
-                    continue;
-                }
-                // boolean and checkboxes elements.
-                if (!isset($params[$cp->getName()])) {
-                    $params[$cp->getName()] = $cp->getType() == 'boolean' ? '0' : array();
-                }
-                $value = $params[$cp->getName()];
-
-                if (is_string($value)) {
-                    $value = trim($value);
-                }
-
-                // Passwords
-                if (substr($cp->getName(), -9) == '-Password') {
-                    $value = encrypt($value);
-                }
-                // Checkboxes
-                if (is_array($value)) {
-                    $value = json_encode($value);
-                }
-
-                if ($cp->getType() == 'color') {
-                    $value = filter_var($value, FILTER_CALLBACK, ['options' => 'sanitize_color']);
-                }
-
-                try {
-                    $cp->setValue($value);
-                    $this->entityManager->persist($cp);
-                }
-                catch (Exception $e) {
-                    $error = 'Une erreur est survenue pendant la modification de la configuration !';
-                }
-            }
-            $this->entityManager->flush();
-
+            $configHelper = new ConfigHelper();
+            $error = $configHelper->saveConfig($params);
         }
 
-        if (isset($error)) {
+        if (isset($error) && $error != null) {
             $session->getFlashBag()->add('error', $error);
         } else {
             $flash = 'La configuration a été modifiée avec succès';
             $session->getFlashBag()->add('notice', $flash);
         }
 
-        $options = $technical ? ['options' => 'technical'] : [];
+        $options = $params['technical'] ? ['options' => 'technical'] : [];
 
         return $this->redirectToRoute('config.index', $options);
     }
@@ -180,6 +138,11 @@ class ConfigController extends BaseController
         $port = $request->get('port');
 
         $port = filter_var($port, FILTER_SANITIZE_NUMBER_INT);
+
+        if ($password == '') {
+            $configHelper = new ConfigHelper();
+            $password = decrypt($configHelper->getValue('LDAP-Password'));
+        }
 
         // Connexion au serveur LDAP
         $url = $protocol . '://' . $host . ':' . $port;

--- a/src/Planno/Helper/ConfigHelper.php
+++ b/src/Planno/Helper/ConfigHelper.php
@@ -16,31 +16,12 @@ class ConfigHelper extends BaseHelper
         $this->configRepository = $this->entityManager->getRepository(Config::class);
     }
 
-    public function getValue($name): string
-    {
-        return $this->configRepository->findOneBy(['nom' => $name])->getValue();
-    }
-
-    public function getParam($name)
-    {
-        return $this->configRepository->findOneBy(['nom' => $name]);
-    }
-
-
-    public function getParams($technical): array
-    {
-        return $this->configRepository->findBy(
-                array('technical' => $technical),
-                array('categorie' => 'ASC', 'ordre' => 'ASC', 'id' => 'ASC')
-            );
-    }
-
     public function saveConfig($params): string
     {
             $technical = $params['technical'];
             $error = '';
 
-            $configParams = $this->getParams($technical);
+            $configParams = $this->configRepository->getParams($technical);
 
             foreach ($configParams as $cp) {
                 if (in_array($cp->getType(), ['hidden', 'info'])) {

--- a/src/Planno/Helper/ConfigHelper.php
+++ b/src/Planno/Helper/ConfigHelper.php
@@ -38,7 +38,7 @@ class ConfigHelper extends BaseHelper
                 }
 
                 // Passwords
-                if (substr($cp->getName(), -9) == '-Password') {
+                if ($cp->getType() == 'password') {
                     if ($value == '') {
                         continue;
                     }

--- a/src/Planno/Helper/ConfigHelper.php
+++ b/src/Planno/Helper/ConfigHelper.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Planno\Helper;
+
+use App\Planno\Helper\BaseHelper;
+use App\Entity\Config;
+
+class ConfigHelper extends BaseHelper
+{
+
+    private $configRepository;
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->configRepository = $this->entityManager->getRepository(Config::class);
+    }
+
+    public function getValue($name): string
+    {
+        return $this->configRepository->findOneBy(['nom' => $name])->getValue();
+    }
+
+    public function getParam($name)
+    {
+        return $this->configRepository->findOneBy(['nom' => $name]);
+    }
+
+
+    public function getParams($technical): array
+    {
+        return $this->configRepository->findBy(
+                array('technical' => $technical),
+                array('categorie' => 'ASC', 'ordre' => 'ASC', 'id' => 'ASC')
+            );
+    }
+
+    public function saveConfig($params): string
+    {
+            $technical = $params['technical'];
+            $error = '';
+
+            $configParams = $this->getParams($technical);
+
+            foreach ($configParams as $cp) {
+                if (in_array($cp->getType(), ['hidden', 'info'])) {
+                    continue;
+                }
+                // boolean and checkboxes elements.
+                if (!isset($params[$cp->getName()])) {
+                    $params[$cp->getName()] = $cp->getType() == 'boolean' ? '0' : array();
+                }
+                $value = $params[$cp->getName()];
+
+                if (is_string($value)) {
+                    $value = trim($value);
+                }
+
+                // Passwords
+                if (substr($cp->getName(), -9) == '-Password') {
+                    if ($value == '') {
+                        continue;
+                    }
+                    $value = encrypt($value);
+                }
+                // Checkboxes
+                if (is_array($value)) {
+                    $value = json_encode($value);
+                }
+
+                if ($cp->getType() == 'color') {
+                    $value = filter_var($value, FILTER_CALLBACK, ['options' => 'sanitize_color']);
+                }
+
+                try {
+                    $cp->setValue($value);
+                    $this->entityManager->persist($cp);
+                }
+                catch (Exception $e) {
+                    $error = 'Une erreur est survenue pendant la modification de la configuration !';
+                }
+            }
+            $this->entityManager->flush();
+
+            return $error;
+    }
+}

--- a/src/Repository/ConfigRepository.php
+++ b/src/Repository/ConfigRepository.php
@@ -46,13 +46,17 @@ class ConfigRepository extends EntityRepository
 
     public function setParam($name, $value, $technical = 0): void
     {
+        // FIXME: The variable `$GLOBALS['config']` is intended for unit tests, which continue to use it.
+        // Remove this line when the unit tests will no longer use it.
         $GLOBALS['config'][$name] = $value;
+
         $param = $this->findOneBy(['nom' => $name]);
 
         if (!$param) {
             # error
         } else {
             $param->setValue($value);
+            // FIXME: $technical is not supposed to change, but unit tests fail if it is not forced here.
             $param->setTechnical($technical);
         }
     }

--- a/src/Repository/ConfigRepository.php
+++ b/src/Repository/ConfigRepository.php
@@ -27,4 +27,25 @@ class ConfigRepository extends EntityRepository
 
         return $config;
     }
+
+    public function getParam($name) {
+        return $this->findOneBy(['nom' => $name]);
+    }
+
+    public function getParamValue($name) {
+        return $this->getParam($name)->getValue();
+    }
+
+    public function setParam($name, $value, $technical = 0)
+    {
+        $GLOBALS['config'][$name] = $value;
+        $param = $this->findOneBy(['nom' => $name]);
+
+        if (!$param) {
+            # error
+        } else {
+            $param->setValue($value);
+            $param->setTechnical($technical);
+        }
+    }
 }

--- a/src/Repository/ConfigRepository.php
+++ b/src/Repository/ConfigRepository.php
@@ -44,7 +44,7 @@ class ConfigRepository extends EntityRepository
         return $this->getParam($name)->getValue();
     }
 
-    public function setParam($name, $value, $technical = 0)
+    public function setParam($name, $value, $technical = 0): void
     {
         $GLOBALS['config'][$name] = $value;
         $param = $this->findOneBy(['nom' => $name]);

--- a/src/Repository/ConfigRepository.php
+++ b/src/Repository/ConfigRepository.php
@@ -28,11 +28,19 @@ class ConfigRepository extends EntityRepository
         return $config;
     }
 
+    public function getParams($technical): array
+    {
+        return $this->findBy(
+                array('technical' => $technical),
+                array('categorie' => 'ASC', 'ordre' => 'ASC', 'id' => 'ASC')
+            );
+    }
+
     public function getParam($name) {
         return $this->findOneBy(['nom' => $name]);
     }
 
-    public function getParamValue($name) {
+    public function getValue($name) {
         return $this->getParam($name)->getValue();
     }
 

--- a/tests/PLBWebTestCase.php
+++ b/tests/PLBWebTestCase.php
@@ -62,6 +62,7 @@ class PLBWebTestCase extends PantherTestCase
         }
     }
 
+    // When possible, use Config::setParam instead (see src/Repository/ConfigRepository.php)
     protected function setParam($name, $value)
     {
         $GLOBALS['config'][$name] = $value;

--- a/tests/Planno/Helper/ConfigHelperTest.php
+++ b/tests/Planno/Helper/ConfigHelperTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use App\Repository\ConfigRepository;
+use App\Entity\Config;
+use App\Planno\Helper\ConfigHelper;
+use Tests\PLBWebTestCase;
+
+class ConfigHelperTest extends PLBWebTestCase
+{
+    public function testPasswordUpdate(): void {
+
+        $entityManager = $this->entityManager;
+        $repository    = $entityManager->getRepository(Config::class);
+        $helper        = new ConfigHelper();
+
+        $repository->setParam('LDAP-Password', 'current_encrypted_password', 1);
+
+        $params = array('LDAP-Password' => '', 'technical' => 1);
+        $error = $helper->saveConfig($params);
+
+        $this->assertEquals('', $error, 'No error has been returned');
+        $this->assertEquals('current_encrypted_password', $repository->getParamValue('LDAP-Password'), 'Password has not been updated (empty password)');
+
+        $params = array('LDAP-Password' => 'NewPassword', 'technical' => 1);
+        $helper->saveConfig($params);
+
+        $this->assertEquals('', $error, 'No error has been returned');
+        $this->assertNotEquals('current_encrypted_password', $repository->getParamValue('LDAP-Password'), 'Password is not current_encrypted_password');
+        $this->assertNotEquals('NewPassword',                $repository->getParamValue('LDAP-Password'), 'Password is not NewPassword');
+        $this->assertNotEquals('',                           $repository->getParamValue('LDAP-Password'), 'Password is not empty');
+
+    }
+
+}

--- a/tests/Planno/Helper/ConfigHelperTest.php
+++ b/tests/Planno/Helper/ConfigHelperTest.php
@@ -19,15 +19,15 @@ class ConfigHelperTest extends PLBWebTestCase
         $error = $helper->saveConfig($params);
 
         $this->assertEquals('', $error, 'No error has been returned');
-        $this->assertEquals('current_encrypted_password', $repository->getParamValue('LDAP-Password'), 'Password has not been updated (empty password)');
+        $this->assertEquals('current_encrypted_password', $repository->getValue('LDAP-Password'), 'Password has not been updated (empty password)');
 
         $params = array('LDAP-Password' => 'NewPassword', 'technical' => 1);
         $helper->saveConfig($params);
 
         $this->assertEquals('', $error, 'No error has been returned');
-        $this->assertNotEquals('current_encrypted_password', $repository->getParamValue('LDAP-Password'), 'Password is not current_encrypted_password');
-        $this->assertNotEquals('NewPassword',                $repository->getParamValue('LDAP-Password'), 'Password is not NewPassword');
-        $this->assertNotEquals('',                           $repository->getParamValue('LDAP-Password'), 'Password is not empty');
+        $this->assertNotEquals('current_encrypted_password', $repository->getValue('LDAP-Password'), 'Password is not current_encrypted_password');
+        $this->assertNotEquals('NewPassword',                $repository->getValue('LDAP-Password'), 'Password is not NewPassword');
+        $this->assertNotEquals('',                           $repository->getValue('LDAP-Password'), 'Password is not empty');
 
     }
 


### PR DESCRIPTION
The password are no longer displayed in the configuration page. (currently affects Mail-Password and LDAP-Password)

If the password field is left blank, the current password in the database will not be updated.

The test button will use the password in the input field if provided by the user, or the password in database if the input field is left blank.

See tests/Planno/Helper/ConfigHelperTest.php for unit tests.