### PR TITLE
MT46629: Use of Boostrap grid for planning's menu

### DIFF
--- a/public/js/planning.js
+++ b/public/js/planning.js
@@ -19,19 +19,21 @@ $(document).ready(function(){
 
   if ($('.cellSpan').length > 0 ) $('#planning-save').removeClass('disabled');
 
-  $('.pl-icon-open').on('click', function(e) {
-    $('#import-model-button').removeClass('disabled');
-    $('#import-model-button').attr('type', 'submit');
-    date = $('input[name="date"]').val();
-    site = $('input[name="site"]').val();
-    CSRFSession = $('input[name="CSRFSession"]').val();
-    params = '?date=' + date + '&site=' + site + '&CSRFToken=' + CSRFSession;
-    $('#model-selection').load('/modelform' + params);
-    $('#import-model-modal').modal('show');
-    return false;
+  $('#planning-import').on('click keydown', function(e) {
+    if (!event.key || event.key === 'Enter') {
+      $('#import-model-button').removeClass('disabled');
+      $('#import-model-button').attr('type', 'submit');
+      date = $('input[name="date"]').val();
+      site = $('input[name="site"]').val();
+      CSRFSession = $('input[name="CSRFSession"]').val();
+      params = '?date=' + date + '&site=' + site + '&CSRFToken=' + CSRFSession;
+      $('#model-selection').load('/modelform' + params);
+      $('#import-model-modal').modal('show');
+      return false;
+    }
   });
 
-   $('#duplicate-model-form').submit(function(e) {
+  $('#duplicate-model-form').submit(function(e) {
     e.preventDefault();
     save_model(true);
   });
@@ -245,7 +247,7 @@ $(function() {
           $('.pl-validation').hide();
           $('#planning-drop').show();
           $('#planning-import').show();
-          $('#icon-unlock').show();
+          $('#icon-unlock').show().focus();
           // data-verrou : pour activer le menudiv
           $('#planning-data').attr('data-verrou', 0);
           $('#undo-redo').show();
@@ -284,7 +286,7 @@ $(function() {
       success: function(result) {
         if(result[1] == 'highlight') {
           $('#icon-unlock').hide();
-          $('#icon-lock').show();
+          $('#icon-lock').show().focus();
           $('.pl-validation').html(result[2]);
           $('.pl-validation').show();
           $('#planning-drop').hide();
@@ -1367,8 +1369,10 @@ function bataille_navale(poste, date, debut, fin, perso_id, barrer, ajouter, sit
       // Enable and disable the save planning button depending on whether it is empty or not
       if ($('.cellSpan').length > 0 ) {
         $('#planning-save').removeClass('disabled');
+        $('#planning-save').attr('data-bs-toggle', 'modal');
       } else {
         $('#planning-save').addClass('disabled');
+        $('#planning-save').attr('data-bs-toggle', '');
       }
 
       // cacher le menudiv

--- a/public/themes/default/default.css
+++ b/public/themes/default/default.css
@@ -66,12 +66,6 @@ h4{
   font-weight: bold;
 }
 
-#h3-Multisites{
-  margin: 30px 20px auto;
-  color: #FFF;
-  font-size: 20px;
-}
-
 .ui-state-error p,
 .ui-state-highlight p {
     margin-top: 15px;
@@ -195,7 +189,7 @@ h4{
   padding: 0 0 0 0;
 }
 
-#ferie,.ferie{
+.ferie {
   color: #DC3545;
   margin: 15px 0 5px 0;
 }
@@ -775,29 +769,6 @@ a.myAccountLink.active {
 /*		Plannings				*/
 /* Calendrier, titre (Semaine ...), Boutons de droite */
 
-.pl-validation {
-  margin: 0px 0 10px 0;
-  color: #FFFFFF;
-  position: absolute;
-  right: 175px;
-}
-
-/*.pl-undo {
-  color: #FFFFFF;
-  position: absolute;
-  right: 75px;
-}
-
-.pl-undo a {
-  color: #FFFFFF;
-}*/
-
-#planning-semaine {
-  padding:30px;
-}
-
-
-
 .pl-semaine-header{
   text-align: left;
   margin: 25px auto 5px auto;
@@ -815,10 +786,6 @@ a.myAccountLink.active {
   margin: 10px auto 0 auto;
   position: absolute;
   right: 5%;
-}
-
-#semaine_planning{
-  display:none;
 }
 
 /*
@@ -1113,6 +1080,58 @@ class cellule = cellule par défaut
   top: calc(50% - 8px);
 }
 
+/* Menu Planning */
+
+#pl-header {
+  background-color: #29495C;
+  margin-left: 0px;
+  margin-right: 0px;
+  height: 170px;
+}
+
+#pl-title {
+  color: #FFFFFF;
+  font-size: 15pt;
+  margin-top: 20px;
+}
+
+#pl-title div, #pl-title ul {
+  padding-top: 5px;
+}
+
+#pl-buttons {
+  text-align:right;
+  margin-top: 20px;
+  margin-right: 40px;
+}
+
+#pl-buttons button.btn-icon {
+  padding: 0px;
+}
+
+#validation {
+  align-items: flex-start;
+  padding-top: 5px;
+}
+
+.pl-validation {
+  color: #FFFFFF;
+}
+
+#ferie {
+  color: #DC3545;
+  width: fit-content;
+}
+
+#undo-redo {
+  padding-top: 5px;
+}
+
+#h3-Multisites {
+  color: #FFF;
+  font-size: 20px;
+}
+
 /* Configuration des tableaux */
 .tableaux-cfg {
   display: inline-block;
@@ -1126,37 +1145,20 @@ class cellule = cellule par défaut
   margin: 20px 0;
 }
 
-#tab_titre{	/* /index */
-  width:100%;
-  height: 145px;
-  border: none;
-  background-color: #29495C;
-  margin-bottom: 20px;
-}
-
-#tab_titre .row {
-  justify-content: space-around;
-}
-
 /* Calendrier affiché en haut des plannings */
-#pl-calendar {
-  border:0;
-  background: transparent;
-  margin: 10px 0 5px 10px;
-  width: 200px;
-}
 
 .datepicker-inline {
   background-color: white;
   width: 185px;
   font-size: 11px;
-  border: 1px solid #29495C;
   padding: 6px 4px 1px 4px;
+  border: 1px solid #29495C;
 }
 
 .datepicker {
   font-size: 12px;
   color: #29495C;
+  text-align:center;
 }
 
 .datepicker .datepicker-days table thead tr th {
@@ -1245,11 +1247,9 @@ class cellule = cellule par défaut
 }
 
 #pl-notes-div2{
-  width: 100%;
   position: relative;
-  left: 5%;
-  display: inline-block;
   margin: 15px 10px 0 0;
+  padding-left: 92px;
   text-align: left;
 }
 
@@ -1293,22 +1293,6 @@ class cellule = cellule par défaut
 	font-size:32.0pt;
 	font-family:Poppins;
 	}
-
-.titreSemFixe{
-  color:#FFFFFF;
-  text-decoration:none;
-  font-size:15pt;
-  font-family: Poppins;
-  font-weight: normal;
-  width:50%;
-  text-align:left;
-  padding: 20px 0 10px 5px;
-}
-
-.titreSemFixe div,
-.titreSemFixe ul {
-  padding-top: 5px;
-}
 
 .top-button-div {
     text-align:right;
@@ -1400,40 +1384,17 @@ img{
   border: none;
 }
 
-#tab_titre tr{
-  vertical-align:top;
-}
-
 #cal_ifram{	
   width:200px;
   height:160px;
-}
-
-#td_boutons{
-  text-align:right;
-  padding:20px 20px 0 0;
-}
-
-#td_boutons .ui-state-error{
-    text-align: left;
-}
-
-#validation{
-  font-size:13px;
-  margin:0 20px 0 0;
-}
-
-#undo-redo{
-  font-size:13px;
-  margin:5px 20px 0 0;
 }
 
 #imprimante{
   cursor:pointer;
 }
 
-#choix_tableaux{
-  margin: 75px 15px;
+#choix_tableaux {
+  margin: 60px 15px;
 }
 
 #choix_tableaux td{
@@ -1445,9 +1406,9 @@ img{
   width:180px;
 }
 
-#tableau, .tableau{
+#tableau, .tableau {
   text-align:center;
-  padding: 30px 0 0 0;
+  padding: 50px 0 0 0;
 }
 
 /*	Jours Fériés	*/
@@ -1897,6 +1858,13 @@ div.dt-buttons button.dt-button.buttons-print:hover {
 .btn-icon {
   min-width :auto;
   padding: 3px;
+}
+
+.btn-icon:focus-visible {
+  color: var(--bs-body-color);
+  border-color: #86b7fe;
+  outline: 0;
+  box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.25);
 }
 
 .btn-icon:focus {
@@ -2459,10 +2427,6 @@ table.dataTable th{
 
   #accountDivReverse {
     display: block;
-  }
-
-  .titreSemFixe{
-    padding: 5px 0 10px 0;
   }
 
 }

--- a/public/themes/default/print.css
+++ b/public/themes/default/print.css
@@ -13,31 +13,37 @@ Incluse dans les fichiers include/header.php et setup/header.php
 	color: #29495C;
 */
 
-body, #tab_titre {
+body {
   background: none;
+}
+
+#pl-header {
+  background-color: transparent;
+  height: 55px;
+  width: 90%;
+  margin: auto;
+  padding-left: 1rem;
 }
 
 #date_planning, #week_planning, #h3-Multisites, .pl-validation {
   color: #29495C;
 }
 
-.titreSemFixe {
-  padding: 3mm 10mm;
+#pl-buttons {
+  margin-right: 0;
+  padding-right: 2rem;
+}
+
+.pl-validation {
+  padding: 0;
 }
 
 #h3-Multisites {
-  margin: 0;
   font-weight: normal;
 }
 
 .pl-validation {
-  top: 15mm;
-  right: 15mm;
   font-weight: normal;
-}
-
-#divcalendrier {
-  height: 40mm;
 }
 
 a, img, .noprint, .footer, .ui-widget-header, div.ui-state-error, #messages_infos, #pl-calendar, .arrow-right {

--- a/templates/detached/index.html.twig
+++ b/templates/detached/index.html.twig
@@ -9,18 +9,16 @@
 {% block page %}
 
   <!-- Show title and calendar widgets -->
-  <div id="divcalendrier" class="navabar-expand-custom text">
-    <div id="tab_titre" class="container-fluid">
-      <div class="row justify-content-between">
-        <div id="pl-calendar" class="datepicker"></div>
-        <div class="col-xxl titreSemFixe">
-          <div>Sélection des agents volants</div>
-          <div>Semaine {{ week_number }}, du {{ week }}</div>
-          <ul class="days_ul">
-            <li><a href="{{ asset('detached') }}?date={{ previous_week }}"> Semaine précédente </a> / </li>
-            <li><a href="{{ asset('detached') }}?date={{ next_week }}"> Semaine suivante </a></li>
-          </ul>
-        </div>
+  <div id="divcalendrier" class="container">
+    <div id="pl-header" class="row">
+      <div id="pl-calendar" class="col-auto m-4 mt-3 datepicker"></div>
+      <div class="col-6" id="pl-title">
+        <div>Sélection des agents volants</div>
+        <div>Semaine {{ week_number }}, du {{ week }}</div>
+        <ul class="days_ul">
+          <li><a href="{{ asset('detached') }}?date={{ previous_week }}"> Semaine précédente </a> / </li>
+          <li><a href="{{ asset('detached') }}?date={{ next_week }}"> Semaine suivante </a></li>
+        </ul>
       </div>
     </div>
   </div>
@@ -43,14 +41,14 @@
             {% endfor %}
           </select>
         </div>
-    
+
         <div id="volants-buttons-div">
           <input type="button" class="btn btn-secondary" id="volants-add" value="Ajouter >>" /><br/><br/>
           <input type="button" class="btn btn-secondary" id="volants-add-all" value="Ajouter Tout >>" /><br/><br/>
           <input type="button" class="btn btn-danger" id="volants-remove" value="<< Supprimer" /><br/><br/>
           <input type="button" class="btn btn-danger" id="volants-remove-all" value="<< Supprimer Tout" /><br/><br/>
         </div>
-    
+
         <div id="volants-selectionnes-div">
           <h4>Agents sélectionnés</h4>
           <select id="volants-selectionnes" name="selectionnes" multiple="multiple">
@@ -63,7 +61,7 @@
             {% endfor %}
           </select>
         </div>
-    
+
         <div id="volants-validation">
           <input type="submit" role="button" class="btn btn-primary" id="submit" value="Valider" />
         </div>

--- a/templates/menu.html.twig
+++ b/templates/menu.html.twig
@@ -1,5 +1,5 @@
 {# menu.html.twig #}
-  <nav id="mainMenu" class="navbar navbar-expand-lg" role="navigation">
+  <nav id="mainMenu" class="navbar navbar-expand-lg d-print-none" role="navigation">
      <div class="container-fluid">
       <button class="navbar-toggler ms-auto" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Menu">
         <div class="logo-thumbnail"></div>

--- a/templates/planning/poste/index.html.twig
+++ b/templates/planning/poste/index.html.twig
@@ -31,7 +31,7 @@
     {% endif %}
 
     {% if not_ready %}
-      <div class='decalage-gauche'>
+      <div class="decalage-gauche" style="margin-top: 60px;">
         <p>Le planning du {{ date | datefr }} n'est pas prêt.</p>
       </div>
 
@@ -41,7 +41,7 @@
     {% endif %}
 
     {% if tab and not locked and not autorisationN1 %}
-      <div class='decalage-gauche'>
+      <div class="decalage-gauche" style="margin-top: 60px;">
         <p class="important">Le planning du {{ date | datefr }} n'est pas validé !</p>
       </div>
 

--- a/templates/planning/poste/menu.html.twig
+++ b/templates/planning/poste/menu.html.twig
@@ -6,126 +6,118 @@
 {% endblock %}
 
 <!-- Show title and calendar widgets -->
-<div id='divcalendrier' class='navabar-expand-custom text'>
+<div id="divcalendrier" class="container">
   <form name='form' method='get' action='#'>
     <input type='hidden' id='date' name='date' value='{{ date }}' data-set-calendar='{{ date }}' />
     <input type='hidden' id='site' name='date' value='{{ site }}' />
   </form>
 
-  <div id='tab_titre' class="container-fluid">
-    <div class="row">
-      <div id="pl-calendar" class="datepicker {{ week_view ? 'datepickerSemaine' }}" data-date="{{date}}"></div>
-      <div class='col-xxl titreSemFixe'>
-        <div id='week_planning'>
-          <b>Semaine {{ affSem }}</b>
-        </div>
-
-        <div id='semaine_planning'>
-          <b>Du {{ dates[0] | date("d/m/Y") }} au {{ dates[6] | date("d/m/Y")}}.</b>
-        </div>
-
-        {% if not week_view %}
-          <div id='date_planning'>
-            Planning du {{ date | datefull }}
-            {% if public_holiday %}
-              <font id='ferie'>{{ public_holiday }}</font>
-            {% endif %}
-          </div>
-        {% endif %}
-
-        <div class='noprint' id='tab_jours'>
-          <ul class="days_ul">
-            <li><a href="{{ path('home', {date: dates[0]}) }}" {% if date == dates[0] and not week_view %} class="active" {% endif %}>Lundi</a> / </li>
-            <li><a href="{{ path('home', {date: dates[1]}) }}" {% if date == dates[1] and not week_view %} class="active" {% endif %}>Mardi</a> / </li>
-            <li><a href="{{ path('home', {date: dates[2]}) }}" {% if date == dates[2] and not week_view %} class="active" {% endif %}>Mercredi</a> / </li>
-            <li><a href="{{ path('home', {date: dates[3]}) }}" {% if date == dates[3] and not week_view %} class="active" {% endif %}>Jeudi</a> / </li>
-            <li><a href="{{ path('home', {date: dates[4]}) }}" {% if date == dates[4] and not week_view %} class="active" {% endif %}>Vendredi</a> / </li>
-            <li><a href="{{ path('home', {date: dates[5]}) }}" {% if date == dates[5] and not week_view %} class="active" {% endif %}>Samedi</a></li>
-            {% if config('Dimanche') %}
-              <li> / <a href="{{ path('home', {date: dates[6]}) }}" {% if date == dates[6] and not week_view %} class="active" {% endif %}>Dimanche</a> </li>
-            {% endif %}
-            <li> / <a href="{{ asset('week') }}" {% if week_view %} class="active" {% endif %}>Semaine</a></li>
-          </ul>
-        </div>
-
-        <!-- Show informations -->
-
+  <div id="pl-header" class="row">
+    <div id="pl-calendar" class="col-auto m-4 mt-3 datepicker {{ week_view ? 'datepickerSemaine' }}" data-date="{{date}}"></div>
+    <div class="col-6" id="pl-title">
+      <div class="row" id='week_planning'>
+        Semaine {{ affSem }}
       </div>
 
-      <!-- Show action icons -->
-      <div id='td_boutons' class="col-2 col-lg-4">
-        {% if week_view %}
-          <a href='javascript:print();' title='Imprimer le planning'>
-            <span class='pl-icon pl-icon-printer'></span>
-          </a>
+      <div class="row {% if not week_view %} d-none {% endif %}" id="semaine_planning">
+        Du {{ dates[0] | date("d/m/Y") }} au {{ dates[6] | date("d/m/Y")}}
+      </div>
 
-          <a href="{{ path('home') }}" title="Actualiser">
-            <span class='pl-icon pl-icon-refresh'>
-          </a>
+      {% if not week_view %}
+        <div class="row nowrap" id="date_planning">
+          Planning du {{ date | datefull }}
+          {% if public_holiday %}
+            <font id='ferie'>{{ public_holiday }}</font>
+          {% endif %}
+        </div>
+      {% endif %}
 
-        {% else %}
+      <div class="row d-print-none" id="tab_jours">
+        <ul class="days_ul">
+          <li><a href="{{ path('home', {date: dates[0]}) }}" {% if date == dates[0] and not week_view %} class="active" {% endif %}>Lundi</a> / </li>
+          <li><a href="{{ path('home', {date: dates[1]}) }}" {% if date == dates[1] and not week_view %} class="active" {% endif %}>Mardi</a> / </li>
+          <li><a href="{{ path('home', {date: dates[2]}) }}" {% if date == dates[2] and not week_view %} class="active" {% endif %}>Mercredi</a> / </li>
+          <li><a href="{{ path('home', {date: dates[3]}) }}" {% if date == dates[3] and not week_view %} class="active" {% endif %}>Jeudi</a> / </li>
+          <li><a href="{{ path('home', {date: dates[4]}) }}" {% if date == dates[4] and not week_view %} class="active" {% endif %}>Vendredi</a> / </li>
+          <li><a href="{{ path('home', {date: dates[5]}) }}" {% if date == dates[5] and not week_view %} class="active" {% endif %}>Samedi</a></li>
+          {% if config('Dimanche') %}
+            <li> / <a href="{{ path('home', {date: dates[6]}) }}" {% if date == dates[6] and not week_view %} class="active" {% endif %}>Dimanche</a> </li>
+          {% endif %}
+          <li> / <a href="{{ asset('week') }}" {% if week_view %} class="active" {% endif %}>Semaine</a></li>
+        </ul>
+      </div>
+    </div>
+
+    <!-- Show informations -->
+    <!-- Show action icons -->
+    <div id="pl-buttons" class="col">
+      <div id="validation" class="row justify-content-end">
+        {% if not week_view %}
+
           {% if ( userCan('300', site) or userCan('1000', site) ) and config('CatAFinDeService') %}
-            <div id='pl-verif-categorie-A'></div>
+            <div id="pl-verif-categorie-A" class="col-auto"></div>
           {% endif %}
 
-          <div id='validation'>
-            <div class='pl-validation' style="{{ locked ?: 'display:none'}}">
-              <u>Validation</u><br/>
-              {{ lockPerson }} {{ lockDate | datefr }}
-            </div>
+          <div class="col-auto pl-validation" style="{{ locked ?: 'display:none'}}">
+            <u>Validation</u><br/>
+            {{ lockPerson }} {{ lockDate | datefr }}
+          </div>
+
+          <div class="col-auto d-print-none p-0">
 
             {% if userCan('300', site) or userCan('1000', site) %}
-              <span id="icon-lock" class="pl-icon pl-icon-lock pointer noprint" title="Déverrouiller le planning" {% if not locked %} style="display:none;" {% endif %}></span>
-              <span id="icon-unlock" class="pl-icon pl-icon-unlock pointer noprint" title="Verrouiller le planning" {% if locked %} style="display:none;" {% endif %}></span>
+              <button id="icon-lock" type="button" class="col-auto btn btn-icon" {% if not locked %} style="display:none;" {% endif %} >
+                <span class="col-auto pl-icon pl-icon-lock pointer" title="Déverrouiller le planning" ></span>
+              </button>
+              <button id="icon-unlock" type="button" class="col-auto btn btn-icon" {% if locked %} style="display:none;" {% endif %}>
+                <span class="col-auto pl-icon pl-icon-unlock pointer" title="Verrouiller le planning"></span>
+              </button>
             {% endif %}
 
             {% if userCan('300', site) %}
-
-              <button id="planning-save" type="button" class="btn btn-icon disabled" data-bs-toggle="modal" data-bs-target="#save-model-modal">
+              <button id="planning-save" type="button" class="col-auto btn btn-icon disabled" data-bs-toggle="modal" data-bs-target="#save-model-modal">
                 <span class="pl-icon pl-icon-save" title="Enregistrer comme modèle"></span>
               </button>
 
-              <button id="planning-import" type="button" class="btn btn-icon" data-bs-toggle="modal" data-bs-target="#import-model-modal" style="{{ locked ? 'display:none;' }}">
+              <button id="planning-import" type="button" class="col-auto btn btn-icon" data-bs-toggle="modal" data-bs-target="#import-model-modal" style="{{ locked ? 'display:none;' }}">
                 <span class="pl-icon pl-icon-open" title="Importer un modèle"></span>
               </button>
 
-              <button id="planning-drop" type="button" class="btn btn-icon" data-bs-toggle="modal" data-bs-target="#drop-model-modal" style="{{ locked ? 'display:none;' }}">
+              <button id="planning-drop" type="button" class="col-auto btn btn-icon" data-bs-toggle="modal" data-bs-target="#drop-model-modal" style="{{ locked ? 'display:none;' }}">
                 <span class="pl-icon pl-icon-drop" title="Supprimer le planning"></span>
               </button>
             {% endif %}
 
-            <a href="javascript:print();">
-              <span class="pl-icon pl-icon-printer" title="Imprimer le planning"></span>
-            </a>
-
-            <a href="{{ path('home') }}">
-              <span class="pl-icon pl-icon-refresh" title="Actualiser">
-            </a>
-
           </div>
-
-          {% if (userCan('300', site) or userCan('1000', site)) and not locked %}
-            <div id='undo-redo' class='pl-undo' style="{{ locked ? 'display:none;' }}">
-              {% if undoable %}
-                <a id="undo-action" href='javascript:void(0);'><span class="pl-icon pl-icon-undo"></span></a> -
-              {% else %}
-                <a id="undo-action" class="isDisabled" href='javascript:void(0);'><span class="pl-icon pl-icon-undo"></span></a> -
-              {% endif %}
-
-              {% if redoable %}
-                <a id="redo-action" href='javascript:void(0);'><span class="pl-icon pl-icon-redo"></span></a>
-              {% else %}
-                <a id="redo-action" class="isDisabled" href='javascript:void(0);'><span class="pl-icon pl-icon-redo"></span></a>
-              {% endif %}
-            </div>
-          {% endif %}
         {% endif %}
-        {% if config('Multisites-nombre') > 1 %}
-          <div>
-            <h3 id='h3-Multisites'>{{ siteName(site) }}</h3>
-          </div>
+
+        <div class="col-auto d-print-none p-0">
+          <button onclick="print();" class="col-auto btn btn-icon">
+            <span class="pl-icon pl-icon-printer" title="Imprimer le planning"></span>
+          </button>
+          <button onclick="location.href='{{ path('home') }}'" class="col-auto btn btn-icon">
+            <span class="pl-icon pl-icon-refresh" title="Actualiser">
+          </button>
+        </div>
+      </div>
+
+      <div class="row justify-content-end d-print-none" id="undo-redo" style="{{ locked ? 'display:none;' }}">
+        {% if (userCan('300', site) or userCan('1000', site)) and not week_view %}
+          <button id="undo-action" class="col-auto btn btn-icon {% if not undoable %} isDisabled {% endif %}" onclick="void(0);">
+            <span class="pl-icon pl-icon-undo"></span>
+          </butonn>
+          <button id="redo-action" class="col-auto btn btn-icon {% if not redoable %} isDisabled {% endif %}" onclick="void(0);">
+            <span class="pl-icon pl-icon-redo"></span>
+          </button>
         {% endif %}
       </div>
+
+      {% if config('Multisites-nombre') > 1 %}
+        <div class="row">
+          <h3 id="h3-Multisites" class="mt-3 pe-1">{{ siteName(site) }}</h3>
+        </div>
+      {% endif %}
+
     </div>
   </div>
 </div>

--- a/tests/PLBWebTestCase.php
+++ b/tests/PLBWebTestCase.php
@@ -6,7 +6,6 @@ use App\Entity\Config;
 use Facebook\WebDriver\Remote\DesiredCapabilities;
 use Facebook\WebDriver\Remote\RemoteWebDriver;
 use Facebook\WebDriver\WebDriverBy;
-use Facebook\WebDriver\WebDriverDimension;
 use Facebook\WebDriver\WebDriverSelect;
 use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\Panther\PantherTestCase;
@@ -126,9 +125,6 @@ class PLBWebTestCase extends PantherTestCase
                 '--headless'
             )
         );
-
-        $size = new WebDriverDimension(1600, 1000);
-        $this->client->manage()->window()->maximize()->setSize($size);
     }
 
     protected function login($agent)


### PR DESCRIPTION
* Update Planning Header
* Resolved issue with the window size
* add focus on btn-icon
* modified color focus of btn-primary and btn-secondary for more uniformity
* removed class center and ui-widget-content from datepicker (in script.js)
* use of BS grid for planning header
* move focus from lock to unlock icon when enter for smooth transition
* clean menu css
* SaveModal open disabled when button is disabled
* Grouping the CSS elements of the pl-header in the “Menu Planning” section
* deleted unused css classes
* adjusted pl-header css, mainly margins
* modified #pl-notes-div2 (misalignment error)
* condition after div on #undo-redo
* bs grid and css on detached
* Import model modal open on enter
* remove duplicate id
* semaine_planning visisble on week_view
* reduce icons padding
* adapted planning print display
* title visible and aligned, icon hidden, navbar hidden
* regrouped planning icons in .d-print-none div
* deleted unused id tab_titre