### PR TITLE
MT53720: Do not display unamed sites

### DIFF
--- a/src/Controller/AgentController.php
+++ b/src/Controller/AgentController.php
@@ -227,10 +227,17 @@ class AgentController extends BaseController
         $managersMails = array_map('trim', $managersMails);
         $sites = $agent->getSites();
 
+        $sitesSelect = [];
+
         // Multi-sites
         if ($this->config['Multisites-nombre'] > 1) {
-            $sitesSelect = [];
             for ($i = 1; $i <= $this->config['Multisites-nombre']; $i++) {
+
+                // Avoid displaying unamed or deleted sites
+                if (empty($this->config['Multisites-site' . $i])) {
+                    continue;
+                }
+
                 $sitesSelect[] = [
                     'id' => $i,
                     'name' => $this->config("Multisites-site$i"),
@@ -327,16 +334,11 @@ class AgentController extends BaseController
             $rights[ $elem['categorie'] ]['rights'][] = $elem;
         }
 
+        $rights_sites = [];
+
         // Affichage des droits d'accès dépendant des sites (si plusieurs sites)
         if ($this->config('Multisites-nombre') > 1) {
-            $sites_for_rights = array();
-            for ($i = 1; $i <= $this->config('Multisites-nombre'); $i++) {
-                $sites_for_rights[] = array( 'site_name' => $this->config("Multisites-site$i") );
-            }
 
-            $this->templateParams(array('sites_for_rights' => $sites_for_rights));
-
-            $rights_sites = array();
             foreach ($accessgroupsBySite as $elem) {
                 // N'affiche pas les droits de gérer les congés si le module n'est pas activé
                 if (!$this->config('Conges-Enable') and in_array($elem['groupe_id'], array(25, 401, 601))) {
@@ -356,6 +358,12 @@ class AgentController extends BaseController
 
                 $elem['sites'] = array();
                 for ($i = 1; $i < $this->config('Multisites-nombre') +1; $i++) {
+
+                    // Avoid displaying unamed or deleted sites
+                    if (empty($this->config['Multisites-site' . $i])) {
+                        continue;
+                    }
+
                     $groupe_id = $elem['groupe_id'] - 1 + $i;
 
                     $checked = in_array($groupe_id, $access);

--- a/src/Planno/Menu.php
+++ b/src/Planno/Menu.php
@@ -90,6 +90,11 @@ class Menu
         
             $i=0;
             foreach ($keys2 as $key2) {
+                // Avoid displaying empty items, such as a deleted site under the planning menu.
+                if (empty($elements[$key][$key2]['titre'])) {
+                  continue;
+                }
+
                 $menu_js[$key]['items'][$i] = array(
                     'key' => $key,
                     'url' => $elements[$key][$key2]['url'],

--- a/templates/agents/rights.html.twig
+++ b/templates/agents/rights.html.twig
@@ -21,8 +21,8 @@
       <thead>
         <tr>
           <th>&nbsp;</th>
-          {% for s in sites_for_rights %}
-            <th class='center' style='padding:0 10px;'>{{ s.site_name }}</th>
+          {% for s in sitesSelect %}
+            <th class="center" style="padding:0 10px;">{{ s.name }}</th>
           {% endfor %}
         </tr>
       </thead>

--- a/templates/agents/rights_edit.html.twig
+++ b/templates/agents/rights_edit.html.twig
@@ -17,8 +17,8 @@
       <thead>
         <tr>
           <th>&nbsp;</th>
-          {% for s in sites_for_rights %}
-            <th class='center' style='padding:0 10px;'>{{ s.site_name }}</th>
+          {% for s in sitesSelect %}
+            <th class="center" style="padding:0 10px;">{{ s.name }}</th>
           {% endfor %}
         </tr>
       </thead>

--- a/tests/Class/ClassMenuTest.php
+++ b/tests/Class/ClassMenuTest.php
@@ -41,5 +41,36 @@ class ClassMenuTest extends TestCase
         $this->assertEquals($menu->checkCondition('config!=Conges-Enable&config=Conges-Recuperations'), false, 'both equal and not equal single conditions');
         $this->assertEquals($menu->checkCondition('config=Conges-Enable&config!=Conges-Recuperations'), false, 'both equal and not equal single conditions');
 
+        // Check Sites display under Planning Menu
+        $GLOBALS['config']['Multisites-nombre'] = 3;
+        $GLOBALS['config']['Multisites-site1'] = 'Site 1';
+        $GLOBALS['config']['Multisites-site2'] = 'Site 2';
+        $GLOBALS['config']['Multisites-site3'] = 'Site 3';
+
+        $menu = new Menu();
+        $result = $menu->get();
+
+        $this->assertEquals(3, count($result['menu_js'][30]['items']), "Planning menu should count 3 entries.");
+        $this->assertEquals('Site 1', $result['menu_js'][30]['items'][0]['title'], "Planning menu 1 title should be 'Site 1'.");
+        $this->assertEquals('Site 2', $result['menu_js'][30]['items'][1]['title'], "Planning menu 2 title should be 'Site 2'.");
+        $this->assertEquals('Site 3', $result['menu_js'][30]['items'][2]['title'], "Planning menu 3 title should be 'Site 3'.");
+
+        $GLOBALS['config']['Multisites-site2'] = '';
+
+        $menu = new Menu();
+        $result = $menu->get();
+
+        $this->assertEquals(2, count($result['menu_js'][30]['items']), "Planning menu should count 2 entries.");
+        $this->assertEquals('Site 1', $result['menu_js'][30]['items'][0]['title'], "Planning menu 1 title should be 'Site 1'.");
+        $this->assertEquals('Site 3', $result['menu_js'][30]['items'][1]['title'], "Planning menu 2 title should be 'Site 3'.");
     }
+
+    public static function tearDownAfterClass(): void
+    {
+        $GLOBALS['config']['Multisites-nombre'] = 1;
+        $GLOBALS['config']['Multisites-site1'] = '';
+        $GLOBALS['config']['Multisites-site2'] = '';
+        $GLOBALS['config']['Multisites-site3'] = '';
+   }
+
 }

--- a/tests/Controller/AgentControllerTest.php
+++ b/tests/Controller/AgentControllerTest.php
@@ -185,6 +185,8 @@ class AgentControllerTest extends PLBWebTestCase
     public function testEditFormElement(): void {
 
         $GLOBALS['config']['Multisites-nombre'] = 2;
+        $GLOBALS['config']['Multisites-site1'] = 'Site 1';
+        $GLOBALS['config']['Multisites-site2'] = 'Site 2';
         $GLOBALS['config']['Granularite'] = 30;
         $GLOBALS['config']['LDAP-Host'] = '';
         $GLOBALS['config']['LDAP-Suffix'] = '';
@@ -203,8 +205,6 @@ class AgentControllerTest extends PLBWebTestCase
         ));
 
         $id = $jdupont->getId();
-
-        //$this->login($kboivin);
 
         $this->logInAgent($kboivin, $kboivin->getACL());
         $crawler = $this->client->request('GET', "/agent/$id");
@@ -241,6 +241,9 @@ class AgentControllerTest extends PLBWebTestCase
         $this->assertStringContainsString('E-mails des responsables :', $result->text('Node does not exist', false));
         $this->assertStringContainsString('Informations :', $result->text('Node does not exist', false));
         $this->assertStringContainsString('Identifiant :', $result->text('Node does not exist', false));
+        $this->assertStringContainsString('Identifiant :', $result->text('Node does not exist', false));
+        $this->assertStringContainsString('Site 1', $result->text('Node does not exist', false));
+        $this->assertStringContainsString('Site 2', $result->text('Node does not exist', false));
 
         $result = $crawler->filterXPath('//input[@name="nom"]');
         $this->assertEquals('Dupont', $result->attr('value'));
@@ -337,6 +340,16 @@ class AgentControllerTest extends PLBWebTestCase
         $this->assertStringContainsString('Accès aux statistiques Présents / Absents', $result->text('Node does not exist', false));
         $this->assertStringContainsString('Gestion des jours fériés', $result->text('Node does not exist', false));
         $this->assertStringContainsString('Informations', $result->text('Node does not exist', false));
+
+
+        // Remove a site name
+        $GLOBALS['config']['Multisites-site2'] = '';
+
+        $crawler = $this->client->request('GET', "/agent/$id");
+        $result = $crawler->filterXPath('//table[@style="width:90%;"]');
+
+        $this->assertStringContainsString('Site 1', $result->text('Node does not exist', false));
+        $this->assertStringNotContainsString('Site 2', $result->text('Node does not exist', false));
 
     }
 


### PR DESCRIPTION
* Under the planning menu
* In agents records, general info tab and ACL tab.

This is useful when we want to remove a site: we simply need to delete its name from the configuration, while waiting for better site management.

TEST PLAN :
* Create sites (config)
* Check that they display correctly and are accessible under the planning menu.
* Check that they display correctly in agent records, info general tab and access right tab.
* Remove a site name from the configuration without changing the number of sites.
* Check that the other sites still display and are accessible.