### PR TITLE
MT46629 : hoursPerDay display

### DIFF
--- a/config/permissions.yaml
+++ b/config/permissions.yaml
@@ -107,6 +107,8 @@
     - 100
 "ajax.holidays-hours-to-days":
     - 100
+"ajax.holidays-hours-per-day":
+    - 100
 "ajax.holiday.absence.control":
     - 100
 "ajax.changeownpassword":

--- a/config/permissions.yaml
+++ b/config/permissions.yaml
@@ -107,8 +107,6 @@
     - 100
 "ajax.holidays-hours-to-days":
     - 100
-"ajax.holidays-hours-per-day":
-    - 100
 "ajax.holiday.absence.control":
     - 100
 "ajax.changeownpassword":
@@ -200,6 +198,8 @@
 "holiday.accounts":
     - 100
 "holiday.edit":
+    - 100
+"holiday.hours-per-day":
     - 100
 "holiday.index":
     - 100

--- a/public/js/holiday.js
+++ b/public/js/holiday.js
@@ -194,14 +194,14 @@ function resetHoursPerDay(){
     perso_id=$('#selected_agent_id').val();
 
     $.ajax({
-      url: url('ajax/holidays-hours-per-day'),
+      url: url('holiday/hours-per-day'),
       data: { id: perso_id },
       dataType: 'json',
       type: 'get',
       async: false,
       success: function(result){
         $('#hours_per_day').val(result['hoursPerDay']);
-        $('label[for=nbJours]').html('Équivalence en jour :<br/>(1 jour = '+ result['hoursPerDayInHoursMinutes'] +')')
+        $('#hours-per-day').text(result['hoursPerDayInHoursMinutes']);
       },
       error: function(){
         stackAlert('Impossible de récupérer le compte d\'heure par jours.', 'error');

--- a/public/js/holiday.js
+++ b/public/js/holiday.js
@@ -188,6 +188,28 @@ function resetTerms(){
   }
 }
 
+function resetHoursPerDay(){
+
+  if ($('#conges-mode').val() == 'heures' && $('#hours_per_day').val()) {
+    perso_id=$('#selected_agent_id').val();
+
+    $.ajax({
+      url: url('ajax/holidays-hours-per-day'),
+      data: { id: perso_id },
+      dataType: 'json',
+      type: 'get',
+      async: false,
+      success: function(result){
+        $('#hours_per_day').val(result['hoursPerDay']);
+        $('label[for=nbJours]').html('Équivalence en jour :<br/>(1 jour = '+ result['hoursPerDayInHoursMinutes'] +')')
+      },
+      error: function(){
+        stackAlert('Impossible de récupérer le compte d\'heure par jours.', 'error');
+      },
+    });
+  }
+}
+
 function validationStatusInvalidDisplay() {
   recup = $('#negative-recover').val();
   state = $('select#validation-state').val();
@@ -1026,6 +1048,7 @@ function supprimeAgent(id){
   // Mise à jour des status disponible.
   update_validation_statuses();
   resetTerms();
+  resetHoursPerDay();
 }
 
 function getAgentsBySites(sites) {
@@ -1145,6 +1168,7 @@ $(function(){
     currentCredits();
     calculCredit();
     resetTerms();
+    resetHoursPerDay();
 
   });
 });
@@ -1163,4 +1187,5 @@ $(document).ready(function() {
     // Mise à jour des status disponible.
     update_validation_statuses();
     resetTerms();
+    resetHoursPerDay();
 });

--- a/public/js/holiday.js
+++ b/public/js/holiday.js
@@ -188,10 +188,10 @@ function resetTerms(){
   }
 }
 
-function resetHoursPerDay(){
+function resetHoursPerDay() {
 
   if ($('#conges-mode').val() == 'heures' && $('#hours_per_day').val()) {
-    perso_id=$('#selected_agent_id').val();
+    perso_id = $('#selected_agent_id').val();
 
     $.ajax({
       url: url('holiday/hours-per-day'),
@@ -199,11 +199,11 @@ function resetHoursPerDay(){
       dataType: 'json',
       type: 'get',
       async: false,
-      success: function(result){
+      success: function(result) {
         $('#hours_per_day').val(result['hoursPerDay']);
         $('#hours-per-day').text(result['hoursPerDayInHoursMinutes']);
       },
-      error: function(){
+      error: function() {
         stackAlert('Impossible de récupérer le compte d\'heure par jours.', 'error');
       },
     });

--- a/src/Controller/CompTimeController.php
+++ b/src/Controller/CompTimeController.php
@@ -3,12 +3,12 @@
 namespace App\Controller;
 
 use App\Controller\BaseController;
-use App\Planno\Helper\HolidayHelper;
 use App\Entity\Agent;
-
-use Symfony\Component\HttpFoundation\Session\Session;
+use App\Planno\Helper\HolidayHelper;
+use App\Planno\Helper\HourHelper;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Routing\Annotation\Route;
 
 include_once(__DIR__ . '/../../legacy/Class/class.conges.php');
@@ -61,6 +61,13 @@ class CompTimeController extends BaseController
         $balance2_before_days = null;
 
         $holiday_helper = new HolidayHelper();
+        $hoursPerDay = 0;
+        if ($holiday_helper->showHoursToDays()) {
+            $hoursPerDay = $holiday_helper->hoursPerDay($perso_id);
+            $hoursPerDayInHoursMinutes = HourHelper::decimalToHoursMinutes($hoursPerDay)['as_string'];
+            $balance_before_days = $holiday_helper->hoursToDays($balance[1], $perso_id, null, true);
+            $balance2_before_days = $holiday_helper->hoursToDays($balance[4], $perso_id, null, true);
+        }
 
         $managed = $this->entityManager
             ->getRepository(Agent::class)
@@ -101,7 +108,8 @@ class CompTimeController extends BaseController
             'balance2_before_days'  => $balance2_before_days,
             'credit'                => $credit,
             'CSRFToken'             => $GLOBALS['CSRFSession'],
-            'hours_per_day'         => 0,
+            'hours_per_day'         => $hoursPerDay,
+            'hours_per_day_in_hhmm' => $hoursPerDayInHoursMinutes,
             'holiday_info'          => $holiday_info,
             'agent_name'            => $_SESSION['login_nom'] . ' ' . $_SESSION['login_prenom'],
             'loggedin_name'         => $_SESSION['login_nom'],

--- a/src/Controller/CompTimeController.php
+++ b/src/Controller/CompTimeController.php
@@ -61,12 +61,6 @@ class CompTimeController extends BaseController
         $balance2_before_days = null;
 
         $holiday_helper = new HolidayHelper();
-        $hours_per_day = '';
-        if ($holiday_helper->showHoursToDays()) {
-            $hours_per_day = $holiday_helper->hoursPerDay($perso_id);
-            $balance_before_days = $holiday_helper->hoursToDays($balance[1], $perso_id, null, true);
-            $balance2_before_days = $holiday_helper->hoursToDays($balance[4], $perso_id, null, true);
-        }
 
         $managed = $this->entityManager
             ->getRepository(Agent::class)
@@ -107,7 +101,7 @@ class CompTimeController extends BaseController
             'balance2_before_days'  => $balance2_before_days,
             'credit'                => $credit,
             'CSRFToken'             => $GLOBALS['CSRFSession'],
-            'hours_per_day'         => $hours_per_day,
+            'hours_per_day'         => 0,
             'holiday_info'          => $holiday_info,
             'agent_name'            => $_SESSION['login_nom'] . ' ' . $_SESSION['login_prenom'],
             'loggedin_name'         => $_SESSION['login_nom'],

--- a/src/Controller/HolidayController.php
+++ b/src/Controller/HolidayController.php
@@ -274,6 +274,20 @@ class HolidayController extends BaseController
         return $this->output('holiday/index.html.twig');
     }
 
+    #[Route(path: '/ajax/holidays-hours-per-day', name: 'ajax.holidays-hours-per-day', methods: ['GET'])]
+    public function blip(Request $request, Session $session) : \Symfony\Component\HttpFoundation\JsonResponse
+    {
+        $perso_id = $request->get('id');
+        $holiday_helper = new HolidayHelper();
+        $result = array();
+        $hoursPerDay = $holiday_helper->hoursPerDay($perso_id);
+        $result['hoursPerDay'] = $hoursPerDay;
+        $result['hoursPerDayInHoursMinutes'] = HourHelper::decimalToHoursMinutes($hoursPerDay)['as_string'];
+
+        return $this->json($result);
+    }
+
+
     #[Route(path: '/ajax/holidays-hours-to-days', name: 'ajax.holidays-hours-to-days', methods: ['GET'])]
     public function hoursToDays(Request $request, Session $session): \Symfony\Component\HttpFoundation\JsonResponse
     {
@@ -410,6 +424,7 @@ class HolidayController extends BaseController
         if ($this->config('Conges-Recuperations') == 1 and $data['debit']=="recuperation") {
             $request_type = 'recover';
             $title = 'Overtime compensation request';
+            $hoursPerDay = 0;
         }
 
         $show_allday = 0;
@@ -428,7 +443,7 @@ class HolidayController extends BaseController
 
         $hoursPerDay = null;
         $hoursPerDayInHoursMinutes = null;
-        if ($holiday_helper->showHoursToDays()) {
+        if ($request_type = 'holiday' and $holiday_helper->showHoursToDays()) {
 
             $hoursPerDay               = $holiday_helper->hoursPerDay($perso_id);
             $hoursPerDayInHoursMinutes = HourHelper::decimalToHoursMinutes($hoursPerDay)['as_string'];

--- a/src/Controller/HolidayController.php
+++ b/src/Controller/HolidayController.php
@@ -2,21 +2,16 @@
 
 namespace App\Controller;
 
-use DateTime;
-
 use App\Controller\BaseController;
-
 use App\Entity\Agent;
-
 use App\Planno\Helper\HolidayHelper;
 use App\Planno\Helper\HourHelper;
 use App\Planno\Helper\WeekPlanningHelper;
-
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\HttpFoundation\JsonResponse;
 
 require_once(__DIR__ . '/../../legacy/Class/class.conges.php');
 require_once(__DIR__ . '/../../legacy/Class/class.personnel.php');
@@ -276,18 +271,17 @@ class HolidayController extends BaseController
     }
 
     #[Route(path: '/holiday/hours-per-day', name: 'holiday.hours-per-day', methods: ['GET'])]
-    public function getHoursPerDay(Request $request) : JsonResponse    
+    public function getHoursPerDay(Request $request): JsonResponse
     {
         $perso_id = $request->query->getInt('id');
         $holiday_helper = new HolidayHelper();
-        $result = array();
+        $result = [];
         $hoursPerDay = $holiday_helper->hoursPerDay($perso_id);
         $result['hoursPerDay'] = $hoursPerDay;
         $result['hoursPerDayInHoursMinutes'] = HourHelper::decimalToHoursMinutes($hoursPerDay)['as_string'];
 
         return $this->json($result);
     }
-
 
     #[Route(path: '/ajax/holidays-hours-to-days', name: 'ajax.holidays-hours-to-days', methods: ['GET'])]
     public function hoursToDays(Request $request, Session $session): \Symfony\Component\HttpFoundation\JsonResponse

--- a/src/Controller/HolidayController.php
+++ b/src/Controller/HolidayController.php
@@ -419,7 +419,6 @@ class HolidayController extends BaseController
         if ($this->config('Conges-Recuperations') == 1 and $data['debit']=="recuperation") {
             $request_type = 'recover';
             $title = 'Overtime compensation request';
-            $hoursPerDay = 0;
         }
 
         $show_allday = 0;
@@ -436,9 +435,9 @@ class HolidayController extends BaseController
         $credit_jours = null;
         $reliquat_jours = null;
 
-        $hoursPerDay = null;
+        $hoursPerDay = 0;
         $hoursPerDayInHoursMinutes = null;
-        if ($request_type == 'holiday' and $holiday_helper->showHoursToDays()) {
+        if ($holiday_helper->showHoursToDays()) {
 
             $hoursPerDay               = $holiday_helper->hoursPerDay($perso_id);
             $hoursPerDayInHoursMinutes = HourHelper::decimalToHoursMinutes($hoursPerDay)['as_string'];
@@ -637,7 +636,7 @@ class HolidayController extends BaseController
         $credit_jours = null;
         $reliquat_jours = null;
 
-        $hoursPerDay = null;
+        $hoursPerDay = 0;
         $hoursPerDayInHoursMinutes = null;
         if ($holiday_helper->showHoursToDays()) {
 
@@ -681,7 +680,7 @@ class HolidayController extends BaseController
             'commentaires'          => '',
             'CSRFToken'             => $GLOBALS['CSRFSession'],
             'hours_per_day'         => $hoursPerDay,
-            'hours_per_day_in_hhmm' => $hoursPerDayInHoursMinutes ?? null,
+            'hours_per_day_in_hhmm' => $hoursPerDayInHoursMinutes,
             'reliquat'              => $reliquat,
             'reliquat2'             => $holiday_helper->HumanReadableDuration($reliquat),
             'reliquat_jours'        => $reliquat_jours,

--- a/src/Controller/HolidayController.php
+++ b/src/Controller/HolidayController.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\HttpFoundation\JsonResponse;
 
 require_once(__DIR__ . '/../../legacy/Class/class.conges.php');
 require_once(__DIR__ . '/../../legacy/Class/class.personnel.php');
@@ -274,10 +275,10 @@ class HolidayController extends BaseController
         return $this->output('holiday/index.html.twig');
     }
 
-    #[Route(path: '/ajax/holidays-hours-per-day', name: 'ajax.holidays-hours-per-day', methods: ['GET'])]
-    public function blip(Request $request, Session $session) : \Symfony\Component\HttpFoundation\JsonResponse
+    #[Route(path: '/holiday/hours-per-day', name: 'holiday.hours-per-day', methods: ['GET'])]
+    public function getHoursPerDay(Request $request) : JsonResponse    
     {
-        $perso_id = $request->get('id');
+        $perso_id = $request->query->getInt('id');
         $holiday_helper = new HolidayHelper();
         $result = array();
         $hoursPerDay = $holiday_helper->hoursPerDay($perso_id);

--- a/src/Controller/HolidayController.php
+++ b/src/Controller/HolidayController.php
@@ -443,7 +443,7 @@ class HolidayController extends BaseController
 
         $hoursPerDay = null;
         $hoursPerDayInHoursMinutes = null;
-        if ($request_type = 'holiday' and $holiday_helper->showHoursToDays()) {
+        if ($request_type == 'holiday' and $holiday_helper->showHoursToDays()) {
 
             $hoursPerDay               = $holiday_helper->hoursPerDay($perso_id);
             $hoursPerDayInHoursMinutes = HourHelper::decimalToHoursMinutes($hoursPerDay)['as_string'];

--- a/src/Planno/Helper/HolidayHelper.php
+++ b/src/Planno/Helper/HolidayHelper.php
@@ -262,7 +262,7 @@ class HolidayHelper extends BaseHelper
 
     public function hoursPerDay($perso_id, $holidays_hours_per_year = null)
     {
-        if ($this->config('conges-hours-per-day')) {
+        if ($this->config['Conges-Mode'] == 'heures' and $this->config('conges-hours-per-day')) {
             if ($holidays_hours_per_year == null) {
                 $agent = $this->entityManager->find(Agent::class, $perso_id);
                 $holidays_hours_per_year = $agent->getHolidayAnnualCredit();
@@ -276,6 +276,7 @@ class HolidayHelper extends BaseHelper
         } else {
             return 7;
         }
+        
         return -1;
     }
 
@@ -283,10 +284,16 @@ class HolidayHelper extends BaseHelper
         if (empty($given_hours) and !$human_readable) { return 0; }
         if (empty($given_hours) and $human_readable) { return ''; }
 
-        $hours_per_day = ($holidays_hours_per_year == null) ? $this->hoursPerDay($perso_id) : $this->hoursPerDay(null, $holidays_hours_per_year);
+        $hours_per_day = 7;
 
-        $result = round((float) $given_hours / $hours_per_day, 2);
+        if ($this->config('Conges-Mode') == 'heures') {
+            $hours_per_day = ($holidays_hours_per_year == null) ? $this->hoursPerDay($perso_id) : $this->hoursPerDay(null, $holidays_hours_per_year);
+        }
 
+        $given_hours = (float) $given_hours / $hours_per_day;
+
+        $result = round((float) $given_hours, 2);
+        
         if ($human_readable) {
             if (empty($result)) {
                 return '';

--- a/src/Planno/Helper/HolidayHelper.php
+++ b/src/Planno/Helper/HolidayHelper.php
@@ -262,7 +262,7 @@ class HolidayHelper extends BaseHelper
 
     public function hoursPerDay($perso_id, $holidays_hours_per_year = null)
     {
-        if ($this->config['Conges-Mode'] == 'heures' and $this->config('conges-hours-per-day')) {
+        if ($this->config['Conges-Mode'] == 'heures' and $this->config['conges-hours-per-day']) {            
             if ($holidays_hours_per_year == null) {
                 $agent = $this->entityManager->find(Agent::class, $perso_id);
                 $holidays_hours_per_year = $agent->getHolidayAnnualCredit();
@@ -286,7 +286,7 @@ class HolidayHelper extends BaseHelper
 
         $hours_per_day = 7;
 
-        if ($this->config('Conges-Mode') == 'heures') {
+        if ($this->config['Conges-Mode'] == 'heures') {
             $hours_per_day = ($holidays_hours_per_year == null) ? $this->hoursPerDay($perso_id) : $this->hoursPerDay(null, $holidays_hours_per_year);
         }
 

--- a/src/Planno/Helper/HolidayHelper.php
+++ b/src/Planno/Helper/HolidayHelper.php
@@ -262,7 +262,7 @@ class HolidayHelper extends BaseHelper
 
     public function hoursPerDay($perso_id, $holidays_hours_per_year = null)
     {
-        if ($this->config['Conges-Mode'] == 'heures' and $this->config['conges-hours-per-day']) {
+        if ($this->config['Conges-Mode'] == 'heures' and $this->config('conges-hours-per-day')) {
             if ($holidays_hours_per_year == null) {
                 $agent = $this->entityManager->find(Agent::class, $perso_id);
                 $holidays_hours_per_year = $agent->getHolidayAnnualCredit();
@@ -287,12 +287,12 @@ class HolidayHelper extends BaseHelper
         $hours_per_day = 7;
 
         if ($this->config['Conges-Mode'] == 'heures') {
-            $hours_per_day = ($holidays_hours_per_year == null) ? $this->hoursPerDay($perso_id) : $this->hoursPerDay(null, $holidays_hours_per_year);
+            $hours_per_day = $holidays_hours_per_year == null ? $this->hoursPerDay($perso_id) : $this->hoursPerDay(null, $holidays_hours_per_year);
         }
 
         $given_hours = (float) $given_hours / $hours_per_day;
 
-        $result = round((float) $given_hours, 2);
+        $result = round($given_hours, 2);
         
         if ($human_readable) {
             if (empty($result)) {

--- a/src/Planno/Helper/HolidayHelper.php
+++ b/src/Planno/Helper/HolidayHelper.php
@@ -262,7 +262,7 @@ class HolidayHelper extends BaseHelper
 
     public function hoursPerDay($perso_id, $holidays_hours_per_year = null)
     {
-        if ($this->config['Conges-Mode'] == 'heures' and $this->config['conges-hours-per-day']) {            
+        if ($this->config['Conges-Mode'] == 'heures' and $this->config['conges-hours-per-day']) {
             if ($holidays_hours_per_year == null) {
                 $agent = $this->entityManager->find(Agent::class, $perso_id);
                 $holidays_hours_per_year = $agent->getHolidayAnnualCredit();

--- a/templates/holiday/edit.html.twig
+++ b/templates/holiday/edit.html.twig
@@ -296,20 +296,10 @@
           </div>
         {% endif %}
 
-        {% if request_type=='holiday' and config('Conges-Mode') == 'heures' and hours_per_day is not empty %}
+        {% if hours_per_day %}
 
           <div class="row gx-5 mb-2 hideWhenMultipleAgents">
-            <label class="col-2 col-form-label text-end" for="hr_rest">Équivalence en jour :<br/>(1 jour =  {{ hours_per_day_in_hhmm }})</label>
-            <div class="col-3">
-              <input id="nbJours" readonly class="form-control-plaintext"/>
-              <input type="hidden" name="hours_per_day" id="hours_per_day" value="{{ hours_per_day }}" />
-            </div>
-          </div>
-
-        {% elseif hours_per_day %}
-
-          <div class="row gx-5 mb-2">
-            <label class="col-2 col-form-label text-end" for="hr_rest">Nombre de jours ({{ hours_per_day }}h/jour) :</label>
+            <label class="col-2 col-form-label text-end" for="nbJours">Équivalence en jour :<br/>(1 jour =  {{ hours_per_day_in_hhmm }})</label>
             <div class="col-3">
               <input id="nbJours" readonly class="form-control-plaintext"/>
               <input type="hidden" name="hours_per_day" id="hours_per_day" value="{{ hours_per_day }}" />

--- a/templates/holiday/edit.html.twig
+++ b/templates/holiday/edit.html.twig
@@ -299,7 +299,7 @@
         {% if hours_per_day %}
 
           <div class="row gx-5 mb-2 hideWhenMultipleAgents">
-            <label class="col-2 col-form-label text-end" for="nbJours">Équivalence en jour :<br/>(1 jour =  {{ hours_per_day_in_hhmm }})</label>
+            <label class="col-2 col-form-label text-end" for="nbJours">Équivalence en jour :<br/>(1 jour =  <font id="hours-per-day">{{ hours_per_day_in_hhmm }}</font>)</label>
             <div class="col-3">
               <input id="nbJours" readonly class="form-control-plaintext"/>
               <input type="hidden" name="hours_per_day" id="hours_per_day" value="{{ hours_per_day }}" />

--- a/tests/Controller/HolidayControllerAddTest.php
+++ b/tests/Controller/HolidayControllerAddTest.php
@@ -3,7 +3,9 @@
 use App\Entity\Agent;
 use App\Entity\Manager;
 use App\Entity\OverTime;
+use App\Entity\Cron;
 use App\Entity\WorkingHour;
+use App\Planno\Helper\HolidayHelper;
 use Doctrine\ORM\EntityManagerInterface;
 use Tests\FixtureBuilder;
 use Tests\PLBWebTestCase;
@@ -36,6 +38,14 @@ class HolidayControllerAddTest extends PLBWebTestCase
         $builder->delete(Manager::class);
         $builder->delete(WorkingHour::class);
         $builder->delete(Overtime::class);
+
+        $cron = $entityManager->getRepository(Cron::class)->findAll();
+        foreach ($cron as $c){
+            $c->setDisabled(true);
+            $entityManager->persist($c);
+        }
+
+        $entityManager->flush();
 
         $jdevoe = new Agent();
         $jdevoe->setLogin('jdevoe');
@@ -116,6 +126,14 @@ class HolidayControllerAddTest extends PLBWebTestCase
         $builder->delete(Manager::class);
         $builder->delete(WorkingHour::class);
         $builder->delete(Overtime::class);
+
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+
+        $cron = $entityManager->getRepository(Cron::class)->findAll();
+        foreach ($cron as $c){
+            $c->setDisabled(false);
+            $entityManager->persist($c);
+        }
    }
 
     protected function setUp(): void
@@ -346,6 +364,8 @@ class HolidayControllerAddTest extends PLBWebTestCase
         $this->config->setParam('Conges-Recuperations', 1);
         $this->config->setParam('Conges-Heures', 1);
 
+        $jdevoe = $this->entityManager->getRepository(Agent::class)->findOneBy(['login' => 'jdevoe']);
+
         $crawler = $this->client->request('GET', '/holiday/new');
 
         $this->assertSelectorExists('input[name=allday]');
@@ -369,7 +389,15 @@ class HolidayControllerAddTest extends PLBWebTestCase
 
         $heuresLabel = $crawler->filter('label[for=nbHeures]');
         $this->assertStringContainsString('Nombre d\'heures', $heuresLabel->text(),'The label is incorrect');
-        $this->assertSelectorNotExists('label[for=nbJours]');
+        
+        $holiday_helper = new HolidayHelper();
+        $hoursPerDay = $holiday_helper->hoursPerDay($jdevoe->getId());
+
+        if ($hoursPerDay == 7)
+            $this->assertSelectorNotExists('label[for=nbJours]');
+        else {
+            $this->assertSelectorExists('label[for=nbJours]');
+        }
     }
 
     public function testHolidayConfig4(): void

--- a/tests/Controller/HolidayControllerAddTest.php
+++ b/tests/Controller/HolidayControllerAddTest.php
@@ -364,8 +364,6 @@ class HolidayControllerAddTest extends PLBWebTestCase
         $this->config->setParam('Conges-Recuperations', 1);
         $this->config->setParam('Conges-Heures', 1);
 
-        $jdevoe = $this->entityManager->getRepository(Agent::class)->findOneBy(['login' => 'jdevoe']);
-
         $crawler = $this->client->request('GET', '/holiday/new');
 
         $this->assertSelectorExists('input[name=allday]');
@@ -389,14 +387,12 @@ class HolidayControllerAddTest extends PLBWebTestCase
 
         $heuresLabel = $crawler->filter('label[for=nbHeures]');
         $this->assertStringContainsString('Nombre d\'heures', $heuresLabel->text(),'The label is incorrect');
-        
-        $holiday_helper = new HolidayHelper();
-        $hoursPerDay = $holiday_helper->hoursPerDay($jdevoe->getId());
 
-        if ($hoursPerDay == 7)
-            $this->assertSelectorNotExists('label[for=nbJours]');
-        else {
+        $holiday_helper = new HolidayHelper();
+        if ($holiday_helper->showHoursToDays()) {
             $this->assertSelectorExists('label[for=nbJours]');
+        } else {
+            $this->assertSelectorNotExists('label[for=nbJours]');
         }
     }
 


### PR DESCRIPTION
 - deleted display on comptime (both day mode and hour mode)
 - bugfix : conversion now only on hour mode, no more display contradiction
 - simplified condition in template
 - added `ajax.holidays-hours-per-day` route to return hoursPerDay values for a specific agent
 - added the `resetHoursPerDay()` fct to update the hoursPerDay value when the selected agent changes