### PR TITLE
BugFix : duplicate name in select on edit absence

### DIFF
--- a/templates/absences/edit.html.twig
+++ b/templates/absences/edit.html.twig
@@ -59,7 +59,7 @@
                     {% endif %}
 
                     {% for a in agents_tous %}
-                      {% if a.id in absence.perso_id %}
+                      {% if a.id in absence.perso_ids %}
                         <option value='{{ a.id }}' id='option{{ a.id }}' style="display:none;">{{ a.lastname }} {{ a.firstname }}</option>
                       {% else %}
                         <option value='{{ a.id }}' id='option{{ a.id }}'>{{ a.lastname }} {{ a.firstname }}</option>


### PR DESCRIPTION
<img width="975" height="746" alt="Capture d’écran_2026-06-15_09-51-56" src="https://github.com/user-attachments/assets/222d8985-8310-4c9a-aec7-b5783c093d0b" />


In edit mode, it was possible to select the same name twice from the list of agents affected by the absence.
This issue does not create a duplicate in the database; it only affects the display.