### PR TITLE
MT53418: Fix validation level on deleted agents

### DIFF
--- a/src/Repository/AgentRepository.php
+++ b/src/Repository/AgentRepository.php
@@ -285,6 +285,10 @@ class AgentRepository extends EntityRepository
         $sites_number = $entityManager->getRepository(Config::class)
             ->findOneBy(['nom' => 'Multisites-nombre'])->getValue();
 
+        if ($this->agent_id) {
+            $agent = $entityManager->find(Agent::class, $this->agent_id);
+        }
+
         $sites = array(1);
         if ($this->check_by_site && $sites_number > 1) {
             $sites = array();
@@ -293,13 +297,16 @@ class AgentRepository extends EntityRepository
                 $sites[] = $i;
             }
 
-            // will only check for agent sites
             if ($this->agent_id) {
-                $agent = $entityManager->find(Agent::class, $this->agent_id);
                 $sites = $agent->getSites();
             }
         }
 
+        // Give rigths for deleted agents
+        // Avoid "Access denied" when modifying absences with several agents and some of them are deleted
+        if (isset($agent) and $agent->getDeletion() == 2) {
+            return array(true, true);
+        }
         $l1 = false;
         $l2 = false;
 
@@ -344,12 +351,6 @@ class AgentRepository extends EntityRepository
         // No validation by agent.
         // Check for module rights.
         $agent_rights = $loggedin->getACL();
-
-        // Give rigths for deleted agents
-        // Avoid "Access denied" when modifying absences with several agents and some of them are deleted
-        if (isset($agent) and $agent->getDeletion() == 2) {
-            return array(true, true);
-        }
 
         foreach ($sites as $i) {
             if (in_array($this->needed_level1 + $i, $agent_rights)) {

--- a/tests/Entity/AgentValidationLevelTest.php
+++ b/tests/Entity/AgentValidationLevelTest.php
@@ -290,5 +290,30 @@ class AgentValidationLevelTest extends PLBWebTestCase
 
         $this->assertFalse($adminN1, 'Manager is not admin L1 for agent 3');
         $this->assertFalse($adminN2, 'Manager is not admin L2 for agent 3');
+
+        // Agent is deleted
+        $deletedagent = $this->builder->build(
+            Agent::class,
+            array(
+                'login' => 'deletedagent', 'nom' => 'Deleted', 'prenom' => 'Agent', 'actif' => 'Inactif', 'supprime' => 2, 'mail' => 'deletedagent@example.com',
+            )
+        );
+
+        $manager = new Manager();
+        $manager->setUser($deletedagent);
+        $manager->setLevel1(0);
+        $manager->setLevel2(0);
+        $agent_manager->addManaged($manager);
+
+        $this->entityManager->persist($agent_manager);
+        $this->entityManager->flush();
+
+        list($adminN1, $adminN2) = $this->entityManager->getRepository(Agent::class)
+            ->setModule('absence')
+            ->forAgent($deletedagent->getId())
+            ->getValidationLevelFor($agent_manager->getId());
+        $this->assertTrue($adminN1, 'Manager is admin L1 for deleted agent');
+        $this->assertTrue($adminN2, 'Manager is admin L2 for deleted agent');
+
     }
 }


### PR DESCRIPTION
Validation level on a deleted agent was not properly set when Absences-notifications-agent-par-agent is enabled

Test plan:

 1) Create an absence for an agent you are a manager of

 2) Check that you can edit that absence

 3) Delete that agent
    (once from the agents list, and then again from the
    deleted agents list. Check that personnel.supprime = 2
    in the database for that agent, but keep in mind that
    its login is now "deleted_<id>")

 4) Without the patch, check that you cannot edit the absence
 5) With the patch, check that you can edit the absence