### PR TITLE
MT53738: Fix TypeError in StatisticController::common

### DIFF
--- a/src/Controller/StatisticController.php
+++ b/src/Controller/StatisticController.php
@@ -228,7 +228,7 @@ class StatisticController extends BaseController
             $resultat = $db->result;
 
             // Add service and status to $resultat for each agent
-            if (in_array($type, ['service', 'status'])) {
+            if ($resultat && in_array($type, ['service', 'status'])) {
                 for ($i = 0; $i < count($resultat); $i++) {
 
                     if (!array_key_exists($resultat[$i]['perso_id'], $agents)) {


### PR DESCRIPTION
Error message was:

Uncaught PHP Exception TypeError:
"count(): Argument #1 ($value) must be of type Countable|array, null given" at StatisticController.php line 232

$db->result is null when the query does not return any row