### PR TITLE
MT52609: Add date filters to info list pages (admin, absences, holiday)

### DIFF
--- a/src/Controller/AbsenceInfoController.php
+++ b/src/Controller/AbsenceInfoController.php
@@ -4,6 +4,7 @@ namespace App\Controller;
 
 use App\Controller\BaseController;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Session;
@@ -13,21 +14,19 @@ use App\Entity\AbsenceInfo;
 
 class AbsenceInfoController extends BaseController
 {
-    #[Route(path: '/absences/info', name: 'absences.info.index', methods: ['GET'])]
-    public function index(Request $request, Session $session)
+    #[Route(path: '/absences/info/{reset?}', name: 'absences.info.index', methods: ['GET'], requirements: ['reset' => 'reset'])]
+    public function index(Request $request, Session $session, EntityManagerInterface $em)
     {
-        $today = date('Y-m-d');
+        $start = $this->initDate('start', 'AbsenceInfoStart');
+        $end = $this->initDate('end', 'AbsenceInfoEnd', '+1 year');
 
-        $queryBuilder = $this->entityManager->createQueryBuilder();
+        $info = $em->getRepository(AbsenceInfo::class)->findByDateRange($start, $end);
 
-        $query = $queryBuilder->select(array('a'))
-            ->from(AbsenceInfo::class, 'a')
-            ->where('a.fin >= :today')
-            ->setParameter('today', $today)
-            ->orderBy('a.debut', 'ASC', 'a.fin', 'ASC')
-            ->getQuery();
-
-        $this->templateParams( array('info' => $query->getResult()) );
+        $this->templateParams([
+            'info' => $info,
+            'start' => $start,
+            'end' => $end,
+        ]);
 
         return $this->output('absenceInfo/index.html.twig');
     }
@@ -45,12 +44,12 @@ class AbsenceInfoController extends BaseController
         return $this->output('absenceInfo/edit.html.twig');
     }
 
-    #[Route(path: '/absences/info/{id}', name: 'absences.info.edit', methods: ['GET'])]
+    #[Route(path: '/absences/info/{id<\d+>}', name: 'absences.info.edit', methods: ['GET'])]
     public function edit(Request $request)
     {
         $id = $request->get('id');
 
-        $info = $this->entityManager->getRepository(AbsenceInfo::class)->findOneById($id);
+        $info = $this->entityManager->getRepository(AbsenceInfo::class)->find($id);
 
         $this->templateParams(array(
             'id'    => $id,

--- a/src/Controller/AdminInfoController.php
+++ b/src/Controller/AdminInfoController.php
@@ -4,6 +4,7 @@ namespace App\Controller;
 
 use App\Controller\BaseController;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HtmlSanitizer\HtmlSanitizer;
 use Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig;
 use Symfony\Component\HttpFoundation\Request;
@@ -15,20 +16,19 @@ use App\Entity\AdminInfo;
 
 class AdminInfoController extends BaseController
 {
-    #[Route(path: '/admin/info', name: 'admin.info.index', methods: ['GET'])]
-    public function index(Request $request, Session $session)
+    #[Route(path: '/admin/info/{reset?}', name: 'admin.info.index', methods: ['GET'], requirements: ['reset' => 'reset'])]
+    public function index(Request $request, Session $session, EntityManagerInterface $em)
     {
-        $today = date('Ymd');
+        $start = $this->initDate('start', 'AdminInfoStart');
+        $end = $this->initDate('end', 'AdminInfoEnd', '+1 year');
 
-        $queryBuilder = $this->entityManager->createQueryBuilder();
+        $info = $em->getRepository(AdminInfo::class)->findByDateRange($start, $end);
 
-        $query = $queryBuilder->select(array('a'))
-            ->from(AdminInfo::class, 'a')
-            ->where($queryBuilder->expr()->gte('a.fin', $today))
-            ->orderBy('a.debut', 'ASC', 'a.fin', 'ASC')
-            ->getQuery();
-
-        $this->templateParams( array('info' => $query->getResult()) );
+        $this->templateParams([
+            'info' => $info,
+            'start' => $start,
+            'end' => $end,
+        ]);
 
         return $this->output('adminInfo/index.html.twig');
     }

--- a/src/Controller/BaseController.php
+++ b/src/Controller/BaseController.php
@@ -4,6 +4,7 @@ namespace App\Controller;
 
 use App\Entity\Config;
 use App\Planno\Notifier;
+use DateTime;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
@@ -120,15 +121,37 @@ class BaseController extends AbstractController
         return $this->config[$key];
     }
 
-    protected function initDate(string $queryName, string $sessionName, string $when = 'today', string $format = 'd/m/Y'): ?\DateTime
+    /**
+     * Initialize and return a DateTime object using:
+     * - the query parameter named $queryName, or
+     * - the session parameter named $sessionName if the query parameter is absent or empty.
+     *
+     * If both the query parameter and the session parameter are absent, empty
+     * or invalid, the DateTime object is initialized with the method parameter
+     * $when, which can be any string accepted by DateTime constructor
+     * (default: "today")
+     *
+     * The query parameter and the session parameter must be in the format
+     * specified in $format (default: "d/m/Y")
+     *
+     * The resulting date is then stored in the session parameter named
+     * $sessionName using the format specified in $format
+     */
+    protected function initDate(string $queryName, string $sessionName, string $when = 'today', string $format = 'd/m/Y'): DateTime
     {
-        $dateSession = $this->request->getSession()->get($sessionName, date($format, strtotime($when)));
+        $session = $this->request->getSession();
 
-        $date = $this->request->query->get($queryName, $dateSession);
+        $date = $this->request->query->get($queryName) ?: $session->get($sessionName);
+        $reset = $this->request->attributes->get('reset') === 'reset';
 
-        $this->request->getSession()->set($sessionName, $date);
+        $dt = $date ? DateTime::createFromFormat($format, $date) : null;
+        if (!$dt or $reset) {
+            $dt = new DateTime($when);
+        }
 
-        return \DateTime::createFromFormat($format, $date);
+        $session->set($sessionName, $dt->format($format));
+
+        return $dt;
     }
 
     protected function csrf_protection(Request $request): bool

--- a/src/Controller/HolidayInfoController.php
+++ b/src/Controller/HolidayInfoController.php
@@ -3,7 +3,8 @@
 namespace App\Controller;
 
 use App\Controller\BaseController;
-
+use App\Entity\HolidayInfo;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Routing\Annotation\Route;
@@ -12,32 +13,27 @@ require_once(__DIR__ . '/../../legacy/Class/class.conges.php');
 
 class HolidayInfoController extends BaseController
 {
-    #[Route(path: '/holiday-info', name: 'holiday_info.index', methods: ['GET'])]
-    public function index(Request $request, Session $session)
+    #[Route(path: '/holiday-info/{reset?}', name: 'holiday_info.index', methods: ['GET'], requirements: ['reset' => 'reset'])]
+    public function index(Request $request, Session $session, EntityManagerInterface $em)
     {
-        $CSRFSession = $GLOBALS['CSRFSession'];
-        $dbprefix = $GLOBALS['dbprefix'];
-        $admin = false;
-        $today = date("Y-m-d");
-        $information = null;
+        if ($this->config('Conges-Enable') == 0 ) {
+            return $this->redirectToRoute('access-denied');
+        }
 
         if (!$this->isAdmin()) {
             return $this->redirectToRoute('access-denied');
         }
 
-        $db = new \db();
-        $db->query("SELECT * FROM `{$dbprefix}conges_infos` WHERE `fin`>='$today' ORDER BY `debut`,`fin`;");
+        $start = $this->initDate('start', 'HolidayInfoStart');
+        $end = $this->initDate('end', 'HolidayInfoEnd', '+1 year');
 
-        if($db->result){
-            $information  = $db->result;
-        }
+        $info = $em->getRepository(HolidayInfo::class)->findByDateRange($start, $end);
 
-        $this->templateParams(
-            array(
-                'info' => $information,
-                'admin' => $admin
-            )
-        );
+        $this->templateParams([
+            'info' => $info,
+            'start' => $start,
+            'end' => $end,
+        ]);
 
         return $this->output('holidayInfo/index.html.twig');
     }
@@ -61,7 +57,7 @@ class HolidayInfoController extends BaseController
         return $this->output('holidayInfo/edit.html.twig');
     }
 
-    #[Route(path: '/holiday-info/{id}', name: 'holiday_info.edit', methods: ['GET'])]
+    #[Route(path: '/holiday-info/{id<\d+>}', name: 'holiday_info.edit', methods: ['GET'])]
     public function edit(Request $request)
     {
         if(!$this->isAdmin()){

--- a/src/Entity/AbsenceInfo.php
+++ b/src/Entity/AbsenceInfo.php
@@ -2,10 +2,11 @@
 
 namespace App\Entity;
 
+use App\Repository\AbsenceInfoRepository;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
-#[ORM\Entity]
+#[ORM\Entity(repositoryClass: AbsenceInfoRepository::class)]
 #[ORM\Table(name: 'absences_infos')]
 class AbsenceInfo
 {

--- a/src/Entity/AdminInfo.php
+++ b/src/Entity/AdminInfo.php
@@ -2,10 +2,11 @@
 
 namespace App\Entity;
 
+use App\Repository\AdminInfoRepository;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
-#[ORM\Entity]
+#[ORM\Entity(repositoryClass: AdminInfoRepository::class)]
 #[ORM\Table(name: 'infos')]
 class AdminInfo
 {

--- a/src/Entity/HolidayInfo.php
+++ b/src/Entity/HolidayInfo.php
@@ -2,10 +2,11 @@
 
 namespace App\Entity;
 
+use App\Repository\HolidayInfoRepository;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
-#[ORM\Entity]
+#[ORM\Entity(repositoryClass: HolidayInfoRepository::class)]
 #[ORM\Table(name: 'conges_infos')]
 class HolidayInfo
 {

--- a/src/Repository/AbsenceInfoRepository.php
+++ b/src/Repository/AbsenceInfoRepository.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\AbsenceInfo;
+use DateTimeInterface;
+use Doctrine\ORM\EntityRepository;
+use Doctrine\DBAL\Types\Types;
+
+/**
+ * @extends EntityRepository<AbsenceInfo>
+ */
+class AbsenceInfoRepository extends EntityRepository
+{
+    /**
+     * Returns all entities whose start-end date range intersects with the
+     * passed date range
+     *
+     * $end defaults to $start if not passed or null
+     *
+     * @return AbsenceInfo[]
+     */
+    public function findByDateRange(DateTimeInterface $start, ?DateTimeInterface $end = null): array
+    {
+        $end = $end ?? $start;
+
+        return $this->createQueryBuilder('a')
+            ->andWhere('a.debut <= :end')
+            ->andWhere('a.fin >= :start')
+            ->orderBy('a.debut', 'ASC')
+            ->addOrderBy('a.fin', 'ASC')
+            ->setParameter('start', $start, Types::DATE_MUTABLE)
+            ->setParameter('end', $end, Types::DATE_MUTABLE)
+            ->getQuery()
+            ->getResult();
+    }
+}

--- a/src/Repository/AdminInfoRepository.php
+++ b/src/Repository/AdminInfoRepository.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\AdminInfo;
+use DateTimeInterface;
+use Doctrine\ORM\EntityRepository;
+use Doctrine\DBAL\Types\Types;
+
+/**
+ * @extends EntityRepository<AdminInfo>
+ */
+class AdminInfoRepository extends EntityRepository
+{
+    /**
+     * Returns all entities whose start-end date range intersects with the
+     * passed date range
+     *
+     * $end defaults to $start if not passed
+     *
+     * @return AdminInfo[]
+     */
+    public function findByDateRange(DateTimeInterface $start, ?DateTimeInterface $end = null): array
+    {
+        $end = $end ?? $start;
+
+        return $this->createQueryBuilder('a')
+            ->andWhere('a.debut <= :end')
+            ->andWhere('a.fin >= :start')
+            ->orderBy('a.debut', 'ASC')
+            ->addOrderBy('a.fin', 'ASC')
+            ->setParameter('start', $start, Types::DATE_MUTABLE)
+            ->setParameter('end', $end, Types::DATE_MUTABLE)
+            ->getQuery()
+            ->getResult();
+    }
+}

--- a/src/Repository/HolidayInfoRepository.php
+++ b/src/Repository/HolidayInfoRepository.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\HolidayInfo;
+use DateTimeInterface;
+use Doctrine\ORM\EntityRepository;
+use Doctrine\DBAL\Types\Types;
+
+/**
+ * @extends AbstractInfoRepository<HolidayInfo>
+ */
+class HolidayInfoRepository extends EntityRepository
+{
+    /**
+     * Returns all entities whose start-end date range intersects with the
+     * passed date range
+     *
+     * $end defaults to $start if not passed
+     *
+     * @return HolidayInfo[]
+     */
+    public function findByDateRange(DateTimeInterface $start, ?DateTimeInterface $end = null): array
+    {
+        $end = $end ?? $start;
+
+        return $this->createQueryBuilder('a')
+            ->andWhere('a.debut <= :end')
+            ->andWhere('a.fin >= :start')
+            ->orderBy('a.debut', 'ASC')
+            ->addOrderBy('a.fin', 'ASC')
+            ->setParameter('start', $start, Types::DATE_MUTABLE)
+            ->setParameter('end', $end, Types::DATE_MUTABLE)
+            ->getQuery()
+            ->getResult();
+    }
+}

--- a/templates/absenceInfo/index.html.twig
+++ b/templates/absenceInfo/index.html.twig
@@ -5,36 +5,57 @@
 {% block page %}
     <h3>Informations sur les absences</h3>
 
-    <div class="top-button-div">
-        <a href="{{ asset('absences/info/add') }}" role="button" class="btn btn-primary" aria-label="Ajouter une absence">Ajouter</a>
-    </div>
+    <form method="get" action="{{ asset('absences/info') }}">
+        <div class="row row-search">
+            <label class="col-xl-auto col-form-label mt-2" for="start-date">{{ 'Start' | trans }} :</label>
 
-    {% if info %}
-        <table class='CJDataTable' data-sort='[[1,"asc"],[2,"asc"]]' id='AbsenceInfoTable'>
-            <thead>
+            <div class="col-xl-auto ps-0">
+                <input id="start-date" type="text" name="start" class="datepicker start-date form-control" value="{{ start | dateOrNull('d/m/Y') }}">
+            </div>
+
+            <label class="col-xl-auto col-form-label mt-2" for="end-date">{{ 'End' | trans }} :</label>
+
+            <div class="col-xl-auto ps-0">
+                <input id="end-date" type="text" name="end" class="datepicker end-date form-control" value="{{ end | dateOrNull('d/m/Y') }}">
+            </div>
+
+            <div class="col-xl-3 ps-0">
+                <input type="submit" role="button" value="{{ 'Search' | trans }}" class="btn btn-primary m-2">
+                <a href="{{ asset('absences/info/reset') }}" class="btn btn-secondary m-2">{{ 'Clear' | trans }}</a>
+            </div>
+
+            <div class="col-xl text-end">
+                <a href="{{ asset('absences/info/add') }}" role="button" class="btn btn-primary m-2">{{ 'Add' | trans }}</a>
+            </div>
+        </div>
+
+        <div class="row mb-3">
+            <div class="invalid-feedback">{% trans from 'validators' %}Please choose a valid date interval.{% endtrans %}</div>
+        </div>
+    </form>
+
+    <table class="CJDataTable" data-sort='[[1,"asc"],[2,"asc"]]' id="AbsenceInfoTable">
+        <thead>
+            <tr>
+                <th class="dataTableNoSort"></th>
+                <th class="dataTableDateFR">{{ 'Start' | trans }}</th>
+                <th class="dataTableDateFR">{{ 'End' | trans }}</th>
+                <th>{{ 'Text' | trans }}</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for elem in info %}
                 <tr>
-                    <th class='dataTableNoSort'></th>
-                    <th class='dataTableDateFR'>Début</th>
-                    <th class='dataTableDateFR'>Fin</th>
-                    <th>Texte</th>
+                    <td>
+                        <a href="{{ asset('absences/info/') }}{{elem.id}}">
+                            <span class="pl-icon pl-icon-edit" title="{{ 'Edit' | trans }}"></span>
+                        </a>
+                    </td>
+                    <td>{{ elem.start | date('d/m/Y') }}</td>
+                    <td>{{ elem.end | date('d/m/Y') }}</td>
+                    <td>{{ elem.comment | nl2br }}</td>
                 </tr>
-            </thead>
-            <tbody>
-                {%for elem in info %}
-                    <tr>
-                        <td>
-                            <a href='{{ asset('absences/info/') }}{{elem.id}}'>
-                                <span class='pl-icon pl-icon-edit' title='Edit'></span>
-                            </a>
-                        </td>
-                        <td>{{ elem.start | date("d/m/Y") }}</td>
-                        <td>{{ elem.end | date("d/m/Y")  }}</td>
-                        <td>{{ elem.comment | nl2br }}</td>
-                    </tr>
-                {% endfor %}
-            </tbody>
-        </table>
-    {% else %}
-        <p>Aucune information enregistrée.</p>
-    {% endif %}
+            {% endfor %}
+        </tbody>
+    </table>
 {% endblock %}

--- a/templates/adminInfo/index.html.twig
+++ b/templates/adminInfo/index.html.twig
@@ -5,36 +5,57 @@
 {% block page %}
     <h3>Messages d'informations</h3>
 
-    <div class="top-button-div">
-        <a href="{{ asset('admin/info/add') }}" role="button" class="btn btn-primary">Ajouter</a>
-    </div>
+    <form method="get" action="{{ asset('admin/info') }}">
+        <div class="row row-search">
+            <label class="col-xl-auto col-form-label mt-2" for="start-date">{{ 'Start' | trans }} :</label>
 
-    {% if info %}
-        <table class="CJDataTable" data-sort='[[1,"asc"],[2,"asc"]]' id="AbsenceInfoTable">
-            <thead>
+            <div class="col-xl-auto ps-0">
+                <input id="start-date" type="text" name="start" class="datepicker start-date form-control" value="{{ start | dateOrNull('d/m/Y') }}">
+            </div>
+
+            <label class="col-xl-auto col-form-label mt-2" for="end-date">{{ 'End' | trans }} :</label>
+
+            <div class="col-xl-auto ps-0">
+                <input id="end-date" type="text" name="end" class="datepicker end-date form-control" value="{{ end | dateOrNull('d/m/Y') }}">
+            </div>
+
+            <div class="col-xl-3 ps-0">
+                <input type="submit" role="button" value="{{ 'Search' | trans }}" class="btn btn-primary m-2">
+                <a href="{{ asset('admin/info/reset') }}" class="btn btn-secondary m-2">{{ 'Clear' | trans }}</a>
+            </div>
+
+            <div class="col-xl text-end">
+                <a href="{{ asset('admin/info/add') }}" role="button" class="btn btn-primary m-2">{{ 'Add' | trans }}</a>
+            </div>
+        </div>
+
+        <div class="row mb-3">
+            <div class="invalid-feedback">{% trans from 'validators' %}Please choose a valid date interval.{% endtrans %}</div>
+        </div>
+    </form>
+
+    <table class="CJDataTable" data-sort='[[1,"asc"],[2,"asc"]]' id="AdminInfoTable">
+        <thead>
+            <tr>
+                <th class="dataTableNoSort"></th>
+                <th class="dataTableDateFR">{{ 'Start' | trans }}</th>
+                <th class="dataTableDateFR">{{ 'End' | trans }}</th>
+                <th>{{ 'Text' | trans }}</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for elem in info %}
                 <tr>
-                    <th class="dataTableNoSort"></th>
-                    <th>Début</th>
-                    <th>Fin</th>
-                    <th>Texte</th>
+                    <td>
+                        <a href="{{ asset('admin/info/') }}{{elem.id}}">
+                            <span class="pl-icon pl-icon-edit" title="{{ 'Edit' | trans }}"></span>
+                        </a>
+                    </td>
+                    <td>{{ elem.start | date('d/m/Y') }}</td>
+                    <td>{{ elem.end | date('d/m/Y') }}</td>
+                    <td>{{ elem.comment | nl2br }}</td>
                 </tr>
-            </thead>
-            <tbody>
-                {%for elem in info %}
-                    <tr>
-                        <td>
-                            <a href="{{ asset('admin/info/') }}{{elem.id}}">
-                                <span class="pl-icon pl-icon-edit" title="Edit"></span>
-                            </a>
-                        </td>
-                        <td>{{ elem.start | date("d/m/Y") }}</td>
-                        <td>{{ elem.end | date("d/m/Y")  }}</td>
-                        <td>{{ elem.comment }}</td>
-                    </tr>
-                {% endfor %}
-            </tbody>
-        </table>
-    {% else %}
-        Aucune information enregistrée.
-    {% endif %}
+            {% endfor %}
+        </tbody>
+    </table>
 {% endblock %}

--- a/templates/holidayInfo/index.html.twig
+++ b/templates/holidayInfo/index.html.twig
@@ -5,36 +5,57 @@
 {% block page %}
     <h3>Informations sur les congés</h3>
 
-    <div class="top-button-div">
-        <a role="button" href="{{ asset('holiday-info/add') }}" class="btn btn-primary">Ajouter</a>
-    </div>
+    <form method="get" action="{{ asset('holiday-info') }}">
+        <div class="row row-search">
+            <label class="col-xl-auto col-form-label mt-2" for="start-date">{{ 'Start' | trans }} :</label>
 
-    {% if not info is empty %}
-      <table class="CJDataTable" data-sort='[[1,"asc"],[2,"asc"]]'>
-        <thead>
+            <div class="col-xl-auto ps-0">
+                <input id="start-date" type="text" name="start" class="datepicker start-date form-control" value="{{ start | dateOrNull('d/m/Y') }}">
+            </div>
+
+            <label class="col-xl-auto col-form-label mt-2" for="end-date">{{ 'End' | trans }} :</label>
+
+            <div class="col-xl-auto ps-0">
+                <input id="end-date" type="text" name="end" class="datepicker end-date form-control" value="{{ end | dateOrNull('d/m/Y') }}">
+            </div>
+
+            <div class="col-xl-3 ps-0">
+                <input type="submit" role="button" value="{{ 'Search' | trans }}" class="btn btn-primary m-2">
+                <a href="{{ asset('holiday-info/reset') }}" class="btn btn-secondary m-2">{{ 'Clear' | trans }}</a>
+            </div>
+
+            <div class="col-xl text-end">
+                <a href="{{ asset('holiday-info/add') }}" role="button" class="btn btn-primary m-2">{{ 'Add' | trans }}</a>
+            </div>
+        </div>
+
+        <div class="row mb-3">
+            <div class="invalid-feedback">{% trans from 'validators' %}Please choose a valid date interval.{% endtrans %}</div>
+        </div>
+    </form>
+
+    <table class="CJDataTable" data-sort='[[1,"asc"],[2,"asc"]]' id="HolidayInfoTable">
+      <thead>
+        <tr>
+            <th class="dataTableNoSort"></th>
+            <th class="dataTableDateFR">{{ 'Start' | trans }}</th>
+            <th class="dataTableDateFR">{{ 'End' | trans }}</th>
+            <th>{{ 'Text' | trans }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for elem in info %}
           <tr>
-              <th class="dataTableNoSort"></th>
-              <th class="dataTableDateFR">Début</th>
-              <th class="dataTableDateFR">Fin</th>
-              <th>Texte</th>
+            <td>
+              <a href="{{ asset('holiday-info') }}/{{ elem.id }}">
+                <span class="pl-icon pl-icon-edit" title="{{ 'Edit' | trans }}"></span>
+              </a>
+            </td>
+            <td>{{ elem.start | date('d/m/Y') }}</td>
+            <td>{{ elem.end | date('d/m/Y')  }}</td>
+            <td>{{ elem.comment | nl2br }}</td>
           </tr>
-        <thead>
-        <tbody>
-          {% for elem in info %}
-            <tr>
-              <td>
-                <a href="{{ asset('holiday-info') }}/{{ elem.id }}">
-                  <span class="pl-icon pl-icon-edit" title="Edit"></span>
-                </a>
-              </td>
-              <td>{{ elem.debut | date("d/m/Y") }}</td>
-              <td>{{ elem.fin | date("d/m/Y")  }}</td>
-              <td>{{ elem.texte | nl2br }}</td>
-            </tr>
-          {% endfor %}
-        <tbody>
-      </table>
-    {% else %}
-        <p>Aucune information enregistrée.</p>
-    {% endif %}
-{% endblock %} 
+        {% endfor %}
+      </tbody>
+    </table>
+{% endblock %}

--- a/tests/Controller/AbsenceInfoControllerTest.php
+++ b/tests/Controller/AbsenceInfoControllerTest.php
@@ -12,7 +12,6 @@ use Tests\FixtureBuilder;
 
 class AbsenceInfoControllerTest extends PLBWebTestCase
 {
-
     public function testAdd(): void
     {
         $entityManager = $this->entityManager;
@@ -148,10 +147,11 @@ class AbsenceInfoControllerTest extends PLBWebTestCase
 
         $this->assertSelectorTextContains('h3', 'Informations sur les absences');
 
-        $result = $crawler->filterXPath('//a[@class="btn btn-primary"]');
+        $result = $crawler->filterXPath('//a[@href="/absences/info/add"]');
         $this->assertEquals('Ajouter', $result->text('Node does not exist', false), 'a button is Ajouter');
 
-        $this->assertSelectorTextContains('p', 'Aucune information enregistrée');
+        $rowCount = $crawler->filter('table > tbody > tr')->count();
+        $this->assertEquals(0, $rowCount);
 
         $start = new DateTime('+1 day');
         $end = new DateTime('+1 month +1 day');
@@ -168,7 +168,7 @@ class AbsenceInfoControllerTest extends PLBWebTestCase
 
         $this->assertSelectorTextContains('h3', 'Informations sur les absences');
 
-        $result = $crawler->filterXPath('//a[@class="btn btn-primary"]');
+        $result = $crawler->filterXPath('//a[@href="/absences/info/add"]');
         $this->assertEquals('Ajouter', $result->text('Node does not exist', false), 'a button is Ajouter');
 
         $result = $crawler->filterXPath('//table[@id="AbsenceInfoTable"]');
@@ -178,11 +178,25 @@ class AbsenceInfoControllerTest extends PLBWebTestCase
         $this->assertStringContainsString('Texte',$result->text('Node does not exist', false), 'table title is Texte');
 
         $result = $crawler->filterXPath('//span[@class="pl-icon pl-icon-edit"]');
-        $this->assertEquals($result->attr('title'),'Edit','span logo edit title is Edit');
+        $this->assertEquals($result->attr('title'),'Editer','span logo edit title is Edit');
 
         $result = $crawler->filterXPath('//tbody/tr/td');
         $this->assertEquals($result->eq(1)->text('Node does not exist', false), $start->format('d/m/Y'),'date début is ok');
         $this->assertEquals($result->eq(2)->text('Node does not exist', false), $end->format('d/m/Y'),'date fin is ok');
         $this->assertEquals($result->eq(3)->text('Node does not exist', false), 'hello','text info is ok');
+
+        $afterEnd = DateTime::createFromInterface($end)->modify('+1 day');
+        $crawler = $this->client->request('GET', sprintf('/absences/info?start=%s', $afterEnd->format('d/m/Y')));
+        $rowCount = $crawler->filter('table > tbody > tr')->count();
+        $this->assertEquals(0, $rowCount);
+
+        $beforeStart = DateTime::createFromInterface($start)->modify('-1 day');
+        $crawler = $this->client->request('GET', sprintf('/absences/info?end=%s', $beforeStart->format('d/m/Y')));
+        $rowCount = $crawler->filter('table > tbody > tr')->count();
+        $this->assertEquals(0, $rowCount);
+
+        $crawler = $this->client->request('GET', sprintf('/absences/info?start=%s&end=%s', $start->format('d/m/Y'), $end->format('d/m/Y')));
+        $rowCount = $crawler->filter('table > tbody > tr')->count();
+        $this->assertEquals(1, $rowCount);
     }
 }

--- a/tests/Controller/AdminInfoControllerTest.php
+++ b/tests/Controller/AdminInfoControllerTest.php
@@ -8,6 +8,46 @@ use Tests\FixtureBuilder;
 
 class AdminInfoControllerTest extends PLBWebTestCase
 {
+    public function testAdminInfoList(): void
+    {
+        $builder = new FixtureBuilder();
+        $builder->delete(Agent::class);
+        $agent = $builder->build(Agent::class, ['login' => 'jdevoe']);
+        $builder->delete(AdminInfo::class);
+
+        $this->logInAgent($agent, [23]);
+
+        $info = new AdminInfo();
+        $info->setStart('2022-10-05');
+        $info->setEnd('2022-10-10');
+        $info->setComment('Test comment');
+        $this->entityManager->persist($info);
+
+        $info2 = new AdminInfo();
+        $info2->setStart('2023-10-05');
+        $info2->setEnd('2023-10-10');
+        $info2->setComment('Test comment 2');
+        $this->entityManager->persist($info2);
+
+        $this->entityManager->flush();
+
+        $crawler = $this->client->request('GET', '/admin/info?start=06/10/2022');
+        $rowCount = $crawler->filter('table > tbody > tr')->count();
+        $this->assertEquals(2, $rowCount);
+
+        $crawler = $this->client->request('GET', '/admin/info?start=06/10/2023');
+        $rowCount = $crawler->filter('table > tbody > tr')->count();
+        $this->assertEquals(1, $rowCount);
+
+        $crawler = $this->client->request('GET', '/admin/info?start=01/01/2000&end=06/10/2022');
+        $rowCount = $crawler->filter('table > tbody > tr')->count();
+        $this->assertEquals(1, $rowCount);
+
+        $crawler = $this->client->request('GET', '/admin/info?start=01/01/2000&end=06/10/2021');
+        $rowCount = $crawler->filter('table > tbody > tr')->count();
+        $this->assertEquals(0, $rowCount);
+    }
+
     public function testAdd(): void
     {
         $builder = new FixtureBuilder();

--- a/tests/Controller/HolidayInfoControllerTest.php
+++ b/tests/Controller/HolidayInfoControllerTest.php
@@ -145,10 +145,11 @@ class HolidayInfoControllerTest extends PLBWebTestCase
 
         $this->assertSelectorTextContains('h3', 'Informations sur les congés');
 
-        $result = $crawler->filterXPath('//a[@class="btn btn-primary"]');
+        $result = $crawler->filterXPath('//a[@href="/holiday-info/add"]');
         $this->assertEquals('Ajouter', $result->text('Node does not exist', false), 'a is Ajouter');
 
-        $this->assertSelectorTextContains('p', 'Aucune information enregistrée.');
+        $rowCount = $crawler->filter('table > tbody > tr')->count();
+        $this->assertEquals(0, $rowCount);
 
         $start = new DateTime('+1 day');
         $end = new DateTime('+1 month +1 day');
@@ -165,7 +166,7 @@ class HolidayInfoControllerTest extends PLBWebTestCase
 
         $this->assertSelectorTextContains('h3', 'Informations sur les congés');
 
-        $result = $crawler->filterXPath('//a[@class="btn btn-primary"]');
+        $result = $crawler->filterXPath('//a[@href="/holiday-info/add"]');
         $this->assertEquals('Ajouter', $result->text('Node does not exist', false), 'a is Ajouter');
 
         $result = $crawler->filterXPath('//th[@class="dataTableDateFR"]');
@@ -173,11 +174,25 @@ class HolidayInfoControllerTest extends PLBWebTestCase
         $this->assertEquals($result->eq(1)->text('Node does not exist', false), 'Fin','table title is Fin');
 
         $result = $crawler->filterXPath('//span[@class="pl-icon pl-icon-edit"]');
-        $this->assertEquals($result->attr('title'),'Edit','span logo edit title is Edit');
+        $this->assertEquals($result->attr('title'),'Editer','span logo edit title is Edit');
 
         $result = $crawler->filterXPath('//tbody/tr/td');
         $this->assertEquals($result->eq(1)->text(), $start->format('d/m/Y'),'date début is ok');
         $this->assertEquals($result->eq(2)->text(), $end->format('d/m/Y'),'date fin is ok');
         $this->assertEquals($result->eq(3)->text(),'hello','text info is ok');
+
+        $afterEnd = DateTime::createFromInterface($end)->modify('+1 day');
+        $crawler = $this->client->request('GET', sprintf('/holiday-info?start=%s', $afterEnd->format('d/m/Y')));
+        $rowCount = $crawler->filter('table > tbody > tr')->count();
+        $this->assertEquals(0, $rowCount);
+
+        $beforeStart = DateTime::createFromInterface($start)->modify('-1 day');
+        $crawler = $this->client->request('GET', sprintf('/holiday-info?end=%s', $beforeStart->format('d/m/Y')));
+        $rowCount = $crawler->filter('table > tbody > tr')->count();
+        $this->assertEquals(0, $rowCount);
+
+        $crawler = $this->client->request('GET', sprintf('/holiday-info?start=%s&end=%s', $start->format('d/m/Y'), $end->format('d/m/Y')));
+        $rowCount = $crawler->filter('table > tbody > tr')->count();
+        $this->assertEquals(1, $rowCount);
     }
 }

--- a/tests/Repository/HolidayRepositoryTest.php
+++ b/tests/Repository/HolidayRepositoryTest.php
@@ -199,6 +199,7 @@ class HolidayRepositoryTest extends TestCase
 
         $holiday = $repo->findOneBy(['perso_id' => $amy->getId()]);
         $originHoliday = $repo->find($originHolidayId);
+        $infoDate = (new \DateTime())->getTimestamp();
 
         $this->assertEquals(new \DateTime(date('Y-m-d') . ' 00:00:00'), $holiday->getStart());
         $this->assertEquals(new \DateTime(date('Y-m-d') . ' 00:00:00'), $holiday->getEnd());
@@ -211,7 +212,7 @@ class HolidayRepositoryTest extends TestCase
         $this->assertEquals($credits['conges_reliquat'], $holiday->getActualRemainder());
         $this->assertEquals($credits['conges_anticipation'], $holiday->getActualAnticipation());
         $this->assertEquals(999999999, $holiday->getInfo());
-        $this->assertEquals((new \DateTime())->getTimestamp(), $holiday->getInfoDate()->getTimestamp());
+        $this->assertEquals($infoDate, $holiday->getInfoDate()->getTimestamp());
     }
 
     public function testInsertWithUpdateWithoutOriginId(): void

--- a/translations/messages.en.po
+++ b/translations/messages.en.po
@@ -70,6 +70,9 @@ msgstr "Clear"
 msgid "Add"
 msgstr "Add"
 
+msgid "Edit"
+msgstr "Edit"
+
 msgid "Import"
 msgstr "Import"
 

--- a/translations/messages.fr.po
+++ b/translations/messages.fr.po
@@ -70,6 +70,9 @@ msgstr "Réinitialiser"
 msgid "Add"
 msgstr "Ajouter"
 
+msgid "Edit"
+msgstr "Editer"
+
 msgid "Import"
 msgstr "Importer"
 


### PR DESCRIPTION
and display the table even if there are no results

Follow up:
* Improve AbsenceInfoRepository
* Use BaseController::initDate
* Set correct times for start and end into AbsenceInfoRepository
* Fix AbsenceInfoRepository (now extends EntityRepository)
* Rework info repositories and controllers
  * Remove AbstractInfoRepository, duplicate findByDateRange instead
  * Fix BaseController::initDate for when input is empty or invalid
  * Do not use `setTime` on dates passed to the repository method as it modifies the original object, use explicit doctrine type instead to discard the time part
* Fix AdminInfoControllerTest
* Add reset route
* Clean templates