### PR TITLE
MT53764: Fix unit test WorkingHourExportCommand

### DIFF
--- a/tests/Command/WorkingHourExportCommandTest.php
+++ b/tests/Command/WorkingHourExportCommandTest.php
@@ -53,10 +53,10 @@ class WorkingHourExportCommandTest extends PLBWebTestCase
     {
         $file = sys_get_temp_dir() . '/plannoTestWorkingHourExport.csv';
 
-        $this->setParam('PlanningHebdo-ExportFile', $file);
-        $this->setParam('PlanningHebdo-ExportDaysBefore', 5);
-        $this->setParam('PlanningHebdo-ExportDaysAfter', 10);
-        $this->setParam('PlanningHebdo-ExportAgentId', 'matricule');
+        $this->addConfig('PlanningHebdo-ExportFile', $file);
+        $this->addConfig('PlanningHebdo-ExportDaysBefore', 5);
+        $this->addConfig('PlanningHebdo-ExportDaysAfter', 10);
+        $this->addConfig('PlanningHebdo-ExportAgentId', 'matricule');
         $this->config->setParam('EDTSamedi',1);
         $this->config->setParam('PlanningHebdo',1);
 

--- a/tests/Command/WorkingHourExportCommandTest.php
+++ b/tests/Command/WorkingHourExportCommandTest.php
@@ -35,14 +35,28 @@ class WorkingHourExportCommandTest extends PLBWebTestCase
         }
     }
 
+    public static function tearDownAfterClass(): void
+    {
+        $files = [
+            sys_get_temp_dir() . '/plannoTestWorkingHourExport.csv',
+            sys_get_temp_dir() . '/plannoWorkingHourExport.lock',
+        ];
+
+        foreach ($files as $file) {
+            if (file_exists($file)) {
+                unlink($file);
+            }
+        }
+    }
+
     public function testWorkingHourExportCommand(): void
     {
         $file = sys_get_temp_dir() . '/plannoTestWorkingHourExport.csv';
 
-        $this->config->setParam('PlanningHebdo-ExportFile', $file);
-        $this->config->setParam('PlanningHebdo-ExportDaysBefore', 5);
-        $this->config->setParam('PlanningHebdo-ExportDaysAfter', 10);
-        $this->config->setParam('PlanningHebdo-ExportAgentId', 'matricule');
+        $this->setParam('PlanningHebdo-ExportFile', $file);
+        $this->setParam('PlanningHebdo-ExportDaysBefore', 5);
+        $this->setParam('PlanningHebdo-ExportDaysAfter', 10);
+        $this->setParam('PlanningHebdo-ExportAgentId', 'matricule');
         $this->config->setParam('EDTSamedi',1);
         $this->config->setParam('PlanningHebdo',1);
 

--- a/tests/PLBWebTestCase.php
+++ b/tests/PLBWebTestCase.php
@@ -63,23 +63,6 @@ class PLBWebTestCase extends PantherTestCase
         }
     }
 
-    protected function setParam($name, $value)
-    {
-        $GLOBALS['config'][$name] = $value;
-        $param = $this->entityManager
-            ->getRepository(Config::class)
-            ->findOneBy(['nom' => $name]);
-
-        if (!$param) {
-            $this->addConfig($name, $value);
-        } else {
-            $param->setValue($value);
-            $this->entityManager->persist($param);
-        }
-
-        $this->entityManager->flush();
-    }
-
     protected function setUp(): void
     {
         global $entityManager;


### PR DESCRIPTION
The test failed because its parameters were not saved. Some parameters used by this test are stored in the custom_options.php file, and the config::setParam method does not handle parameters from this file.