### PR TITLE
MT53517: Use CJDataTable class for absences CSV import

### DIFF
--- a/public/js/CJScript.js
+++ b/public/js/CJScript.js
@@ -8,6 +8,24 @@ Fichier : CJScript.js
 
  DataTable.type('date', 'className', 'dt-left');
 
+function CJDataTableLogLevelFilter() {
+    $.fn.dataTable.ext.search.push(function(settings, data, dataIndex) {
+         var max = $('#maxLevel').val();
+         if (!max) return true;
+         return data[1] <= max;
+       });
+
+     $('#maxLevel').on('change', function() {
+        CJDataTableDraw();
+     });
+}
+
+function CJDataTableDraw() {
+    $(".CJDataTable").each(function(){
+        $(this).DataTable().draw();
+    });
+}
+
 function CJDataTableHideRow(selector){
   // (.hide mieux que .remove car si .remove, la ligne réapparait lors de l'utilisation des tris
   $(selector).hide();
@@ -149,6 +167,7 @@ $(function(){
   Sur les balises th de l'entête, les classes suivantes permettent de définir le type de données contenues dans les cellules 
   pour trier correctement les colonnes :
   - dataTableNoSort : La colonne ne sera pas triable
+  - dataTableHide: la colonne sera masquée
   - dataTableDateFR : La colonne contient des dates au format JJ-MM-AAAA [HH:mm:ss]. 
       Si seule l'heure est affichée, le tri considère que la date est celle du jour
   - dataTableDateFR-fin : La colonne des dates de fin
@@ -207,6 +226,9 @@ $(function(){
 	else if(th[i].hasClass("dataTableNoSort")){
 	  aoCol.push({"bSortable":false});
 	}
+    else if(th[i].hasClass("dataTableHide")){
+      aoCol.push({"visible":false});
+    }
     // For accentuated string
     else if(th[i].hasClass('clear-string')){
       aoCol.push({'sType': 'clear-string'});

--- a/public/js/absence.js
+++ b/public/js/absence.js
@@ -27,26 +27,7 @@ $(function() {
       $('#recurrence-checkbox').attr('checked','checked');
     }
 
-    // MT53517 Quick fix, to be continued
-    // Filtrer les résultats d'un import CSV par niveau de log
-    // var table = $('#tableAbsencesImportResult').DataTable({
-    //         'language' : { 'url' : url('js/dataTables.french.lang.json') },
-    //         'iDisplayLength': 25,
-    //         columnDefs: [
-    //             { target: 1, visible: false }
-    //         ]
-    //     }
-    // );
-
-    // $.fn.dataTable.ext.search.push(function(settings, data, dataIndex) {
-    //     var max = $('#maxLevel').val();
-    //     if (!max) return true;
-    //     return data[1] <= max;
-    //   });
-
-    // $('#maxLevel').on('change', function() {
-    //     table.draw();
-    // });
+    CJDataTableLogLevelFilter();
 
   });
 

--- a/templates/absences/import.html.twig
+++ b/templates/absences/import.html.twig
@@ -23,24 +23,25 @@
         <table id="tableAbsencesImportResult" class="CJDataTable">
           <thead>
             <th>Ligne</th>
+            <th class="dataTableHide">Niveau</th>
             <th>Type</th>
             <th>Message</th>
           </thead>
           <tbody>
             {% for log in importLog %}
-              {% if log.type < 4 %}
               <tr>
                 <td>{{ log.line }}</td>
-                <td data-order="{{ log.type }}">
+                <td>{{ log.type }}</td>
+                <td>
                   {% if log.type == 1 %}<div class="red">Erreur</div>
                   {% elseif log.type == 2 %}<div class="orange">Avertissement</div>
                   {% elseif log.type == 3 %}<div class="green">Information</div>
                   {% elseif log.type == 4 %}Débogage
+                  {% else %}Inconnu
                   {% endif %}
                 </td>
                 <td>{{ log.message | striptags('<a>') | raw }}</td>
               </tr>
-              {% endif %}
             {% endfor %}
           </tbody>
         </table>


### PR DESCRIPTION
Use CJDataTable class for absences CSV import instead of using custom DataTable code:

 - allow to hide column using dataTableHide
 - add log level filtering

Both features can be re-used for other DataTables.

Test plan:
 DataTable behavior should be the same as before, see
 MT48492: Import absences from CSV file:

 Once the file is processed check that you have a table with the results.
 Traditional log levels are used: ERROR, WARNING, INFO, DEBUG
 INFO is used by default, but you can set the log level you want using the
 dropdown list.