### PR TITLE
BugFix :  Undefined variables error on Agent Controller

### DIFF
--- a/src/Controller/AgentController.php
+++ b/src/Controller/AgentController.php
@@ -226,9 +226,10 @@ class AgentController extends BaseController
         $managersMails = array_map('trim', $managersMails);
         $sites = $agent->getSites();
 
+        $sitesSelect = [];
+
         // Multi-sites
         if ($this->config['Multisites-nombre'] > 1) {
-            $sitesSelect = [];
             for ($i = 1; $i <= $this->config['Multisites-nombre']; $i++) {
                 $sitesSelect[] = [
                     'id' => $i,
@@ -326,6 +327,8 @@ class AgentController extends BaseController
             $rights[ $elem['categorie'] ]['rights'][] = $elem;
         }
 
+        $rights_sites = array();
+
         // Affichage des droits d'accès dépendant des sites (si plusieurs sites)
         if ($this->config('Multisites-nombre') > 1) {
             $sites_for_rights = array();
@@ -335,7 +338,6 @@ class AgentController extends BaseController
 
             $this->templateParams(array('sites_for_rights' => $sites_for_rights));
 
-            $rights_sites = array();
             foreach ($accessgroupsBySite as $elem) {
                 // N'affiche pas les droits de gérer les congés si le module n'est pas activé
                 if (!$this->config('Conges-Enable') and in_array($elem['groupe_id'], array(25, 401, 601))) {


### PR DESCRIPTION
In AgentController.php two variables (`$sitesSelect,$rights_sites`) where only initiliazed when
 `Multisites-nombre > 1`.
So when the condition wasn't true an undefined variable error was raised, blocking the agent edit page.