### PR TITLE
Remplacer les requêtes AJAX DELETE par des requêtes AJAX POST.

### DIFF
--- a/public/js/absence.js
+++ b/public/js/absence.js
@@ -604,10 +604,10 @@ function update_validation_statuses() {
 
 function delete_absence(CSRFToken, id, recurrence) {
   $.ajax({
-    url: url('absence'),
+    url: url('absence/delete'),
     data: {id: id, CSRFToken: CSRFToken, rec: recurrence},
-    dataType: "json",
-    type: "delete",
+	dataType: "json",
+    type: "post",
     async: false,
     success: function(result){
       msg = result['msg'];

--- a/public/js/framework.js
+++ b/public/js/framework.js
@@ -11,8 +11,8 @@ function supprimeGroupe(id){
 
   if(confirm("Etes vous sûr(e) de vouloir supprimer le groupe \""+nom+"\"?")){
     $.ajax({
-      url: url('framework-group'),
-      type: "delete",
+      url: url('framework-group/delete'),
+      type: "post",
       dataType: "json",
       data: {id: id, CSRFToken: CSRFToken},
       success: function(){
@@ -50,8 +50,8 @@ function supprimeLigne(id){
 
   if(confirm("Etes-vous sûr(e) de vouloir supprimer la ligne \""+nom+"\" ?")){
     $.ajax({
-      url: url('framework-line'),
-      type: "delete",
+      url: url('framework-line/delete'),
+      type: "post",
       dataType: "json",
       data: {id: id, CSRFToken: CSRFToken},
       success: function(){
@@ -79,8 +79,8 @@ function supprimeTableau(tableau){
   if(confirm("Etes vous sûr(e) de vouloir supprimer le tableau \""+nom+"\"?\nLes groupes utilsant ce tableau seront également supprimés")){
     var CSRFToken = $('#CSRFSession').val();
     $.ajax({
-      url: url('framework'),
-      type: "delete",
+      url: url('framework/delete'),
+      type: "post",
       dataType: "json",
       data: {tableau: tableau, CSRFToken: CSRFToken, name: nom},
       success: function(){

--- a/public/js/workingHour.js
+++ b/public/js/workingHour.js
@@ -215,10 +215,10 @@ function plHebdoSupprime(id){
     // Suppression du planning en arrière plan
 
     $.ajax({
-      url: url('workinghour'),
+      url: url('workinghour/delete'),
       dataType: "json",
       data: {id: id, CSRFToken: CSRFToken},
-      type: "delete",
+      type: "post",
 
       success: function(){
         // On cache la ligne du planning supprimée dans le tableau

--- a/src/Controller/AbsenceController.php
+++ b/src/Controller/AbsenceController.php
@@ -505,7 +505,7 @@ class AbsenceController extends BaseController
         return $this->output('absences/edit.html.twig');
     }
 
-    #[Route(path: '/absence', name: 'absence.delete', methods: ['DELETE'])]
+    #[Route(path: '/absence/delete', name: 'absence.delete', methods: ['POST'])]
     public function delete_absence(Request $request): \Symfony\Component\HttpFoundation\JsonResponse
     {
         $session = $request->getSession();

--- a/src/Controller/FrameworkController.php
+++ b/src/Controller/FrameworkController.php
@@ -463,7 +463,7 @@ class FrameworkController extends BaseController
         return $this->json('ok');
     }
 
-     #[Route(path: '/framework', name: 'framework.delete_table', methods: ['DELETE'])]
+     #[Route(path: '/framework/delete', name: 'framework.delete_table', methods: ['POST'])]
     public function deleteTable (Request $request, Session $session): JsonResponse
     {
         $post = $request->request->all();
@@ -687,7 +687,7 @@ class FrameworkController extends BaseController
         return $this->redirectToRoute('framework.index');
     }
 
-    #[Route(path: '/framework-group', name: 'framework.delete_group', methods: ['DELETE'])]
+    #[Route(path: '/framework-group/delete', name: 'framework.delete_group', methods: ['POST'])]
     public function deleteGroup (Request $request, Session $session): JsonResponse
     {
         $CSRFToken =  $request->request->get("CSRFToken");
@@ -772,7 +772,7 @@ class FrameworkController extends BaseController
         return $this->redirectToRoute('framework.index', array("msg" => $msg, "msgType" => $msgType));
     }
 
-    #[Route(path: '/framework-line', name: 'framework.delete_line', methods: ['DELETE'])]
+    #[Route(path: '/framework-line/delete', name: 'framework.delete_line', methods: ['POST'])]
     public function deleteLine (Request $request, Session $session): JsonResponse
     {
         $post = $request->request->all();

--- a/src/Controller/WorkingHourController.php
+++ b/src/Controller/WorkingHourController.php
@@ -635,7 +635,7 @@ class WorkingHourController extends BaseController
         return $this->redirectToRoute($route);
     }
 
-    #[Route(path: '/workinghour', name: 'workinghour.delete', methods: ['DELETE'])]
+    #[Route(path: '/workinghour/delete', name: 'workinghour.delete', methods: ['POST'])]
     public function delete(Request $request, Session $session): \Symfony\Component\HttpFoundation\JsonResponse{
         $CSRFToken = $request->get('CSRFToken');
         $id = $request->get("id");


### PR DESCRIPTION
Mettre type: 'post' et ajouter /delete dans la fonction url() dans les fichiers Javascript.
Dans les contrôleurs, ajouter /delete dans le path et remplacer DELETE par POST dans la méthode. 