### PR TITLE
MT46629: Replace CJInfo with StackAlert

### DIFF
--- a/public/js/CJScript.js
+++ b/public/js/CJScript.js
@@ -57,92 +57,86 @@ function CJDataTableStripe() {
   });
 }
 
-function CJErrorHighlight(e, type, icon) {
-    if (!icon) {
-        if (type === 'highlight') {
-            icon = 'ui-icon-info';
-        } else {
-            icon = 'ui-icon-alert';
-        }
-    }
-    return e.each(function() {
-        $(this).addClass('ui-widget');
-
-        var alertHtml = '<div class="ui-state-' + type + ' ui-corner-all" style="padding:0 .7em;">';
-        alertHtml += '<p style="text-align:center;">';
-        alertHtml += '<span class="ui-icon ' + icon + '" style="float:left;margin-right: .3em;"></span>';
-        alertHtml += $(this).html();
-        alertHtml += '</p>';
-        alertHtml += '</div>';
-
-        $(this).html(alertHtml);
-    });
-}
-
 /**
- * @function CJInfo
- * Affiche des messages d'erreur ou d'information en haut de l'application
- * @param string message : message à afficher, utiliser #BR# pour les sauts de lignes
- * @param string type : type de message, valeurs = success ou error
- * @param int top : position haute du message en pixel, default=82
- * @param int time : temps d'affichage en milisecondes, default=8000
- * @param string myClass : permet d'attribuer une classe au div affichant le message pour agir dessus à postériori (ex : $(".myClass").remove(); )
+ * @function stackAlert
+ * Generates a stacked alert. Uses BS alerts classes and comportment.
+ * @param string message : message to display
+ * @param string type :  message type; possible values: info, success, error or warning
+ * @param int timeout : display duration in milliseconds; if timeout = 0, the alert is permanent
+ * @param int position : position on the screen; possible values: combination of top/bottom and left/center/right
+ * @param array translationOptions : message additional translation information (variables, domains ...)
  */
-function CJInfo(message,type,top,time,myClass){
-  if(type==undefined || type=="success"){
-  	type="highlight";
+
+function stackAlert(message, type='success', timeout=7000, position='top-center', translationOptions = null)
+{
+  type = (type === 'error') ? 'danger' : type;
+
+  // Translate the message
+  message = Translator.trans(message, translationOptions);
+  message = message.replace(/#BR#/g,"<br/>&emsp;&emsp;");
+  message = message.replace(/\n/g,"<br/>&emsp;&emsp;");
+
+  const close_msg = Translator.trans('Close');
+
+  // Map of types with associated icons (Bootstrap Icons).
+  const icons = {
+    info: 'bi-info-circle-fill bi-information',
+    success: 'bi-check-circle-fill bi-success',
+    warning: 'bi-exclamation-triangle-fill bi-warning',
+    danger: 'bi-exclamation-triangle-fill bi-danger'
+  };
+
+  // Map of positions with associated CSS coordinates
+  const positions = {
+    'top-right': { top: '70px', right: '20px' },
+    'bottom-right': { bottom: '20px', right: '20px' },
+    'top-left':	{ top: '70px', left: '20px' },
+    'bottom-left': { bottom: '20px', left: '20px' },
+    'top-center': { top: '70px', left: '50%', transform: 'translateX(-50%)' },
+    'bottom-center': { bottom: '20px', left: '50%', transform: 'translateX(-50%)' }
+  };
+
+  // Unique ID for the alert (used for DOM manipulation)
+  const alertId = 'alert-' + Date.now();
+
+  // ID of the container for the current position
+  const containerId = 'alert-stack-' + position;
+  let $container = $('#' + containerId);
+
+  // If the container doesn't exist, it initializes it
+  if (!$container.length) {
+    $container = $('<div>', {
+      id: containerId,
+      css: $.extend({
+        position: 'fixed',
+        zIndex: 1050,
+        minWidth: '25%'
+      }, positions[position])
+    }).appendTo('body');
+
+    // Center the container if necessary
+    if (positions[position].transform) {
+      $container.css('transform', positions[position].transform);
+    }
   }
 
-  if(top==undefined){
-    top=82;
+  // Builds the HTML for the alert and inserts it into the container
+  const alertHtml = `
+  <div id="${alertId}" class="alert alert-${type} alert-dismissible fade show mb-2" role="alert"">
+    <i class="bi ${icons[type]} me-2"></i> 
+      ${message}
+      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="${close_msg}"></button>
+    </div>`;
+
+  $container.append(alertHtml);
+
+  // Dismiss automatically the alert after the timeout if timeout > 0
+  if (timeout > 0) {
+    setTimeout(() => {$('#' + alertId).alert('close');}, timeout);
   }
 
-  if(time==undefined){
-    time=8000;
-  }
-
-  if(myClass==undefined){
-    myClass=null;
-  }
-
-  if(typeof(timeoutCJInfo)!== 'undefined' && time != 'permanent'){
-    window.clearTimeout(timeoutCJInfo);
-  }
-
-  var id=1;
-  $(".CJInfo").each(function(){
-    id=$(this).attr("data-id")>=id?($(this).attr("data-id")+1):id;
-    top=$(this).position().top+$(this).height()+5;
-  });
-
-  message=message.replace(/#BR#/g,"<br/>");
-  message=message.replace(/\n/g,"<br/>");
-
-  $("body").append("<div class='CJInfo noprint "+myClass+"' id='CJInfo"+id+"' data-id='"+id+"'>"+message+"</div>");
-  CJErrorHighlight($("#CJInfo"+id),type);
-  CJPosition($("#CJInfo"+id),top,"center");
-
-  if( time != 'permanent' ){
-    timeoutCJInfo=window.setTimeout(function(){
-      var height=$("#CJInfo"+id).height();
-      $("#CJInfo"+id).remove();
-      $(".CJInfo").each(function(){
-              var top=$(this).position().top-height;
-              $(this).css("top",top);
-      });
-    },time);
-  }
-}
-
-function CJPosition(object,top,left){
-  object.css("position","absolute");
-  object.css("z-index",10);
-  object.css("top",top);
-  if(left=="center"){
-    left=($(window).width()-object.width())/2;
-    object.css("left",left);
-  }
-}
+  return this;
+};
 
 // Fonction JQuery
 $(function(){

--- a/public/js/absence.js
+++ b/public/js/absence.js
@@ -494,10 +494,11 @@ $(function() {
       method: 'POST',
       data: 'id=' + id + '&pj=' + pj + '&checked=' + checked + '&CSRFToken=' + CSRFToken,
       success: function(){
-        information('Modification enregistrée', 'highlight');
+        $('#alert-stack-top-center').remove();
+        stackAlert('Modification enregistrée');
       },
       error: function(){
-        information('Attention, la modification n\'a pas pu être enregistrée', 'error');
+        stackAlert('Attention, la modification n\'a pas pu être enregistrée', 'error');
       }
     });
   });
@@ -605,7 +606,7 @@ function update_validation_statuses() {
       highlight($('tr#validation-line'));
     },
     error: function(xhr, ajaxOptions, thrownError) {
-      information("Une erreur s'est produite lors de la mise à jour de la liste des statuts", 'error');
+      stackAlert('Une erreur s\'est produite lors de la mise à jour de la liste des statuts', 'error');
     }
   });
 }
@@ -858,13 +859,13 @@ function verif_absences() {
   }
 
   if($("select[name=motif] option:selected").attr("disabled")=="disabled"){
-    CJInfo("Le motif sélectionné n'est pas valide.\nVeuillez le modifier s'il vous plaît.","error");
+    stackAlert('Le motif sélectionné n\'est pas valide.\nVeuillez le modifier s\'il vous plaît.', 'error');
     return false;
   }
 
   if($("select[name=motif]").val().toLowerCase()=="autre" || $("select[name=motif]").val().toLowerCase()=="other"){
     if($("input[name=motif_autre]").val()==""){
-      CJInfo("Veuillez choisir un motif.","error");
+      stackAlert('Veuillez choisir un motif.', 'error');
       return false;
     }
   }
@@ -877,7 +878,7 @@ function verif_absences() {
 
   // Si aucun agent n'est sélectionné, on quitte en affichant "Veuillez sélectionner ..."
   if(perso_ids.length<1){
-    CJInfo("Veuillez sélectionner un ou plusieurs agents","error");
+    stackAlert('Veuillez sélectionner un ou plusieurs agents', 'error');
     return false;
   }
 
@@ -967,7 +968,7 @@ function verif_absences() {
             retour=false;
           }
         } else {
-          CJInfo("Vous ne pouvez pas enregistrer d'absences pour les dates suivantes car les plannings sont en cours d'élaboration :#BR#"+result["planning_started"], "error");
+          stackAlert('Vous ne pouvez pas enregistrer d\'absences pour les dates suivantes car les plannings sont en cours d\'élaboration :\n' + result['planning_started'], 'error');
           retour=false;
         }
       }
@@ -978,7 +979,7 @@ function verif_absences() {
             retour = false;
           }
         } else {
-          CJInfo("Vous ne pouvez pas enregistrer d'absences pour les dates suivantes car elles rentrent en conflit avec une période bloquée.", "error");
+          stackAlert('Vous ne pouvez pas enregistrer d\'absences pour les dates suivantes car elles rentrent en conflit avec une période bloquée.', 'error');
           retour = false;
         }
       }
@@ -1007,14 +1008,14 @@ function verif_absences() {
           if(!confirm(message +"\nVoulez-vous continuer ?"))
             retour=false;
           } else {
-            CJInfo("Vous ne pouvez pas ajouter d'absences car " + message.replace("\n", "#BR#"), "error");
+            stackAlert('Vous ne pouvez pas ajouter d\'absences car ' + message, 'error');
             retour=false;
           }
         }
       }
     },
     error: function(result){
-      information("Une erreur est survenue.","error");
+      stackAlert('Une erreur est survenue.', 'error');
       retour=false;
     }
   });

--- a/public/js/agent.js
+++ b/public/js/agent.js
@@ -303,10 +303,10 @@ function sendPassword() {
       id: $('input[name=id]').val(),
     },
     success: function(result) {
-      CJInfo(result[0], result[1]);
+      stackAlert(result[0], result[1]);
     },
     error: function() {
-      CJInfo('Une errreur est survenue lors de l\'envoi du mot de passe', 'error');
+      stackAlert('Une errreur est survenue lors de l\'envoi du mot de passe', 'error');
     }
   });
 }
@@ -343,17 +343,17 @@ function verif_form_agent(){
   }
 
   if(erreur) {
-    CJInfo(message);
+    stackAlert(message, 'error');
     return false;
   }
 
   if(!verif_mail(document.form.mail.value)) {
-    CJInfo("Adresse e-mail invalide");
+    stackAlert('Adresse e-mail invalide', 'error');
     return false;
   }
 
   if ($('.invalid').length) {
-    CJInfo("Des valeurs sont invalides dans l'onglet \"Congés\"");
+    stackAlert('Des valeurs sont invalides dans l\'onglet "Congés"', 'error');
     return false;
   }
 
@@ -657,14 +657,14 @@ $(function() {
       },
       success: function(result) {
         if(result.error) {
-          updateTips(result.error, 'error');
+          stackAlert(result.error, 'error');
         } else {
-          CJInfo('L\'e-mail a bien été envoyé', 'success');
+          stackAlert('L\'e-mail a bien été envoyé');
           $('#ics-url-modal').modal('hide');
         }
       },
       error: function(){
-        updateTips('Une erreur est survenue lors de l\'envoi de l\'e-mail', 'error');
+        stackAlert('Une erreur est survenue lors de l\'envoi de l\'e-mail', 'error');
       }
     });
   });

--- a/public/js/calendar.js
+++ b/public/js/calendar.js
@@ -1,8 +1,0 @@
-/**
-@desc Javascript functions use to display calendars
-*/
-
-$(document).ready(function() {
-  // Formatting error messages
-  CJErrorHighlight($('.information'), 'error');
-});

--- a/public/js/config.js
+++ b/public/js/config.js
@@ -20,10 +20,8 @@ function ldaptest() {
     filter = '(objectclass=inetorgperson)';
   }
 
-  var pos = $('#LDAP-Test').position();
-  top1 = pos.top - 10;
 
-  $('.CJInfo').remove();
+  $('#alert-stack-top-center').remove();
 
   $.ajax({
     url: url('config/ldap-test'),
@@ -32,17 +30,17 @@ function ldaptest() {
     data: {filter: filter, host: host, idAttribute: idAttribute, password : password, port: port, protocol: protocol, rdn: rdn, suffix: suffix},
     success: function(result) {
       if (result == 'ok') {
-        CJInfo('Les paramètres LDAP sont corrects', 'success', top1);
+        stackAlert('Les paramètres LDAP sont corrects');
       } else if (result == 'bind') {
-        CJInfo('Les paramètres Protocol, RDN et/ou Password sont incorrects', 'error', top1);
+        stackAlert('Les paramètres Protocol, RDN et/ou Password sont incorrects', 'error');
       } else if (result == 'search') {
-        CJInfo('Les paramètres Suffix, Filter et/ou ID-Attribute sont incorrects', 'error', top1);
+        stackAlert('Les paramètres Suffix, Filter et/ou ID-Attribute sont incorrects', 'error');
       } else {
-        CJInfo('Les paramètres LDAP Host et/ou Port sont incorrects', 'error', top1);
+        stackAlert('Les paramètres LDAP Host et/ou Port sont incorrects', 'error');
       }
     },
     error: function() {
-      CJInfo('Impossible de vérifier les paramètres LDAP', 'error', top1);
+      stackAlert('Impossible de vérifier les paramètres LDAP', 'error');
     }
   });
 }
@@ -89,18 +87,16 @@ function mailtest() {
   var signature = $('#Mail-Signature').val();
   var planning = $('#Mail-Planning').val().trim();
 
-  var pos = $('#Mail-Test').position();
-  top1 = pos.top - 10;
 
-  $('.CJInfo').remove();
+  $('#alert-stack-top-center').remove();
 
   if(enabled == 0) {
-    CJInfo('Le paramètre "Mail-IsEnabled" est désactivé', 'error', top1, 8000);
+    stackAlert('Le paramètre "Mail-IsEnabled" est désactivé', 'error');
     return false;
   }
 
   if( !planning) {
-    CJInfo('Veuillez entrer une (ou plusieurs) adresse(s) valide(s) dans le champ "Mail-Planning"', 'error', top1, 8000);
+    stackAlert('Veuillez entrer une (ou plusieurs) adresse(s) valide(s) dans le champ "Mail-Planning"', 'error');
     return false;
   }
 
@@ -127,15 +123,15 @@ function mailtest() {
     data: data,
     success: function(result) {
       if (result == 'ok') {
-        CJInfo('Le mail de test a été envoyé avec succès. Vérifiez votre messagerie.', 'success', top1, 8000);
+        stackAlert('Le mail de test a été envoyé avec succès. Vérifiez votre messagerie.');
       } else if (result == 'socket') {
-        CJInfo('Impossible de joindre le serveur de messagerie.', 'error', top1, 8000);
+        stackAlert('Impossible de joindre le serveur de messagerie.', 'error');
       } else {
-        CJInfo("Une erreur est survenue lors de l'envoi du mail.\n" + result, 'error', top1, 8000);
+        stackAlert('Une erreur est survenue lors de l\'envoi du mail.\n' + result, 'error');
       }
     },
     error: function(result){
-        CJInfo("Une erreur est survenue lors de l'envoi du mail.\n" + result.responseText, 'error', top1, 8000);
+        stackAlert('Une erreur est survenue lors de l\'envoi du mail.\n' + result.responseText, 'error');
     }
   });
 }

--- a/public/js/detached.js
+++ b/public/js/detached.js
@@ -73,13 +73,13 @@ $(function() {
       data: {ids: ids, date: $('#date').val(), CSRFToken: $('#CSRFSession').val(), },
       success: function(result){
         if(result.error){
-          CJInfo("Une erreur est survenue lors de l'enregistrement des informations", 'error');
+          stackAlert('An error occurred while saving the information', 'error');
         } else {
-          CJInfo('Vos modifications ont été enregistrées avec succès', 'success');
+          stackAlert('Vos modifications ont été enregistrées avec succès');
         }
       },
       error: function(){
-        CJInfo("Une erreur est survenue lors de l'enregistrement des informations", 'error');
+        stackAlert('An error occurred while saving the information', 'error');
       }
     });
     

--- a/public/js/framework.js
+++ b/public/js/framework.js
@@ -33,10 +33,10 @@ function supprimeGroupe(id){
           tr=tr.next("tr");
         }
         $("#tr-groupe-"+id).remove();
-        CJInfo("Le groupe \""+nom+"\" a été supprimé avec succès","success");
+        stackAlert('Le groupe "%nom%" a été supprimé avec succès', undefined, undefined, undefined, {'nom' : nom});
       },
       error: function(result){
-        CJInfo("Une erreur est survenue lors de la suppression du groupe \""+nom+"\"","error");
+        stackAlert('Une erreur est survenue lors de la suppression du groupe "%nom%"','error', undefined, undefined, {"nom" : nom});
       }
     });
   }
@@ -64,10 +64,10 @@ function supprimeLigne(id){
           tr=tr.next("tr");
         }
         $("#tr-ligne-"+id).remove();
-        CJInfo("Le ligne \""+nom+"\" a été supprimée avec succès","success");
+        stackAlert('La ligne "%nom%" a été supprimée avec succès', undefined, undefined, undefined, {"nom" : nom});
       },
       error: function(result){
-        CJInfo("Une erreur est survenue lors de la suppression de la ligne \""+nom+"\"","error");
+        stackAlert('Une erreur est survenue lors de la suppression de la ligne "%nom%"', 'error', undefined, undefined, {'nom' : nom});
       }
     });
   }
@@ -87,7 +87,7 @@ function supprimeTableau(tableau){
         window.location.href = url('framework');
       },
       error: function(result){
-        CJInfo("Une erreur est survenue lors de la suppression du tableau \""+nom+"\"\n"+result.responseText,"error");
+        stackAlert('Une erreur est survenue lors de la suppression du tableau "%nom%"\n' + result.responseText, 'error', undefined, undefined, {'nom' : nom});
       }
     });
   }
@@ -178,7 +178,7 @@ function supprime_select(classe,page){
         window.location.href= url('framework?msgType=success&msg=' + msg);
       },
       error: function(){
-        CJInfo("Une erreur est survenue lors de la suppression.","error");
+        stackAlert('An error occurred during deletion', 'error');
       }
     });
   }
@@ -199,7 +199,7 @@ function tableauxInfos(){
       }
     },
     error: function(result){
-      CJInfo("Une erreur est survenue lors de la modification des informations\n"+result.responseText,"error");
+      stackAlert('Une erreur est survenue lors de la modification des informations\n' + result.responseText, 'error');
     }
   });
 }
@@ -263,15 +263,10 @@ $(function(){
             location.href = url('framework');
           },
           error: function(){
-            CJInfo('Une erreur est survenue lors de la récupération du tableau "' + name + '".',"error");
+            stackAlert('Une erreur est survenue lors de la récupération du tableau "%name%"', 'error', undefined, undefined, {'name' : name});
           }
         });
       }
     }
   });
-});
-
-$(document).ready(function(){
-  CJErrorHighlight($(".important"),"error");
-  CJErrorHighlight($(".highlight"),"highlight");
 });

--- a/public/js/holiday.js
+++ b/public/js/holiday.js
@@ -243,7 +243,7 @@ function currentCredits() {
         }
     },
     error: function(xhr, ajaxOptions, thrownError){
-      information("Impossible de récupérer le compte de congés actuel.","error");
+      stackAlert('Impossible de récupérer le compte de congés actuel.', 'error');
     },
   });
 }
@@ -306,6 +306,8 @@ function calculCredit(){
     async: false,
     success: function(result){
       var msg=result[0];
+      $('#alert-stack-top-center').remove();
+
       if(result.error == true) {
         $("#erreurCalcul").val("true");
         document.form.elements["heures"].value=0;
@@ -313,9 +315,8 @@ function calculCredit(){
         $('#nbHeures').val('0h00');
         highlight($('#nbHeures'));
         highlight($('#nbJours'));
-        information("Aucun planning de présence enregistré pour cette période - calcul impossible.","error");
+        stackAlert('Aucun planning de présence enregistré pour cette période - calcul impossible.', 'error');
       } else {
-        $("#JSInformation").remove();
         var balance_date = result.recover[0];  // Date de début, affichée pour le réajustement des crédits disponibles
         var balance = result.recover[1];       // Crédits de récupérations disponibles à la date choisie
 
@@ -373,11 +374,12 @@ function calculCredit(){
     },
     error: function(xhr, ajaxOptions, thrownError){
       var congesMode = $('#conges-mode').val();
+      $('#alert-stack-top-center').remove();
 
       if (congesMode == 'heures') {
-        information("Impossible de calculer le nombre d'heures correspondant au congé demandé.","error");
+        stackAlert('Impossible de calculer le nombre d\'heures correspondant au congé demandé.', 'error');
       } else {
-        information("Impossible de calculer le nombre de jours correspondant au congé demandé.","error");
+        stackAlert('Impossible de calculer le nombre de jours correspondant au congé demandé.', 'error');
       }
     },
   });
@@ -493,9 +495,9 @@ function calculRestes(){
       recuperation = recuperation - heures;
       recuperation_prev = recuperation_prev - heures;
 
-      $('.recup-alert').remove();
+      $('#alert-stack-top-center').remove();
       if(recuperation < 0){
-        CJInfo("Le crédit de récupération ne peut pas être négatif.", "error", null, 5000, 'recup-alert');
+        stackAlert('Le crédit de récupération ne peut pas être négatif.', 'error')
         highlight($('.balance_tr'));
       }
     }
@@ -633,7 +635,7 @@ function supprimeConges(retour){
         location.href = retour;
       },
       error: function(){
-        information("Une erreur est survenue lors de la suppresion du congé.","error");
+        stackAlert('Une erreur est survenue lors de la suppresion du congé.', 'error');
       }
     });
   }
@@ -655,7 +657,7 @@ function verifConges()
   }
 
   if($("#erreurCalcul").val()=="true"){
-    information("Aucun planning de présence enregistré pour cette période - calcul impossible.","error");
+    stackAlert('Aucun planning de présence enregistré pour cette période - calcul impossible.', 'error');
     return false;
   }
 
@@ -679,7 +681,7 @@ function verifConges()
 
   // Si aucun agent n'est sélectionné, on quitte en affichant "Veuillez sélectionner ..."
   if(perso_ids.length<1){
-    CJInfo("Veuillez sélectionner un ou plusieurs agents","error");
+    stackAlert('Veuillez sélectionner un ou plusieurs agents', 'error');
     return false;
   }
 
@@ -695,15 +697,17 @@ function verifConges()
   debut = debut + ' ' + hre_debut;
   fin = fin + ' ' + hre_fin;
 
+  $('#alert-stack-top-center').remove();
+
   // Vérifions si les dates sont correctement saisies
   if($("#debut").val()==""){
-    information("Veuillez choisir la date de début","error");
+    stackAlert('Veuillez choisir la date de début', 'error');
     return false;
   }
 
   // Vérifions si les dates sont cohérentes
   if (debut >= fin) {
-    information("La date de fin doit être supérieure à la date de début","error");
+    stackAlert('La date de fin doit être supérieure à la date de début', 'error');
     return false;
   }
   
@@ -714,10 +718,10 @@ function verifConges()
     isRegularization = true;
   }
   if(recuperation < 0 && isRegularization == false) {
-    $('.recup-alert').remove();
+    $('#alert-stack-top-center').remove();
     highlight($('.balance_tr'));
     if ($('#validation').val() > 0) {
-      CJInfo("Le crédit de récupération ne peut pas être négatif.", "error", null, 5000, 'recup-alert');
+      stackAlert('Le crédit de récupération ne peut pas être négatif.', 'error');
       return false;
     } else {
       if (!confirm("Attention!\nLe crédit de récupération ne peut pas être négatif.\nCette demande ne pourra pas être validée tant que le crédit restera insufisant.\nVoulez-vous continuer ?")) {
@@ -740,7 +744,7 @@ function verifConges()
 
       for (i in result['users']) {
         if (result['users'][i]['holiday'] != undefined) {
-          CJInfo("Un congé a déjà été demandé par " + result['users'][i]['nom'] + " " + result['users'][i]['holiday'], "error");
+          stackAlert('Un congé a déjà été demandé par %agent% %holiday%', 'error', undefined, undefined, {'agent' : result['users'][i]['nom'], 'holiday': result['users'][i]['holiday']});
           valid = false;
         }
       }
@@ -751,7 +755,7 @@ function verifConges()
             valid = false;
           }
         } else {
-          CJInfo("Vous ne pouvez pas enregistrer d'absences pour les dates suivantes car les plannings sont en cours d'élaboration :#BR#"+result["planning_started"], "error");
+          stackAlert('Vous ne pouvez pas enregistrer d\'absences pour les dates suivantes car les plannings sont en cours d\'élaboration :\n %plannings%', 'error', undefined, undefined, {'plannings' : result["planning_started"]});
           valid = false;
         }
       }
@@ -762,7 +766,7 @@ function verifConges()
             valid = false;
           }
         } else {
-          CJInfo("Vous ne pouvez pas enregistrer de congés pour les dates suivantes car elles rentrent en conflit avec une période bloquée.", "error");
+          stackAlert('Vous ne pouvez pas enregistrer de congés pour les dates suivantes car elles rentrent en conflit avec une période bloquée.', 'error');
           valid = false;
         }
       }
@@ -792,7 +796,7 @@ function verifConges()
           if(!confirm(message +"\nVoulez-vous continuer ?"))
             valid = false;
           } else {
-            CJInfo("Vous ne pouvez pas enregsitrer de congés car " + message.replace("\n", "#BR#"), "error");
+            stackAlert('Vous ne pouvez pas enregistrer de congés car ' + message, 'error');
             valid = false;
           }
         }
@@ -808,14 +812,14 @@ function verifConges()
                 async: false,
                 success: function(data){
                   if(data){
-                    CJInfo(data, "error");
+                    stackAlert(data, 'error');
                   }
                   else {
                      return true;
                   }
                 },
                 error: function(){
-                  CJInfo("Une erreur est survenue lors de l'enregistrement du congé","error");
+                  stackAlert('Une erreur est survenue lors de l\'enregistrement du congé', 'error');
                 },
             });
           } else {
@@ -824,7 +828,7 @@ function verifConges()
       }
     },
     error: function(){
-      information("Une erreur est survenue lors de l'enregistrement du congé","error");
+      stackAlert('Une erreur est survenue lors de l\'enregistrement du congé', 'error');
     },
   });
   return valid;
@@ -971,7 +975,7 @@ function update_validation_statuses() {
       highlight($('div#validation-line'));
     },
     error: function(xhr, ajaxOptions, thrownError) {
-      information("Une erreur s'est produite lors de la mise à jour de la liste des statuts", 'error');
+      stackAlert('Une erreur s\'est produite lors de la mise à jour de la liste des statuts', 'error');
     }
   });
 }

--- a/public/js/notification.js
+++ b/public/js/notification.js
@@ -86,7 +86,7 @@ $(function() {
         window.location.reload();
       },
       error: function(result) {
-        CJInfo('Une erreur est survenue lors de l\'enregistrement des responsables', 'error');
+        stackAlert('Une erreur est survenue lors de l\'enregistrement des responsables', 'error');
         $('#update-notification-modal').modal('hide');
       }
     });

--- a/public/js/planning-redo.js
+++ b/public/js/planning-redo.js
@@ -56,7 +56,7 @@ function redo() {
       });
     },
     error: function(result){
-      CJInfo('Impossible de répéter la dernière action. Une erreur s\'est produite','error');
+      stackAlert('Impossible de répéter la dernière action. Une erreur s\'est produite', 'error');
     }
   });
 }

--- a/public/js/planning-undo.js
+++ b/public/js/planning-undo.js
@@ -56,7 +56,7 @@ function undo() {
       });
     },
     error: function(result){
-      CJInfo('Impossible d\'annuler la dernière action. Une erreur s\'est produite','error');
+      stackAlert('Impossible d\'annuler la dernière action. Une erreur s\'est produite', 'error');
     }
   });
 }

--- a/public/js/planning.js
+++ b/public/js/planning.js
@@ -61,7 +61,7 @@ $(document).ready(function(){
             $('#save-model-form input[name="modelName"]').val(result);
         },
         error: function(xhr, ajaxOptions, thrownError){
-            CJInfo('Impossible d\'enregistrer le modèle', 'error');
+            stackAlert('Impossible d\'enregistrer le modèle', 'error');
             return;
         }
     });
@@ -82,13 +82,13 @@ $(document).ready(function(){
         
         if (result == 'ok') {
           $('.modal').modal('hide');
-          if( erase == true) msg = 'Le modèle ' + modelName + ' a bien été remplacé.';
-          else msg = 'Le modèle ' + modelName + ' a bien été enregistré.';
-          CJInfo(msg, 'success');
+          if( erase == true) msg = 'Le modèle %name% a bien été remplacé.';
+          else msg = 'Le modèle %name% a bien été enregistré.';
+          stackAlert(msg, undefined, undefined, undefined, {'name' : modelName});
         }
       },
       error: function(jqXHR, textStatus, errorThrown){
-        CJInfo(result.responseText,'error');
+        stackAlert(result.responseText, 'error');
       }
     });
   };
@@ -136,7 +136,7 @@ $(document).ready(function(){
         afficheTableauxDiv();
       },
       error: function(result){
-	      CJInfo(result.responseText, 'error');
+	      stackAlert(result.responseText, 'error');
       }
     });
   }
@@ -209,12 +209,12 @@ $(document).ready(function(){
                 bataille_navale(job, date, cFrom, to, agents, '', '', site, '', null, cellid);
             }
             if (result.unavailables) {
-                var message = "Les agents suivants n'ont pas été placés car ils sont indisponibles de " + heureFr(cFrom) + " à " + heureFr(to) + " : " + result.unavailables;
-                CJInfo(message, 'error');
+                var message = 'Les agents suivants n\'ont pas été placés car ils sont indisponibles de %from% à %to% : %agents%';
+                stackAlert(message, 'error', undefined, undefined, {'from' : heureFr(cFrom) , 'to' : heureFr(to), 'agents' : result.unavailables });
             }
         },
         error: function(){
-            CJInfo("Une erreur est survenue lors de la copie.", "error");
+            stackAlert('Une erreur est survenue lors de la copie.', 'error');
         }
     });
   });
@@ -256,11 +256,11 @@ $(function() {
 
         // Affichage des lignes vides
         $('.pl-line').show();
-        CJInfo(result[0],result[1]);
+        stackAlert(result[0]);
       },
 
       error: function(result){
-        CJInfo('Erreur lors du dévérrouillage du planning', 'error');
+        stackAlert('Erreur lors du dévérrouillage du planning', 'error');
       }
     });
   });
@@ -307,11 +307,11 @@ $(function() {
         // Masque les lignes vides
         hideEmptyLines();
 
-        CJInfo(result[0], result[1]);
+        stackAlert(result[0]);
       },
 
       error: function(result) {
-        CJInfo('Erreur lors de la validation du planning', 'error');
+        stackAlert('Erreur lors de la validation du planning', 'error');
       }
     });
   });
@@ -353,7 +353,7 @@ $(function() {
 
       success: function(result) {
         if(result.error) {
-          CJInfo(result.error, 'error');
+          stackAlert(result.error, 'error');
         } else {
           if(result.notes) {
             $('#pl-notes-button').text('Modifier le commentaire');
@@ -373,13 +373,13 @@ $(function() {
           // Met à jour le texte affiché en bas du planning
           $('#pl-notes-div1').html(result.notes);
           $('#pl-notes-div1-validation').html(suppression + result.validation);
-          CJInfo('Le commentaire a été modifié avec succès', 'success');
+          stackAlert('Le commentaire a été modifié avec succès');
           // Ferme le dialog
         }
         $('#pl-notes-modal').modal('hide');
       },
       error: function() {
-        updateTips('Une erreur est survenue lors de l\'enregistrement du commentaire', 'error');
+        stackAlert('Une erreur est survenue lors de l\'enregistrement du commentaire', 'error');
       }
     });
   })
@@ -412,15 +412,15 @@ $(function() {
       data: appelDispoData,
       success: function(result) {
         if(result.error) {
-          CJInfo(result.error, 'error');
+          stackAlert(result.error, 'error');
         }
         else {
-          CJInfo('L\'appel à disponibilité a bien été envoyé','success');
+          stackAlert('L\'appel à disponibilité a bien été envoyé');
         }
          $('#pl-appelDispo-modal').modal('hide');
       },
       error: function() {
-        updateAlert('An error occurred while sending the email');
+        stackAlert('An error occurred while sending the email');
       }
     });
   });
@@ -505,7 +505,7 @@ $(function() {
       },
 
       error: function(result){
-	CJInfo("Impossible d'afficher le menu des agents.#BR#"+result.responseText,"error");
+        stackAlert('Impossible d\'afficher le menu des agents.\n' + result.responseText, 'error');
       }
     });
     return false ;
@@ -1156,7 +1156,7 @@ function appelDispo(site,siteNom,poste,posteNom,date,debut,fin,agents) {
     },
 
     error: function(result) {
-      CJInfo(result.responseText, 'error');
+      stackAlert(result.responseText, 'error');
     }
   });
 }
@@ -1390,7 +1390,7 @@ function bataille_navale(poste, date, debut, fin, perso_id, barrer, ajouter, sit
     },
 
     error: function(result) {
-      CJInfo('Une erreur est survenue lors de l\'enregistrement du planning.', 'error');
+      stackAlert('Une erreur est survenue lors de l\'enregistrement du planning.', 'error');
     }
   });
 
@@ -1572,7 +1572,7 @@ function planningNotifications(date, site, CSRFToken) {
     success: function(result) {
     },
     error: function(result) {
-      CJInfo(result.responseText, 'error');
+      stackAlert(result.responseText, 'error');
     }
   });
 }
@@ -1602,7 +1602,7 @@ function refresh_poste() {
       },
 
       error: function(result) {
-        CJInfo(result.responseText, 'error');
+        stackAlert(result.responseText, 'error');
         setTimeout('refresh_poste()', 30000);
     }
   });
@@ -1625,12 +1625,12 @@ function verif_categorieA(){
     data: {date: date, site: site},
     success: function(result) {
       if(result == 'false') {
-        if (!$('.missingCategoryA')[0]) {
-          CJInfo('Attention, pas d\'agent de catégorie A en fin de service.', 'error', 82, 999999, 'missingCategoryA');
+        if ($('#alert-stack-top-center div.alert').length == 0) {
+          stackAlert('Attention, pas d\'agent de catégorie A en fin de service.', 'error', 0);
         }
       } else {
-        if ($('.missingCategoryA')[0]) {
-          $('.missingCategoryA')[0].remove();
+        if ($('#alert-stack-top-center div.alert').length > 0) {
+          $('#alert-stack-top-center').remove();
         }
       }
     }
@@ -1642,7 +1642,7 @@ function showInformationMessages(messages){
   if (messages.length < 1) return false;
 
   var msg = messages[currentIndex];
-  CJInfo(msg, null, null, 5000, null);
+  stackAlert(msg);
   var delay = 5000;
   if (currentIndex === messages.length - 1) {
     delay = 10000;

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -339,7 +339,7 @@ function deleteAjax(id, route, message) {
                 window.location.href=url(route);
             },
             error: function(result){
-              CJInfo('Une erreur est survenue lors de la suppression', 'error');
+              stackAlert('An error occurred during deletion', 'error');
             }
         });
     }
@@ -379,26 +379,6 @@ function heure4(heure){
     heure += 'h00';
   }
   return heure;
-}
-
-
-function information(message,type,top,time){
-  if(top==undefined){
-    top=60;
-  }
-  
-  if(time==undefined){
-    time=5000;
-  }
-
-  if(typeof(timeoutJSInfo)!== "undefined"){
-    window.clearTimeout(timeoutJSInfo);
-  }
-  $("#JSInformation").remove();
-  $("body").append("<div id='JSInformation'>"+message+"</div>");
-  CJErrorHighlight($("#JSInformation"),type);
-  position($("#JSInformation"),top,"center");
-  timeoutJSInfo=window.setTimeout("$('#JSInformation').remove()",time);
 }
 
 function removeAccents(strAccents){
@@ -444,10 +424,10 @@ function resetICSURL(id, nom)
       success: function(result){
         $("#urlIcs").html("<a href='"+result.url+"'>"+result.url+"</a>");
         $("#urlIcsWithAbsences").html("<a href='"+result.url+"&absences=1'>"+result.url+"&absences=1</a>");
-        CJInfo("L'URL du calendrier a été réinitialisée avec succès","success");
+        stackAlert('L\'URL du calendrier a été réinitialisée avec succès');
       },
       error: function(result){
-        CJInfo("Une erreur est survenue lors de la réinitialisation de l'URL<br/>"+result.responseText,"error");
+        stackAlert('Une erreur est survenue lors de la réinitialisation de l\'URL \n' + result.responseText, 'error');
       }
     });
   }
@@ -498,50 +478,34 @@ function updateAgentsList(me,select_id){
       result=JSON.parse(result);
       $("#"+select_id).html("<option value='0'>Tous</option>");
       for(key in result){
-	$("#"+select_id).append("<option value='"+result[key]["id"]+"'>"+result[key]["nom"]+" "+result[key]["prenom"]+"</option>");
-	if(result[key]["id"]==index){
-	  in_array=true;
-	}
+        $('#' + select_id).append('<option value="' + result[key]['id'] + '">' + result[key]['nom'] + ' ' + result[key]['prenom'] + '</option>');
+        if(result[key]['id'] == index) {
+          in_array=true;
+        }
       }
       index=in_array?index:0;
       $("#"+select_id).val(index);
       highlight($('#' + select_id).closest('div.col-xl-2'));
+      // highlight($('#' + select_id).parent('.row'));
     },
     error: function(){
-      information("Une erreur est survenue lors de la mise à jour de la liste des agents.","error");
+      stackAlert('Une erreur est survenue lors de la mise à jour de la liste des agents.', 'error');
     }
   });
 }
 
-// This function will replace the updateTips function
 function updateAlert(text, translationOptions = null) {
   text = Translator.trans(text, translationOptions);
   $('#alert-text').text(text);
   $('#alert').removeClass('d-none');
 }
 
-function hideAlert(){
+function hideAlert() {
   $('#alert').addClass('d-none');
 }
 
 function highlight(obj) {
   obj.addClass('highlight');setTimeout(() => {obj.removeClass('highlight');}, 3000);
-}
-
-// updateTips : utilisée pour valider les formulaires Jquery-UI
-function updateTips( text , type) {
-  if ( type == undefined ) {
-    type = null;
-  }
-  else if ( type == "success" ) {
-    type = "highlight";
-  }
-  
-  text = text.replace("\n", "<br/>");
-
-  $(".validateTips").html(text);
-
-  CJErrorHighlight( $(".validateTips"), type);
 }
 
 // This function is intended to replace verif_date() in the long term
@@ -666,7 +630,7 @@ function verif_form(champs, form='form', callback=null)
   }
   
   if(erreurs){
-    CJInfo("Les champs suivants sont obligatoires :<ul>"+erreurs+"</ul>","error");
+    stackAlert('Les champs suivants sont obligatoires :<ul>' + erreurs + '</ul>', 'error');
     return false;
   }
   else{

--- a/public/js/skill.js
+++ b/public/js/skill.js
@@ -1,8 +1,0 @@
-/**
-Description :
-Fichier regroupant les scripts JS nécessaires aux pages activites/* (affichage et modification des activités)
-*/
-
-$(document).ready(function(){
-  CJErrorHighlight($(".important"),"highlight");
-});

--- a/public/js/workingHour.js
+++ b/public/js/workingHour.js
@@ -223,10 +223,10 @@ function plHebdoSupprime(id){
       success: function(){
         // On cache la ligne du planning supprimée dans le tableau
         CJDataTableHideRow("#tr_"+id);
-        CJInfo("Le planning a été supprimé","success");
+        stackAlert('Le planning a été supprimé');
       },
       error: function(){
-        CJInfo("Erreur lors de la suppression du planning de présence","error");
+        stackAlert('Erreur lors de la suppression du planning de présence', 'error');
       }
     });
   }
@@ -305,7 +305,7 @@ function plHebdoVerifForm(form) {
       }
     },
     error: function(result){
-      information(result.responseText, 'error');
+      stackAlert(result.responseText, 'error');
       retour = false;
     }
   });

--- a/public/themes/default/default.css
+++ b/public/themes/default/default.css
@@ -234,7 +234,7 @@ h4{
   margin-left: 10px;
 }
 
-/*	Icônes		*/
+/* Icônes START */
 
 .bi {
   color : #29495C;
@@ -242,6 +242,18 @@ h4{
 
 .bi-danger {
   color: var(--bs-danger-text-emphasis);
+}
+
+.bi-warning {
+  color: var(--bs-warning-text-emphasis);
+}
+
+.bi-information {
+  color: var(--bs-info-text-emphasis);
+}
+
+.bi-success {
+  color: var(--bs-success-text-emphasis);
 }
 
 .bi.bi-caret-right-fill {
@@ -369,6 +381,7 @@ h4{
 .tooltip-inner {
     text-align: left;
 }
+/* Icônes END */
 
 /* Les agents */
 li .agent-acces-checked2{
@@ -382,7 +395,8 @@ li .agent-acces-checked2{
 }
 
 
-/* Les tableaux */
+/* Les tableaux START */
+
 .tableauStandard,.tableauFiches{
   border-spacing: 0px;
   border-collapse: collapse;
@@ -468,7 +482,9 @@ li .agent-acces-checked2{
   text-align:center;
 } 
 
-/* Tabs */
+/* Les tableaux END */
+
+/* Bootstrap Tabs START */
 
 ul.nav-tabs li .nav-link.disabled {
   opacity: 65%;
@@ -514,6 +530,8 @@ ul.nav-tabs li.nav-item .nav-link.active, ul.nav-tabs li.nav-item .nav-link:hove
   justify-content: center;
 }
 
+/* Bootstrap Tabs END */
+
 /* Menu Principal */
 /* solution temp, il faudrait peut être une class spécifique pour la div top gauche*/
 /* solution provoque des bugss dans les tableaux */
@@ -523,7 +541,7 @@ ul.nav-tabs li.nav-item .nav-link.active, ul.nav-tabs li.nav-item .nav-link:hove
   width:15%;
 }
 
-/* Menu Bootstrap */
+/* Bootstrap Menu START */
 .navbar {
   background-color: white;
 }
@@ -589,6 +607,7 @@ li.nav-item a.nav-link:hover, li.nav-item a.nav-link:focus, li.nav-item a.nav-li
 
 ul.dropdown-menu {
   padding: 0px;
+  z-index: 1052;
 }
 
 ul.dropdown-menu a.dropdown-item {
@@ -628,6 +647,8 @@ ul.dropdown-menu a.dropdown-item.active , a.dropdown-item.active:hover {
   visibility: hidden; 
   z-index:20; 
 }
+
+/* Bootstrap Menu END */
 
 /* Menu top */
 .topgauche{
@@ -1156,7 +1177,26 @@ class cellule = cellule par défaut
   margin: 20px 0;
 }
 
-/* Calendrier affiché en haut des plannings */
+#tab_titre {	/* /index */
+  width:100%;
+  height: 145px;
+  border: none;
+  background-color: #29495C;
+  margin-bottom: 20px;
+}
+
+#tab_titre .row {
+  justify-content: space-around;
+}
+
+/* Datepicker START */
+
+#pl-calendar {
+  border:0;
+  background: transparent;
+  margin: 10px 0 5px 10px;
+  width: 200px;
+}
 
 .datepicker-inline {
   background-color: white;
@@ -1245,6 +1285,8 @@ class cellule = cellule par défaut
 .datepicker.form-control {
   text-align: center;
 }
+
+/* Datepicker END */
 
 .pl-highlight {
   background: #f0e68c;
@@ -1450,7 +1492,7 @@ img{
   padding-right: 5px;
 }
 
-/* Elements "sortable" (gestion des motifs d'absences, des statuts des agents */
+/* Elements "sortable" (gestion des motifs d'absences, des statuts des agents ...) */
 ul[id$="-sortable"] { list-style-type: none; margin: 0; padding: 0; }
 ul[id$="-sortable"] li { margin: 0 3px 3px 3px; padding: 0.4em; padding-left: 1.5em; height: 30px; }
 ul[id$="-sortable"] li span { margin-left: -1.3em; }
@@ -1529,7 +1571,7 @@ div.presents-absents {
   background:#FFD700;
 }
 
-/*	DataTables */
+/*	DataTables START */
 .dataTable tbody tr.odd {
   background-color:#F0F0F0;
 }
@@ -1648,6 +1690,8 @@ div.dt-buttons button.dt-button.buttons-print:hover {
   background-color: #29495C;
   color: #F0F0F0;
 }
+
+/*	DataTables END */
 
 .ellipsis{
   color:#FFF;
@@ -1838,7 +1882,7 @@ div#holiday-info .col-4 {
   margin: 40px auto auto;
 }
 
-/*Buttons START*/
+/* Bootstrap Buttons START */
 
 .btn.btn-primary , .btn.btn-primary:focus, .btn.btn-primary:active {
   background-color: #FFD700;
@@ -1929,7 +1973,7 @@ div#holiday-info .col-4 {
   text-align: right;
 }
 
-/*Buttons END*/
+/* Bootstrap Buttons END */
 
 /* Highlight effect START*/
 
@@ -1944,7 +1988,7 @@ div#holiday-info .col-4 {
 
 /* Highlight effect END*/
 
-/* Modals START */
+/* Bootstrap Modals START */
 
 .modal-header {
   background-color: #FFD700 ;
@@ -1979,6 +2023,10 @@ hr {
   align-items: center;
   justify-content: center;
 }
+
+/* Bootstrap Modals END */
+
+/* Form elements START */
 
 .form-control, .form-control:focus, 
 .row.row-search .form-control-plaintext {
@@ -2062,24 +2110,6 @@ input::placeholder {
 }
 
 .was-validated .form-select:valid {
-  border-color: inherit;
-  padding-right: 2.25rem !important;
-  background-image: none;
-}
-
-.was-validated .form-check-input:valid {
-  border-color: inherit;
-}
-
-.was-validated .form-check-input:valid:checked {
-  background-color: #29495C;
-}
-
-.was-validated .form-check-input:valid ~ .form-check-label {
-  color : inherit;
-}
-
-.was-validated .form-select:valid {
   background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23343a40' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/%3e%3c/svg%3e");
 }
 
@@ -2117,7 +2147,7 @@ input::placeholder {
   box-shadow: 0 0 0 0.25rem rgba(220, 53, 69, 0.25) !important;
 }
 
-/* Modals END */
+/* Form elements END */
 
 /* Bootstrap Grid START */
 

--- a/templates/absences/index.html.twig
+++ b/templates/absences/index.html.twig
@@ -119,26 +119,14 @@
 
           {% if can_manage_sup_doc %}
             <td style='text-align:center;'>
-              <div class='absences-pj'>
-                {% if abs.pj1 %}
-                  <input type='checkbox' id="pj1-{{ abs.id }}" checked="checked"/>
-                {% else %}
-                  <input type='checkbox' id="pj1-{{ abs.id }}"/>
-                {% endif %}
+              <div class="absences-pj">
+                <input type="checkbox" id="pj1-{{ abs.id }}" {% if abs.pj1 %} checked {% endif %}/>
               </div>
-              <div class='absences-pj'>
-                {% if abs.pj2 %}
-                  <input type='checkbox' id="pj2-{{ abs.id }}" checked="checked"/>
-                {% else %}
-                  <input type='checkbox' id="pj2-{{ abs.id }}"/>
-                {% endif %}
+              <div class="absences-pj">
+                <input type="checkbox" id="pj2-{{ abs.id }}" {% if abs.pj2 %} checked {% endif %}/>
               </div>
-              <div class='absences-pj'>
-                {% if abs.so %}
-                  <input type='checkbox' id="so-{{ abs.id }}" checked="checked"/>
-                {% else %}
-                  <input type='checkbox' id="so-{{ abs.id }}"/>
-                {% endif %}
+              <div class="absences-pj">
+                <input type="checkbox" id="so-{{ abs.id }}" {% if abs.so %} checked {% endif %}/>
               </div>
             </td>
           {% endif %}

--- a/templates/admin/model/index.html.twig
+++ b/templates/admin/model/index.html.twig
@@ -13,7 +13,7 @@
             window.location.reload(false);
           },
           error: function() {
-            CJInfo("Une erreur est survenue lors de la suppression","error");
+            stackAlert('An error occurred during deletion', 'error');
           }
         });
       }

--- a/templates/agents/edit.html.twig
+++ b/templates/agents/edit.html.twig
@@ -43,7 +43,8 @@
               tabs.addClass('disabled');
             }
             else {
-              information(Translator.trans('An error occurred while updating the login information.','error'));
+              $('#alert-stack-top-center').remove();
+              stackAlert('An error occurred while updating the login information.', 'error');
             }
           }
         });

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -58,19 +58,19 @@
   <body>
     <!-- Affichage des messages d'erreur ou de confirmation venant de la page précedente-->
     {% if msg  and msg !='null' %}
-      <script type='text/JavaScript'>CJInfo('{{ msg | nl2br }}','{{ msgType }}');</script>
+      <script type='text/JavaScript'>stackAlert('{{ msg | nl2br }}', '{{ msgType }}');</script>
     {% endif %}
 
     {% if msg2 and msg2 !='null' %}
-      <script type='text/JavaScript'>CJInfo('{{ msg2 }}','{{ msg2Type }}', 82, 15000);</script>
+      <script type='text/JavaScript'>stackAlert('{{ msg2 }}', '{{ msg2Type }}', 15000);</script>
     {% endif %}
 
     <!-- Symfony flashMessages -->
     {% for flashMessage in app.session.flashbag.get('error') %}
-        <script type='text/JavaScript'>CJInfo('{{ flashMessage }}','error', 82, 15000);</script>
+        <script type='text/JavaScript'>stackAlert('{{ flashMessage }}', 'error', 15000);</script>
     {% endfor %}
     {% for flashMessage in app.session.flashbag.get('notice') %}
-        <script type='text/JavaScript'>CJInfo('{{ flashMessage }}','success', 82, 15000);</script>
+        <script type='text/JavaScript'>stackAlert('{{ flashMessage }}', 'success', 15000);</script>
     {% endfor %}
 
     <div style='position:relative;top:30px;' class='noprint'></div>

--- a/templates/calendar/index.html.twig
+++ b/templates/calendar/index.html.twig
@@ -2,10 +2,6 @@
 
 {% extends 'base.html.twig' %}
 
-{% block specificjs %}
-  <script type="text/JavaScript" src="{{ asset('js/calendar.js') }}"></script>
-{% endblock %}
-
 {% block page %}
   <div id="div_agenda">
     {% if agent is not null %}
@@ -56,9 +52,7 @@
       Aucun agent disponible
     {% endif %}
 
-    {% if beginSQL > endSQL  %}
-    <p class="information"> La date de fin doit être supérieure à la date de début </p>
-    {% elseif agent is not null and days %}
+    {% if agent is not null and days %}
       <br/>
       <table cellpadding="10" cellspacing="0" border="0" id="tab_agenda">
         <thead>

--- a/templates/framework/edit_tab.html.twig
+++ b/templates/framework/edit_tab.html.twig
@@ -55,14 +55,14 @@
         type: "post",
         data: data,
         success: function(){
-          CJInfo("Le tableau a été enregistré","highlight");
+          stackAlert('Le tableau a été enregistré');
           return true;
         },
         error: function(request, status, error){
           if (request.responseText == '"used"') {
-            CJInfo('Tableau déjà utilisé. Vous ne pouvez pas modifier les horaires.','error');
+            stackAlert('Ce tableau est déjà utilisé. Vous ne pouvez pas modifier les horaires.', 'error');
           } else {
-            CJInfo("Une erreur est survenue lors de l'enregistrement du tableau.","error");
+            stackAlert('Une erreur est survenue lors de l\'enregistrement du tableau.', 'error');
           }
           return false;
         }
@@ -155,7 +155,16 @@
             </table>
           </form>
         </div>
-        <div class="important">Important : Vous devez cliquer sur "Valider" avant de changer d'onglet</div>
+
+        <div class="row justify-content-center">
+          <div class="col-auto">
+            <div class="alert alert-danger" role="alert">
+              <i class="bi bi-exclamation-triangle-fill bi-danger me-2"></i> 
+              Important : Vous devez cliquer sur "Valider" avant de changer d'onglet
+            </div>
+          </div>
+        </div>
+
       </div>
 
       <div class="tab-pane fade {% if  cfgType == 1  %} active show {% endif %} m-4" id="div_horaires" role="tabpanel" aria-labelledby="div_horaires-tab" tabindex="0">
@@ -219,9 +228,18 @@
                 </div> <!-- tab_horaires_{{tableau}} & div_horaires_{{tableau}} -->
               {% endfor %}
             {% endif %}
-        </form>
-      </div>
-        <div class="important">Important : Vous devez cliquer sur "Valider" avant de changer d'onglet</div>
+          </form>
+        </div>
+
+        <div class="row justify-content-center">
+          <div class="col-auto">
+            <div class="alert alert-danger" role="alert">
+              <i class="bi bi-exclamation-triangle-fill bi-danger me-2"></i> 
+              Important : Vous devez cliquer sur "Valider" avant de changer d'onglet
+            </div>
+          </div>
+        </div>
+
       </div>
 
       <div class="tab-pane fade m-4" id="div_lignes" role="tabpanel" aria-labelledby="div_lignes-tab" tabindex="0">
@@ -286,11 +304,18 @@
             {% endif %}
           </form>
         </div>
-        <div class="highlight">
-          <sup>*</sup> Classe CSS appliqué sur le tableau. Permet d'en personnaliser l'affichage.
+
+        <div class="row justify-content-center">
+          <div class="col-auto">
+            <div class="alert alert-info" role="alert">
+              <i class="bi bi-info-circle-fill bi-information me-2"></i> 
+              <sup>*</sup> Classe CSS appliqué sur le tableau. Permet d'en personnaliser l'affichage.
+            </div>
+          </div>
         </div>
 
       </div>
+
     </div>
   </div>
 

--- a/templates/login.html.twig
+++ b/templates/login.html.twig
@@ -25,14 +25,15 @@
             <br/>
             <a href='{{ asset("login") }}{{ auth_args }}'>Re-essayer</a>
           {% elseif error == 'cas_unknown_user' %}
-          <div id='JSInformation' style="max-width: 40%; margin-left: auto; margin-right: auto;">
-            Vous avez été correctement identifié(e) mais vous n'êtes pas autorisé(e) à 
-            utiliser cette application.<br/>
-            <b>Veuillez fermer votre navigateur et recommencer avec un autre identifiant</b>.
+          <div class="row justify-content-center">
+            <div class="col-auto">
+              <div class="alert alert-danger" role="alert">
+                <i class="bi bi-exclamation-triangle-fill bi-danger me-2"></i> 
+                Vous avez été correctement identifié(e) mais vous n'êtes pas autorisé(e) à utiliser cette application.<br/>
+                <b>Veuillez fermer votre navigateur et recommencer avec un autre identifiant.</b>
+              </div>
+            </div>
           </div>
-          <script type='text/JavaScript'>
-            CJErrorHighlight($("#JSInformation"),"error");
-          </script>
           {% endif %}
         </div>
       {% else %}

--- a/templates/planning/poste/index.html.twig
+++ b/templates/planning/poste/index.html.twig
@@ -88,11 +88,6 @@
                 </div>
 
               <div class="modal-footer">
-                <div id="alert" class="alert alert-danger me-auto d-flex d-none" role="alert">
-                  <i class="bi bi-exclamation-triangle-fill me-2 bi-danger"></i>
-                  <div id="alert-text"></div>
-                </div>
-
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{% trans %}Cancel{% endtrans %}</button>
                 <button type="submit" class="btn btn-primary" form="pl-appelDispo-form">{% trans %}Send{% endtrans %}</button>
               </div>

--- a/templates/position/index.html.twig
+++ b/templates/position/index.html.twig
@@ -63,7 +63,7 @@
                             }
                           },
                           error: function(){
-                            CJInfo('Une erreur est survenue lors de la suppression', 'error')
+                            stackAlert('An error occurred during deletion', 'error')
                           }
                         });
                       }

--- a/templates/skill/edit.html.twig
+++ b/templates/skill/edit.html.twig
@@ -1,9 +1,6 @@
 {# skill/edit.html.twig #}
 
 {% extends 'base.html.twig' %}
-{% block specificjs %}
-  <script type="text/JavaScript" src="{{ asset('js/skill.js') }}"></script>
-{% endblock %}
 
 {% block page %}
   <div id="content-skill">

--- a/templates/skill/index.html.twig
+++ b/templates/skill/index.html.twig
@@ -49,7 +49,7 @@
                             }
                           },
                           error: function(){
-                            CJInfo('Une erreur est survenue lors de la suppression', 'error')
+                            stackAlert('An error occurred during deletion', 'error')
                           }
                         });
                       }

--- a/templates/workinghour/edit.html.twig
+++ b/templates/workinghour/edit.html.twig
@@ -41,7 +41,7 @@
                   <div class="row">
                     <label class="col-2 col-form-label" for="perso_id">{% trans %}Agent{% endtrans %}</label>
                     <div class="col-2">
-                      <select name="perso_id" class="form-select form-select-sm pe-0" id="perso_id" style="text-align: center;">
+                      <select name="perso_id" class="form-select form-select-sm" id="perso_id" style="text-align: center;">
                         <option hidden disabled selected value=""></option>
                         {% for m in managed %}
                           <option value="{{ m.id }}" {{ (perso_id == m.id) ? "selected = 'selected'" : " " }} >{{ m.lastname }} {{ m.firstname }}</option>

--- a/translations/messages.en.po
+++ b/translations/messages.en.po
@@ -477,3 +477,11 @@ msgstr "Requesting holidays"
 
 msgid "Requesting compensation for overtime"
 msgstr "Requesting compensation for overtime"
+
+#. Error messages
+
+msgid "An error occurred during deletion"
+msgstr "An error occurred during deletion"
+
+msgid "An error occurred while saving the information"
+msgstr "An error occurred while saving the information"

--- a/translations/messages.fr.po
+++ b/translations/messages.fr.po
@@ -477,3 +477,11 @@ msgstr "Poser des congés"
 
 msgid "Requesting compensation for overtime"
 msgstr "Poser des récupérations"
+
+#. Error messages
+
+msgid "An error occurred during deletion"
+msgstr "Une erreur est survenue lors de la suppression"
+
+msgid "An error occurred while saving the information"
+msgstr "Une erreur est survenue lors de l'enregistrement des informations"


### PR DESCRIPTION
* StackAlert is based on Bootstrap Alert
* Change all CJInfo to stackAlert
* Add translationOptions to stackAlert
* Modify stackAlert default values
* CSS adjustments (icon color, dropdoxn-menu z-index)
* Text alignement adjustments on alerts (with <br/> and tabulation)
* Strcucture default.css file in categories
* Replace elements with stackAlert
  * Information call
  * updateTips call
* Removed CJErrorHighlight call or replaced with inline alerts
* Removed skill.js file (empty after cleaning CJErrorHighlight)
* Delete unused fonctions
  * UpdateTips()
  * Information()
  * CJErrorHighlight()
  * CJInfo()
  * CJPosition
* Clean templates and JS