### PR TITLE
ajout d'une fonctionnalité de génération de planning

### DIFF
--- a/config/permissions.yaml
+++ b/config/permissions.yaml
@@ -257,6 +257,22 @@
     - 100
 "planning.hidden_tables.set":
     - 100
+"planning.expected_staff.set":
+    - 4
+"planning_generation.index":
+    - 4
+"planning_generation.json":
+    - 4
+"planning_generation.statistics":
+    - 4
+"planning_generation.active_tables":
+    - 4
+"planning_generation.generate":
+    - 4
+"planning_generation.status":
+    - 4
+"planning_generation.delete":
+    - 4
 "planning.notes":
     - 100
 "planning.notifications":

--- a/migrations/2026/Version20260811120000.php
+++ b/migrations/2026/Version20260811120000.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260811120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add agent fields used by the planning generation algorithm (quota_pct, quotas_postes, max_sp_journee_pct, pause_inter_listes_min)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $dbprefix = $_ENV['DATABASE_PREFIX'];
+
+        $this->addSql("ALTER TABLE `{$dbprefix}personnel` ADD COLUMN IF NOT EXISTS `quota_pct` FLOAT NULL DEFAULT NULL AFTER `heures_travail`;");
+        $this->addSql("ALTER TABLE `{$dbprefix}personnel` ADD COLUMN IF NOT EXISTS `quotas_postes` JSON NOT NULL DEFAULT '{}' AFTER `quota_pct`;");
+        $this->addSql("ALTER TABLE `{$dbprefix}personnel` ADD COLUMN IF NOT EXISTS `max_sp_journee_pct` FLOAT NULL DEFAULT NULL AFTER `quotas_postes`;");
+        $this->addSql("ALTER TABLE `{$dbprefix}personnel` ADD COLUMN IF NOT EXISTS `pause_inter_listes_min` INT NULL DEFAULT NULL AFTER `max_sp_journee_pct`;");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $dbprefix = $_ENV['DATABASE_PREFIX'];
+
+        $this->addSql("ALTER TABLE `{$dbprefix}personnel` DROP COLUMN IF EXISTS `quota_pct`;");
+        $this->addSql("ALTER TABLE `{$dbprefix}personnel` DROP COLUMN IF EXISTS `quotas_postes`;");
+        $this->addSql("ALTER TABLE `{$dbprefix}personnel` DROP COLUMN IF EXISTS `max_sp_journee_pct`;");
+        $this->addSql("ALTER TABLE `{$dbprefix}personnel` DROP COLUMN IF EXISTS `pause_inter_listes_min`;");
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+}

--- a/migrations/2026/Version20260811130000.php
+++ b/migrations/2026/Version20260811130000.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260811130000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create pl_poste_effectif_attendu table (expected staff per position/timeslot, used by the planning generation algorithm)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $dbprefix = $_ENV['DATABASE_PREFIX'];
+
+        $this->addSql("CREATE TABLE IF NOT EXISTS `{$dbprefix}pl_poste_effectif_attendu` (
+            `id` INT(11) NOT NULL AUTO_INCREMENT,
+            `numero` INT(11) NOT NULL,
+            `tableau` INT(11) NOT NULL,
+            `ligne` INT(11) NOT NULL,
+            `colonne` INT(11) NOT NULL,
+            `nb_attendu` INT(11) NOT NULL DEFAULT 1,
+            PRIMARY KEY (`id`),
+            UNIQUE KEY `numero_tableau_ligne_colonne` (`numero`, `tableau`, `ligne`, `colonne`))
+            ENGINE=MyISAM
+            DEFAULT CHARSET=utf8mb4
+            COLLATE=utf8mb4_unicode_ci;");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $dbprefix = $_ENV['DATABASE_PREFIX'];
+
+        $this->addSql("DROP TABLE IF EXISTS `{$dbprefix}pl_poste_effectif_attendu`;");
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+}

--- a/migrations/2026/Version20260811140000.php
+++ b/migrations/2026/Version20260811140000.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260811140000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create pl_generation_planning table and add the "Générer un planning" admin menu entry';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $dbprefix = $_ENV['DATABASE_PREFIX'];
+
+        $this->addSql("CREATE TABLE IF NOT EXISTS `{$dbprefix}pl_generation_planning` (
+            `id` INT(11) NOT NULL AUTO_INCREMENT,
+            `date_generation` DATETIME NOT NULL,
+            `date_debut` DATE NOT NULL,
+            `date_fin` DATE NOT NULL,
+            `site` INT(11) NULL DEFAULT NULL,
+            `json_envoye` JSON NOT NULL,
+            `json_recu` JSON NULL DEFAULT NULL,
+            `statut` VARCHAR(20) NOT NULL DEFAULT 'en_cours',
+            `created_by` INT(11) NULL DEFAULT NULL,
+            `error_message` TEXT NULL DEFAULT NULL,
+            PRIMARY KEY (`id`))
+            ENGINE=MyISAM
+            DEFAULT CHARSET=utf8mb4
+            COLLATE=utf8mb4_unicode_ci;");
+
+        $this->addSql("INSERT IGNORE INTO `{$dbprefix}menu` (`niveau1`, `niveau2`, `titre`, `url`, `condition`) VALUES (50, 95, 'Générer un planning', '/admin/planning-generation', NULL);");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $dbprefix = $_ENV['DATABASE_PREFIX'];
+
+        $this->addSql("DROP TABLE IF EXISTS `{$dbprefix}pl_generation_planning`;");
+        $this->addSql("DELETE FROM `{$dbprefix}menu` WHERE `url` = '/admin/planning-generation';");
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+}

--- a/migrations/2026/Version20260811150000.php
+++ b/migrations/2026/Version20260811150000.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260811150000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create messenger_messages table (Symfony Messenger Doctrine transport, used for the async planning generation)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $dbprefix = $_ENV['DATABASE_PREFIX'];
+
+        $this->addSql("CREATE TABLE IF NOT EXISTS `{$dbprefix}messenger_messages` (
+            `id` BIGINT(20) NOT NULL AUTO_INCREMENT,
+            `body` LONGTEXT NOT NULL,
+            `headers` LONGTEXT NOT NULL,
+            `queue_name` VARCHAR(190) NOT NULL,
+            `created_at` DATETIME NOT NULL COMMENT '(DC2Type:datetime_immutable)',
+            `available_at` DATETIME NOT NULL COMMENT '(DC2Type:datetime_immutable)',
+            `delivered_at` DATETIME DEFAULT NULL COMMENT '(DC2Type:datetime_immutable)',
+            PRIMARY KEY (`id`),
+            KEY `IDX_75EA56E0FB7336F0E3BD61CE16BA31DBBF396750` (`queue_name`, `available_at`, `delivered_at`, `id`))
+            ENGINE=InnoDB
+            DEFAULT CHARSET=utf8mb4
+            COLLATE=utf8mb4_unicode_ci;");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $dbprefix = $_ENV['DATABASE_PREFIX'];
+
+        $this->addSql("DROP TABLE IF EXISTS `{$dbprefix}messenger_messages`;");
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+}

--- a/migrations/2026/Version20260811150500.php
+++ b/migrations/2026/Version20260811150500.php
@@ -18,8 +18,8 @@ final class Version20260811150500 extends AbstractMigration
     {
         $dbprefix = $_ENV['DATABASE_PREFIX'];
 
-        $this->addSql("INSERT IGNORE INTO `{$dbprefix}config` (`nom`, `type`, `valeur`, `categorie`, `commentaires`, `technical`, `ordre`) VALUES ('PlanningGeneration-ApiUrl', 'text', '', 'Génération de planning', 'URL de l\'API externe de génération de planning', 1, '10');");
-        $this->addSql("INSERT IGNORE INTO `{$dbprefix}config` (`nom`, `type`, `valeur`, `categorie`, `commentaires`, `technical`, `ordre`) VALUES ('PlanningGeneration-ApiKey', 'text', '', 'Génération de planning', 'Clé d\'API (jeton Bearer) pour l\'API externe de génération de planning', 1, '20');");
+        $this->addSql("INSERT IGNORE INTO `{$dbprefix}config` (`nom`, `type`, `valeur`, `categorie`, `commentaires`, `technical`, `ordre`) VALUES ('PlanningGeneration-ApiUrl', 'text', 'https://algorithme-de-planification.onrender.com/', 'Génération de planning', 'URL de l\'API externe de génération de planning', 1, '10');");
+        $this->addSql("INSERT IGNORE INTO `{$dbprefix}config` (`nom`, `type`, `valeur`, `categorie`, `commentaires`, `technical`, `ordre`) VALUES ('PlanningGeneration-ApiKey', 'text', 'cle-test-1234', 'Génération de planning', 'Clé d\'API (jeton Bearer) pour l\'API externe de génération de planning', 1, '20');");
     }
 
     public function down(Schema $schema): void

--- a/migrations/2026/Version20260811150500.php
+++ b/migrations/2026/Version20260811150500.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260811150500 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add PlanningGeneration-ApiUrl and PlanningGeneration-ApiKey config options for the planning generation module';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $dbprefix = $_ENV['DATABASE_PREFIX'];
+
+        $this->addSql("INSERT IGNORE INTO `{$dbprefix}config` (`nom`, `type`, `valeur`, `categorie`, `commentaires`, `technical`, `ordre`) VALUES ('PlanningGeneration-ApiUrl', 'text', '', 'Génération de planning', 'URL de l\'API externe de génération de planning', 1, '10');");
+        $this->addSql("INSERT IGNORE INTO `{$dbprefix}config` (`nom`, `type`, `valeur`, `categorie`, `commentaires`, `technical`, `ordre`) VALUES ('PlanningGeneration-ApiKey', 'text', '', 'Génération de planning', 'Clé d\'API (jeton Bearer) pour l\'API externe de génération de planning', 1, '20');");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $dbprefix = $_ENV['DATABASE_PREFIX'];
+
+        $this->addSql("DELETE FROM `{$dbprefix}config` WHERE `nom` = 'PlanningGeneration-ApiUrl';");
+        $this->addSql("DELETE FROM `{$dbprefix}config` WHERE `nom` = 'PlanningGeneration-ApiKey';");
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+}

--- a/migrations/2026/Version20260812090000.php
+++ b/migrations/2026/Version20260812090000.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260812090000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create pl_poste_effectif_attendu_date table (per-date override of the expected staff for a position/timeslot)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $dbprefix = $_ENV['DATABASE_PREFIX'];
+
+        $this->addSql("CREATE TABLE IF NOT EXISTS `{$dbprefix}pl_poste_effectif_attendu_date` (
+            `id` INT(11) NOT NULL AUTO_INCREMENT,
+            `numero` INT(11) NOT NULL,
+            `tableau` INT(11) NOT NULL,
+            `ligne` INT(11) NOT NULL,
+            `colonne` INT(11) NOT NULL,
+            `date` DATE NOT NULL,
+            `nb_attendu` INT(11) NOT NULL DEFAULT 1,
+            PRIMARY KEY (`id`),
+            UNIQUE KEY `numero_tableau_ligne_colonne_date` (`numero`, `tableau`, `ligne`, `colonne`, `date`),
+            KEY `date` (`date`))
+            ENGINE=MyISAM
+            DEFAULT CHARSET=utf8mb4
+            COLLATE=utf8mb4_unicode_ci;");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $dbprefix = $_ENV['DATABASE_PREFIX'];
+
+        $this->addSql("DROP TABLE IF EXISTS `{$dbprefix}pl_poste_effectif_attendu_date`;");
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+}

--- a/migrations/2026/Version20260813090000.php
+++ b/migrations/2026/Version20260813090000.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260813090000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add conflicts column to pl_generation_planning (agents not imported due to an unavailability filed during generation)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $dbprefix = $_ENV['DATABASE_PREFIX'];
+
+        $this->addSql("ALTER TABLE `{$dbprefix}pl_generation_planning` ADD `conflicts` LONGTEXT DEFAULT NULL;");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $dbprefix = $_ENV['DATABASE_PREFIX'];
+
+        $this->addSql("ALTER TABLE `{$dbprefix}pl_generation_planning` DROP COLUMN `conflicts`;");
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+}

--- a/migrations/2026/Version20260814080000.php
+++ b/migrations/2026/Version20260814080000.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260814080000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add PlanningGeneration-ManualJson config option to enable/disable manual JSON generation';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $dbprefix = $_ENV['DATABASE_PREFIX'];
+
+        $this->addSql("INSERT IGNORE INTO `{$dbprefix}config` (`nom`, `type`, `valeur`, `categorie`, `commentaires`, `technical`, `ordre`) VALUES ('PlanningGeneration-ManualJson', 'boolean', '1', 'Génération de planning', 'Autoriser la génération de planning en collant un JSON personnalisé (sans passer par la génération automatique).', 1, '30');");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $dbprefix = $_ENV['DATABASE_PREFIX'];
+
+        $this->addSql("DELETE FROM `{$dbprefix}config` WHERE `nom` = 'PlanningGeneration-ManualJson';");
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+}

--- a/public/js/expected-staff.js
+++ b/public/js/expected-staff.js
@@ -1,0 +1,51 @@
+$(document).ready(function() {
+  $('#toggle-expected-staff').on('click', function() {
+    $('body').toggleClass('show-expected-staff');
+  });
+
+  $(document).on('click', '.expected-staff-badge', function() {
+    if (!$('body').hasClass('show-expected-staff') || $(this).find('input').length) {
+      return;
+    }
+
+    var badge = $(this);
+    var value = badge.text().trim();
+
+    badge.html('<input type="number" min="0" step="1" class="expected-staff-input" value="' + value + '" />');
+    var input = badge.find('input');
+    input.focus().select();
+
+    input.on('blur keydown', function(e) {
+      if (e.type === 'keydown' && e.key !== 'Enter') {
+        return;
+      }
+
+      var newValue = parseInt(input.val(), 10);
+      if (isNaN(newValue) || newValue < 0) {
+        newValue = parseInt(value, 10);
+      }
+
+      $.ajax({
+        url: url('planning/update-expected-staff'),
+        type: 'POST',
+        data: {
+          _token: $('input[name=_token]').val(),
+          CSRFToken: $('#CSRFSession').val(),
+          numero: badge.data('numero'),
+          tableau: badge.data('tableau'),
+          ligne: badge.data('ligne'),
+          colonne: badge.data('colonne'),
+          date: badge.data('date'),
+          nb_attendu: newValue
+        },
+        success: function(response) {
+          var result = JSON.parse(response);
+          badge.text(result.nb_attendu !== undefined ? result.nb_attendu : newValue);
+        },
+        error: function() {
+          badge.text(value);
+        }
+      });
+    });
+  });
+});

--- a/public/js/planning-generation.js
+++ b/public/js/planning-generation.js
@@ -1,0 +1,236 @@
+function generationFormatDateFr(isoDate) {
+  var parts = isoDate.split('-');
+  return parts[2] + '/' + parts[1] + '/' + parts[0];
+}
+
+function generationResetWizard() {
+  $('#generation-step-1, #generation-step-2, #generation-step-2b, #generation-step-3, #generation-step-manual').hide();
+  $('#generation-step-1').show();
+  $('#generation-next-1').show();
+  $('#generation-next-2').hide();
+  $('#generation-launch').hide();
+  $('#generation-launch-manual').hide();
+  $('#generation-step-3-content').empty();
+  $('#generation-manual-json').val('');
+}
+
+$(document).ready(function() {
+  $('#generer-planning-btn').on('click', function() {
+    generationResetWizard();
+    $('#generation-wizard-modal').modal('show');
+  });
+
+  $('#generation-next-1').on('click', function() {
+    var debut = $('#generation-date-debut').val();
+    var fin = $('#generation-date-fin').val();
+
+    if (!debut || !fin) {
+      stackAlert('Merci de renseigner les deux dates.', 'error');
+      return;
+    }
+
+    if (fin < debut) {
+      stackAlert('La date de fin doit être postérieure à la date de début.', 'error');
+      return;
+    }
+
+    $('#generation-step-2-range').text(generationFormatDateFr(debut) + ' - ' + generationFormatDateFr(fin));
+    $('#generation-step-1').hide();
+    $('#generation-step-2').show();
+    $('#generation-next-1').hide();
+    $('#generation-next-2').show();
+  });
+
+  $('#generation-next-2').on('click', function() {
+    $('#generation-step-2').hide();
+    $('#generation-step-2b').show();
+    $('#generation-next-2').hide();
+  });
+
+  $('#generation-mode-auto').on('click', function() {
+    var debut = $('#generation-date-debut').val();
+    var fin = $('#generation-date-fin').val();
+    var site = $('#generation-site').val();
+
+    $.ajax({
+      url: url('admin/planning-generation/active-tables'),
+      type: 'GET',
+      data: { date_debut: debut, date_fin: fin, site: site },
+      dataType: 'json',
+      success: function(tableaux) {
+        var content = $('#generation-step-3-content');
+        content.empty();
+
+        if (!tableaux.length) {
+          content.append('<p class="important">Aucun tableau actif trouvé sur cette période.</p>');
+        } else {
+          tableaux.forEach(function(tableau) {
+            var block = $('<div class="mb-3"></div>');
+            block.append('<h5>' + tableau.nom + '</h5>');
+            $.each(tableau.postes, function(posteId, posteNom) {
+              block.append(
+                '<div class="form-check">' +
+                '<input class="form-check-input generation-poste-check" type="checkbox" checked ' +
+                'data-numero="' + tableau.numero + '" data-poste-id="' + posteId + '" id="generation-poste-' + tableau.numero + '-' + posteId + '">' +
+                '<label class="form-check-label" for="generation-poste-' + tableau.numero + '-' + posteId + '">' + posteNom + '</label>' +
+                '</div>'
+              );
+            });
+            content.append(block);
+          });
+        }
+
+        $('#generation-step-2b').hide();
+        $('#generation-step-3').show();
+        $('#generation-launch').show();
+      },
+      error: function() {
+        stackAlert('Impossible de récupérer les tableaux actifs sur cette période.', 'error');
+      }
+    });
+  });
+
+  $('#generation-mode-manual').on('click', function() {
+    $('#generation-step-2b').hide();
+    $('#generation-step-manual').show();
+    $('#generation-launch-manual').show();
+  });
+
+  $('#generation-launch').on('click', function() {
+    var debut = $('#generation-date-debut').val();
+    var fin = $('#generation-date-fin').val();
+    var site = $('#generation-site').val();
+
+    var excluded = {};
+    $('.generation-poste-check:not(:checked)').each(function() {
+      var numero = $(this).data('numero');
+      var posteId = $(this).data('poste-id');
+      excluded[numero] = excluded[numero] || [];
+      excluded[numero].push(posteId);
+    });
+
+    $('#generation-launch').prop('disabled', true);
+
+    $.ajax({
+      url: url('admin/planning-generation/generate'),
+      type: 'POST',
+      data: {
+        _token: $('input[name="_token"]').val(),
+        CSRFToken: $('input[name="CSRFToken"]').val(),
+        date_debut: debut,
+        date_fin: fin,
+        site: site,
+        excluded_postes: JSON.stringify(excluded)
+      },
+      dataType: 'json',
+      success: function(result) {
+        if (result.error) {
+          stackAlert(result.error, 'error');
+          $('#generation-launch').prop('disabled', false);
+          return;
+        }
+        $('#generation-wizard-modal').modal('hide');
+        window.location.reload();
+      },
+      error: function(jqXHR) {
+        var message = 'Impossible de lancer la génération du planning.';
+        try {
+          var parsed = JSON.parse(jqXHR.responseText);
+          if (parsed.error) {
+            message = parsed.error;
+          }
+        } catch (e) {}
+        stackAlert(message, 'error');
+        $('#generation-launch').prop('disabled', false);
+      }
+    });
+  });
+
+  $('#generation-launch-manual').on('click', function() {
+    var debut = $('#generation-date-debut').val();
+    var fin = $('#generation-date-fin').val();
+    var site = $('#generation-site').val();
+    var manualJson = $('#generation-manual-json').val();
+
+    try {
+      JSON.parse(manualJson);
+    } catch (e) {
+      stackAlert('Le JSON saisi est invalide.', 'error');
+      return;
+    }
+
+    $('#generation-launch-manual').prop('disabled', true);
+
+    $.ajax({
+      url: url('admin/planning-generation/generate'),
+      type: 'POST',
+      data: {
+        _token: $('input[name="_token"]').val(),
+        CSRFToken: $('input[name="CSRFToken"]').val(),
+        date_debut: debut,
+        date_fin: fin,
+        site: site,
+        manual_json: manualJson
+      },
+      dataType: 'json',
+      success: function(result) {
+        if (result.error) {
+          stackAlert(result.error, 'error');
+          $('#generation-launch-manual').prop('disabled', false);
+          return;
+        }
+        $('#generation-wizard-modal').modal('hide');
+        window.location.reload();
+      },
+      error: function(jqXHR) {
+        var message = 'Impossible de lancer la génération du planning.';
+        try {
+          var parsed = JSON.parse(jqXHR.responseText);
+          if (parsed.error) {
+            message = parsed.error;
+          }
+        } catch (e) {}
+        stackAlert(message, 'error');
+        $('#generation-launch-manual').prop('disabled', false);
+      }
+    });
+  });
+
+  // Rafraîchit automatiquement la page tant qu'une génération est en cours,
+  // pour refléter le passage à "succès"/"échec" une fois le traitement asynchrone terminé.
+  if ($('.generation-status-en_cours').length) {
+    setTimeout(function() {
+      window.location.reload();
+    }, 5000);
+  }
+
+  $('.generation-delete-btn').on('click', function() {
+    var id = $(this).data('id');
+
+    if (!window.confirm('Voulez-vous vraiment supprimer ce planning généré ?')) {
+      return;
+    }
+
+    $.ajax({
+      url: url('admin/planning-generation/' + id),
+      type: 'DELETE',
+      data: {
+        _token: $('input[name="_token"]').val(),
+        CSRFToken: $('input[name="CSRFToken"]').val()
+      },
+      success: function() {
+        window.location.reload();
+      },
+      error: function(jqXHR) {
+        var message = 'Impossible de supprimer ce planning généré.';
+        try {
+          var parsed = JSON.parse(jqXHR.responseText);
+          if (parsed.error) {
+            message = parsed.error;
+          }
+        } catch (e) {}
+        stackAlert(message, 'error');
+      }
+    });
+  });
+});

--- a/public/js/planno-timepicker.js
+++ b/public/js/planno-timepicker.js
@@ -38,8 +38,10 @@ function timePickerChange(date, obj) {
     $(obj).val('');
     $(obj).focus();
   }
+
   if ($(obj).hasClass('checkdate')) {
     dateChange(obj);
+    validationStatusInvalidDisplay();
   }
 
   if ($(obj).hasClass('select')) {
@@ -77,7 +79,10 @@ function roundTimePiker(obj) {
   var times = time.split(':');
   var hours = parseInt(times[0]);
   var minutes = parseInt(times[1]);
-  var rounded = Math.round(minutes / tp.options.granularity) * tp.options.granularity;
+  // La granularité réelle (config admin) est relue directement plutôt que via tp.options.granularity,
+  // pour ne pas dépendre du pas d'affichage du menu déroulant (voir setTimePickerStep).
+  var granularity = parseInt($('form #granularity').val()) || 1;
+  var rounded = Math.round(minutes / granularity) * granularity;
 
   if (rounded == 60) {
     rounded = 0;
@@ -133,8 +138,10 @@ function formatHHmm(hour, minute) {
 }
 
 function setTimePickerStep(granularity) {
-  if (granularity == 1 || granularity == 15 || granularity == 5) {
-    return 30;
+  // "Libre" (1 minute) : un menu déroulant avec un choix par minute serait interminable (1440 entrées).
+  // On garde un pas d'affichage raisonnable ; la saisie manuelle, elle, reste libre à la minute près.
+  if (granularity == 1) {
+    return 15;
   }
 
   return granularity;

--- a/public/themes/default/default.css
+++ b/public/themes/default/default.css
@@ -2481,3 +2481,54 @@ table.dataTable th{
   }
 
 }
+
+.expected-staff-badge {
+  display: none;
+  vertical-align: top;
+  min-width: 16px;
+  margin: 2px;
+  padding: 0 3px;
+  border-radius: 8px;
+  background-color: var(--charcoal-blue);
+  color: white;
+  font-size: 0.7em;
+  text-align: center;
+  cursor: pointer;
+}
+
+body.show-expected-staff .expected-staff-badge {
+  display: inline-block;
+}
+
+.expected-staff-badge .expected-staff-input {
+  width: 30px;
+  font-size: 0.7em;
+}
+
+.generation-status-dot {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+}
+
+.generation-status-dot.generation-status-en_cours {
+  background-color: #2f6fd1;
+}
+
+.generation-status-dot.generation-status-succes {
+  background-color: #2e8b57;
+}
+
+.generation-status-dot.generation-status-echec {
+  background-color: #c0392b;
+}
+
+.generation-status-dot.generation-status-conflit {
+  background-color: #e67e22;
+}
+
+.generation-conflict-message {
+  color: #e67e22;
+  font-weight: bold;
+}

--- a/src/Controller/AgentController.php
+++ b/src/Controller/AgentController.php
@@ -10,6 +10,7 @@ use App\Entity\Agent;
 use App\Entity\Holiday;
 use App\Entity\Manager;
 use App\Entity\PlanningPosition;
+use App\Entity\Position;
 use App\Entity\SaturdayWorkingHours;
 use App\Entity\SelectCategories;
 use App\Entity\SelectStatus;
@@ -180,6 +181,9 @@ class AgentController extends BaseController
             $skillsAllWithName[] = [$elem->getName(), $elem->getId()];
             $skillsAll[] = $elem->getId();
         }
+
+        // Postes actifs, pour les quotas par poste de l'onglet "informations pour l'algorithme"
+        $positionsForAlgo = $this->entityManager->getRepository(Position::class)->findBy(['supprime' => null]);
 
         // Get all categories, services and statuses
         $categories = $this->entityManager->getRepository(SelectCategories::class)->findAll();
@@ -378,9 +382,13 @@ class AgentController extends BaseController
             }
         }
 
+        $canEditAlgoTab = in_array(4, $droits) || in_array(21, $droits);
+
         $this->templateParams([
             'agent'                     => $agent,
             'can_manage_agent'          => in_array(21, $droits),
+            'can_edit_algo_tab'         => $canEditAlgoTab,
+            'positions_algo'            => $positionsForAlgo,
             'exportIcsUrl'              => $exportIcsUrl,
             'action'                    => $action,
             'id'                        => $id,
@@ -693,6 +701,14 @@ class AgentController extends BaseController
         $agent->setHolidayAnticipation($holidays['conges_anticipation']);
         $agent->setHolidayCredit($holidays['conges_credit']);
         $agent->setHolidayRemainder($holidays['conges_reliquat']);
+
+        $droits = $GLOBALS['droits'] ?? [];
+        if (in_array(4, $droits) or in_array(21, $droits)) {
+            $agent->setAlgorithmQuota(isset($params['quota_pct']) && $params['quota_pct'] !== '' ? (float) $params['quota_pct'] : null);
+            $agent->setAlgorithmQuotasByPosition(isset($params['quotas_postes']) ? json_decode($params['quotas_postes'], true) : []);
+            $agent->setAlgorithmMaxDailyQuota(isset($params['max_sp_journee_pct']) && $params['max_sp_journee_pct'] !== '' ? (float) $params['max_sp_journee_pct'] : null);
+            $agent->setAlgorithmMinBreakBetweenLists(isset($params['pause_inter_listes_min']) && $params['pause_inter_listes_min'] !== '' ? (int) $params['pause_inter_listes_min'] : null);
+        }
 
         if ($login) {
             $agent->setLogin($login);

--- a/src/Controller/PlanningController.php
+++ b/src/Controller/PlanningController.php
@@ -7,6 +7,8 @@ use App\Entity\AbsenceReason;
 use App\Entity\Agent;
 use App\Entity\HiddenTables;
 use App\Entity\Model;
+use App\Entity\PlanningPositionExpectedStaff;
+use App\Entity\PlanningPositionExpectedStaffDate;
 use App\Entity\PlanningPositionHistory;
 use App\Entity\PlanningPositionLock;
 use App\Entity\Position;
@@ -40,6 +42,7 @@ class PlanningController extends BaseController
     private $absences = [];
     private $cellId = 0;
     private $cells = [];
+    private $expectedStaffOverrides = [];
     private $date;
     private $dates = [];
     private $locked = 0;
@@ -893,6 +896,74 @@ class PlanningController extends BaseController
     }
 
     /*
+     * Enregistre le nombre d'agents attendus pour un poste/créneau donné (module de génération de planning)
+     */
+    #[Route(path: '/planning/update-expected-staff', name: 'planning.expected_staff.set', methods: ['POST'])]
+    public function setExpectedStaff(Request $request): Response
+    {
+        if (!$this->csrf_protection($request)) {
+            return new Response(json_encode(['error' => 'The CSRF token is invalid. Please try to resubmit the form.']));
+        }
+
+        $droits_agent = $_SESSION['droits'];
+        if (!in_array(4, $droits_agent)) {
+            return new Response(json_encode(['error' => 'Access denied.']));
+        }
+
+        $numero = filter_var($request->get('numero'), FILTER_SANITIZE_NUMBER_INT);
+        $tableau = filter_var($request->get('tableau'), FILTER_SANITIZE_NUMBER_INT);
+        $ligne = filter_var($request->get('ligne'), FILTER_SANITIZE_NUMBER_INT);
+        $colonne = filter_var($request->get('colonne'), FILTER_SANITIZE_NUMBER_INT);
+        $nbAttendu = filter_var($request->get('nb_attendu'), FILTER_SANITIZE_NUMBER_INT);
+        $date = \DateTime::createFromFormat('Y-m-d', $request->get('date'));
+
+        if ($date) {
+            // Modification pour une date précise : n'affecte que cette date, sans toucher au gabarit récurrent
+            // du tableau (partagé par toutes les dates utilisant ce même sous-tableau/créneau).
+            $date->setTime(0, 0, 0);
+
+            $entity = $this->entityManager->getRepository(PlanningPositionExpectedStaffDate::class)->findOneBy([
+                'numero' => $numero,
+                'tableau' => $tableau,
+                'ligne' => $ligne,
+                'colonne' => $colonne,
+                'date' => $date,
+            ]);
+
+            if (!$entity) {
+                $entity = new PlanningPositionExpectedStaffDate();
+                $entity->setNumero($numero);
+                $entity->setTableau($tableau);
+                $entity->setLigne($ligne);
+                $entity->setColonne($colonne);
+                $entity->setDate($date);
+                $this->entityManager->persist($entity);
+            }
+        } else {
+            $entity = $this->entityManager->getRepository(PlanningPositionExpectedStaff::class)->findOneBy([
+                'numero' => $numero,
+                'tableau' => $tableau,
+                'ligne' => $ligne,
+                'colonne' => $colonne,
+            ]);
+
+            if (!$entity) {
+                $entity = new PlanningPositionExpectedStaff();
+                $entity->setNumero($numero);
+                $entity->setTableau($tableau);
+                $entity->setLigne($ligne);
+                $entity->setColonne($colonne);
+                $this->entityManager->persist($entity);
+            }
+        }
+
+        $entity->setExpectedStaff((int) $nbAttendu);
+        $this->entityManager->flush();
+
+        return new Response(json_encode(['nb_attendu' => $entity->getExpectedStaff()]));
+    }
+
+    /*
      * Enregistre dans la base de donées les notes en bas des plannings
      */
     #[Route(path: '/planning/notes', name: 'planning.notes', methods: ['POST'])]
@@ -1507,7 +1578,7 @@ class PlanningController extends BaseController
         }
     }
 
-    private function createCell($date, $debut, $fin, $colspan, $output, $poste, $site): string
+    private function createCell($date, $debut, $fin, $colspan, $output, $poste, $site, $numero = null, $tableau = null, $ligne = null, $colonne = null, $expectedStaff = null): string
     {
         $resultats=array();
         $classe=array();
@@ -1662,7 +1733,7 @@ class PlanningController extends BaseController
 
         $this->cellId++;
 
-        $cellule = "<td id='td{$this->cellId}' colspan='$colspan' style='text-align:center;' class='menuTrigger' oncontextmenu='cellule={$this->cellId}'
+        $cellule = "<td id='td{$this->cellId}' colspan='$colspan' class='menuTrigger text-center' oncontextmenu='cellule={$this->cellId}'
             data-start='$debut' data-end='$fin' data-situation='$poste' data-cell='{$this->cellId}' data-perso-id='0'>";
 
         for ($i=0;$i<count($resultats);$i++) {
@@ -1671,6 +1742,11 @@ class PlanningController extends BaseController
         }
 
         $cellule .= '<a class="pl-icon arrow-right" role="button"></a>';
+
+        if ($numero !== null) {
+            $cellule .= "<span class='expected-staff-badge' data-numero='$numero' data-tableau='$tableau' data-ligne='$ligne' data-colonne='$colonne' data-date='$date'>" . ($expectedStaff ?? 1) . "</span>";
+        }
+
         $cellule .= "</td>\n";
 
         return $cellule;
@@ -1748,6 +1824,11 @@ class PlanningController extends BaseController
 
         $hiddenTables = $this->getHiddenTables($request, $tab);
 
+        // Cadre (numero), utilisé pour adresser les effectifs attendus. $tab est réutilisé juste après pour désigner le sous-tableau courant.
+        $numero = $tab;
+
+        $this->getExpectedStaffOverrides($numero, $date);
+
         // Positions
         $positions = $this->positions;
 
@@ -1813,7 +1894,7 @@ class PlanningController extends BaseController
             $masqueTableaux = null;
             if ($this->config('Planning-TableauxMasques')) {
                 // FIXME HTML
-                $masqueTableaux = "<span title='Masquer' class='pl-icon pl-icon-hide masqueTableau pointer noprint' data-id='$l' ></span>";
+                $masqueTableaux = "<span title='Masquer' class='pl-icon pl-icon-hide masqueTableau pointer d-print-none' data-id='$l' ></span>";
             }
             $tabs[$index]['masqueTableaux'] = $masqueTableaux;
 
@@ -1892,7 +1973,9 @@ class PlanningController extends BaseController
 
                         // function createCell(date,debut,fin,colspan,affichage,poste,site)
                         else {
-                            $horaires['position_cell'] = $this->createCell($date, $horaires['debut'], $horaires['fin'], nb30($horaires['debut'], $horaires['fin']), 'noms', $ligne['poste'], $site);
+                            $overrideKey = "{$tab['nom']}_{$ligne['ligne']}_{$k}";
+                            $expectedStaff = $this->expectedStaffOverrides[$overrideKey] ?? ($tab['effectifs_attendus']["{$ligne['ligne']}_{$k}"] ?? null);
+                            $horaires['position_cell'] = $this->createCell($date, $horaires['debut'], $horaires['fin'], nb30($horaires['debut'], $horaires['fin']), 'noms', $ligne['poste'], $site, $numero, $tab['nom'], $ligne['ligne'], $k, $expectedStaff);
                         }
                         $i++;
                         $k++;
@@ -1987,7 +2070,7 @@ class PlanningController extends BaseController
             $nonValidee = null;
             if ($this->config('Absences-non-validees') == 1) {
                 if ($elem['valide'] > 0) {
-                    $bold = 'bold';
+                    $bold = 'fw-bold';
                 } else {
                     $nonValidee = " (non validée)";
                 }
@@ -2072,6 +2155,25 @@ class PlanningController extends BaseController
         }
 
         $this->cells = $cellules;
+    }
+
+    /*
+     * Charge les surcharges ponctuelles (par date) de l'effectif attendu pour le cadre affiché, afin
+     * qu'une modification sur une date précise n'affecte pas les autres dates partageant le même
+     * sous-tableau/créneau récurrent (voir pl_poste_effectif_attendu_date).
+     */
+    private function getExpectedStaffOverrides($numero, $date): void
+    {
+        $overrides = $this->entityManager->getRepository(PlanningPositionExpectedStaffDate::class)->findBy([
+            'numero' => $numero,
+            'date' => \DateTime::createFromFormat('Y-m-d', $date),
+        ]);
+
+        $this->expectedStaffOverrides = [];
+        foreach ($overrides as $override) {
+            $key = "{$override->getTableau()}_{$override->getLigne()}_{$override->getColonne()}";
+            $this->expectedStaffOverrides[$key] = $override->getExpectedStaff();
+        }
     }
 
     private function getCurrentFramework($date, $site)

--- a/src/Controller/PlanningController.php
+++ b/src/Controller/PlanningController.php
@@ -1973,9 +1973,16 @@ class PlanningController extends BaseController
 
                         // function createCell(date,debut,fin,colspan,affichage,poste,site)
                         else {
-                            $overrideKey = "{$tab['nom']}_{$ligne['ligne']}_{$k}";
-                            $expectedStaff = $this->expectedStaffOverrides[$overrideKey] ?? ($tab['effectifs_attendus']["{$ligne['ligne']}_{$k}"] ?? null);
-                            $horaires['position_cell'] = $this->createCell($date, $horaires['debut'], $horaires['fin'], nb30($horaires['debut'], $horaires['fin']), 'noms', $ligne['poste'], $site, $numero, $tab['nom'], $ligne['ligne'], $k, $expectedStaff);
+                            // Cellule grisée ponctuellement pour cette date précise (import de modèle, "bataille navale"),
+                            // par opposition au grisage statique du gabarit (cellules_grises) déjà géré ci-dessus.
+                            // Comme pour ce dernier, aucune pastille d'effectif attendu n'est affichée dans ce cas.
+                            if ($this->isCellGreyedForDate($ligne['poste'], $horaires['debut'], $horaires['fin'])) {
+                                $horaires['position_cell'] = $this->createCell($date, $horaires['debut'], $horaires['fin'], nb30($horaires['debut'], $horaires['fin']), 'noms', $ligne['poste'], $site);
+                            } else {
+                                $overrideKey = "{$tab['nom']}_{$ligne['ligne']}_{$k}";
+                                $expectedStaff = $this->expectedStaffOverrides[$overrideKey] ?? ($tab['effectifs_attendus']["{$ligne['ligne']}_{$k}"] ?? null);
+                                $horaires['position_cell'] = $this->createCell($date, $horaires['debut'], $horaires['fin'], nb30($horaires['debut'], $horaires['fin']), 'noms', $ligne['poste'], $site, $numero, $tab['nom'], $ligne['ligne'], $k, $expectedStaff);
+                            }
                         }
                         $i++;
                         $k++;
@@ -2174,6 +2181,21 @@ class PlanningController extends BaseController
             $key = "{$override->getTableau()}_{$override->getLigne()}_{$override->getColonne()}";
             $this->expectedStaffOverrides[$key] = $override->getExpectedStaff();
         }
+    }
+
+    /**
+     * Grisage ponctuel d'une cellule poste/créneau pour la date affichée (pl_poste.grise), par opposition
+     * au grisage statique du gabarit (pl_poste_cellules). $this->cells est déjà chargé par getCells().
+     */
+    private function isCellGreyedForDate($poste, $debut, $fin): bool
+    {
+        foreach ($this->cells as $elem) {
+            if ($elem['poste'] == $poste and $elem['debut'] == $debut and $elem['fin'] == $fin and !empty($elem['grise'])) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function getCurrentFramework($date, $site)

--- a/src/Controller/PlanningGenerationController.php
+++ b/src/Controller/PlanningGenerationController.php
@@ -1,0 +1,313 @@
+<?php
+
+namespace App\Controller;
+
+use App\Controller\BaseController;
+
+use App\Entity\Agent;
+use App\Entity\PlanningGenerationJob;
+use App\Entity\PlanningPositionLines;
+use App\Entity\PlanningPositionTab;
+use App\Entity\PlanningPositionTabAffectation;
+use App\Entity\Position;
+use App\Message\GeneratePlanningMessage;
+use App\Planno\PlanningGenerationPayloadBuilder;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Routing\Annotation\Route;
+
+class PlanningGenerationController extends BaseController
+{
+    #[Route('/admin/planning-generation', name: 'planning_generation.index', methods: ['GET'])]
+    public function index(Request $request)
+    {
+        $jobs = $this->entityManager->getRepository(PlanningGenerationJob::class)
+            ->findBy([], ['date_generation' => 'DESC']);
+
+        $sites = [];
+        $nbSites = $this->config('Multisites-nombre');
+        if ($nbSites > 1) {
+            for ($i = 1; $i <= $nbSites; $i++) {
+                if (!empty($this->config('Multisites-site' . $i))) {
+                    $sites[] = ['id' => $i, 'nom' => $this->config('Multisites-site' . $i)];
+                }
+            }
+        } else {
+            $sites[] = ['id' => 1, 'nom' => null];
+        }
+
+        $hasOngoingJob = $this->entityManager->getRepository(PlanningGenerationJob::class)
+            ->findOneBy(['statut' => PlanningGenerationJob::STATUT_EN_COURS]) !== null;
+
+        $this->templateParams([
+            'jobs' => $jobs,
+            'sites' => $sites,
+            'has_ongoing_job' => $hasOngoingJob,
+            'manual_json_enabled' => !empty($this->config('PlanningGeneration-ManualJson')),
+            'CSRFSession' => $GLOBALS['CSRFSession'],
+        ]);
+
+        return $this->output('planning-generation/index.html.twig');
+    }
+
+    #[Route('/admin/planning-generation/{id<\d+>}/json/{type<sent|received>}', name: 'planning_generation.json', methods: ['GET'])]
+    public function viewJson(Request $request, int $id, string $type): Response
+    {
+        $job = $this->entityManager->getRepository(PlanningGenerationJob::class)->find($id);
+
+        if (!$job) {
+            return new Response('Not found', 404);
+        }
+
+        $data = $type === 'sent' ? $job->getJsonEnvoye() : $job->getJsonRecu();
+
+        return new Response(json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE), 200, ['Content-Type' => 'application/json; charset=utf-8']);
+    }
+
+    #[Route('/admin/planning-generation/{id<\d+>}/statistics', name: 'planning_generation.statistics', methods: ['GET'])]
+    public function statistics(int $id): Response
+    {
+        $job = $this->entityManager->getRepository(PlanningGenerationJob::class)->find($id);
+
+        if (!$job) {
+            return new Response('Not found', 404);
+        }
+
+        $jsonRecu = $job->getJsonRecu();
+        $statistiques = $jsonRecu['optimise']['statistiques'] ?? null;
+
+        if ($statistiques) {
+            $statistiques = $this->resolveAgentNames($statistiques);
+        }
+
+        $this->templateParams([
+            'job' => $job,
+            'statistiques' => $statistiques,
+            'conflict_message' => $this->buildConflictMessage($job->getConflicts()),
+            'error_message' => $job->getErrorMessage(),
+        ]);
+
+        return $this->output('planning-generation/statistics.html.twig');
+    }
+
+    /**
+     * Construit le message signalant les agents non importés faute de disponibilité (voir
+     * GeneratePlanningMessageHandler::hasUnavailability), avec accord singulier/pluriel.
+     */
+    private function buildConflictMessage(?array $conflicts): ?string
+    {
+        if (!$conflicts) {
+            return null;
+        }
+
+        $agentNames = array_values(array_unique(array_column($conflicts, 'agent')));
+        $posteDescriptions = array_values(array_unique(array_map(
+            fn ($c) => "{$c['poste']} ({$c['date']} {$c['debut']}-{$c['fin']})",
+            $conflicts
+        )));
+
+        $multipleAgents = count($agentNames) > 1;
+        $multiplePostes = count($posteDescriptions) > 1;
+
+        $agentLabel = ($multipleAgents ? 'Les agents ' : "L'agent ") . implode(', ', $agentNames);
+        $verbe = $multipleAgents ? "n'ont" : "n'a";
+        $participe = $multipleAgents ? 'placés' : 'placé';
+        $posteLabel = ($multiplePostes ? 'les postes ' : 'le poste ') . implode(', ', $posteDescriptions);
+
+        return "$agentLabel $verbe pas pu être $participe sur $posteLabel car une indisponibilité a été déposée pendant la génération du planning.";
+    }
+
+    /**
+     * Les agents sont envoyés à l'algorithme sous forme d'id (et non de login) pour les anonymiser ;
+     * cette méthode reconvertit ces ids en noms lisibles pour l'affichage des statistiques.
+     */
+    private function resolveAgentNames(array $statistiques): array
+    {
+        $agentName = function (string $id) {
+            if (!ctype_digit($id)) {
+                return $id;
+            }
+
+            $agent = $this->entityManager->getRepository(Agent::class)->find((int) $id);
+
+            if (!$agent) {
+                return $id;
+            }
+
+            $name = trim($agent->getFirstname() . ' ' . $agent->getLastname());
+
+            return $name ?: $agent->getLogin();
+        };
+
+        foreach ($statistiques['agents'] ?? [] as $key => $agentStats) {
+            if (isset($agentStats['nom_agent'])) {
+                $statistiques['agents'][$key]['agent_id'] = $agentStats['nom_agent'];
+                $statistiques['agents'][$key]['nom_agent'] = $agentName((string) $agentStats['nom_agent']);
+            }
+        }
+
+        foreach ($statistiques['equilibre']['agents_exclus'] ?? [] as $key => $excludedId) {
+            $statistiques['equilibre']['agents_exclus'][$key] = $agentName((string) $excludedId);
+        }
+
+        return $statistiques;
+    }
+
+    #[Route('/admin/planning-generation/active-tables', name: 'planning_generation.active_tables', methods: ['GET'])]
+    public function activeTables(Request $request): Response
+    {
+        $dateDebut = $request->get('date_debut');
+        $dateFin = $request->get('date_fin');
+        $site = $request->get('site');
+
+        if (!$dateDebut || !$dateFin) {
+            return new Response(json_encode(['error' => 'date_debut et date_fin sont requis']), 400, ['Content-Type' => 'application/json; charset=utf-8']);
+        }
+
+        $qb = $this->entityManager->createQueryBuilder();
+        $qb->select('a')
+            ->from(PlanningPositionTabAffectation::class, 'a')
+            ->andWhere('a.date >= :debut')
+            ->andWhere('a.date <= :fin')
+            ->setParameter('debut', $dateDebut)
+            ->setParameter('fin', $dateFin);
+
+        if ($site) {
+            $qb->andWhere('a.site = :site')->setParameter('site', $site);
+        }
+
+        $affectations = $qb->getQuery()->getResult();
+
+        $cadres = [];
+        foreach ($affectations as $affectation) {
+            $cadres[$affectation->getTable()] = true;
+        }
+
+        $result = [];
+        foreach (array_keys($cadres) as $numero) {
+            $tab = $this->entityManager->getRepository(PlanningPositionTab::class)->findOneBy(['tableau' => $numero]);
+
+            $lignes = $this->entityManager->getRepository(PlanningPositionLines::class)->findBy([
+                'numero' => $numero,
+                'type' => 'poste',
+            ]);
+
+            $postes = [];
+            foreach ($lignes as $ligne) {
+                if (!$ligne->getPosition()) {
+                    continue;
+                }
+                $position = $this->entityManager->getRepository(Position::class)->find($ligne->getPosition());
+                if ($position) {
+                    $postes[$position->getId()] = $position->getName();
+                }
+            }
+
+            $result[] = [
+                'numero' => $numero,
+                'nom' => $tab ? $tab->getName() : "Tableau $numero",
+                'postes' => $postes,
+            ];
+        }
+
+        return new Response(json_encode($result), 200, ['Content-Type' => 'application/json; charset=utf-8']);
+    }
+
+    #[Route('/admin/planning-generation/generate', name: 'planning_generation.generate', methods: ['POST'])]
+    public function generate(Request $request, MessageBusInterface $messageBus): Response
+    {
+        if (!$this->csrf_protection($request)) {
+            return new Response(json_encode(['error' => 'The CSRF token is invalid. Please try to resubmit the form.']));
+        }
+
+        $ongoingJob = $this->entityManager->getRepository(PlanningGenerationJob::class)
+            ->findOneBy(['statut' => PlanningGenerationJob::STATUT_EN_COURS]);
+
+        if ($ongoingJob) {
+            return new Response(json_encode(['error' => 'Une génération de planning est déjà en cours. Merci d\'attendre qu\'elle se termine avant d\'en lancer une nouvelle.']), 409, ['Content-Type' => 'application/json; charset=utf-8']);
+        }
+
+        $dateDebut = \DateTime::createFromFormat('Y-m-d', $request->get('date_debut'));
+        $dateFin = \DateTime::createFromFormat('Y-m-d', $request->get('date_fin'));
+        $site = $request->get('site') ? (int) $request->get('site') : null;
+        $manualJson = $request->get('manual_json');
+
+        if (!$dateDebut || !$dateFin) {
+            return new Response(json_encode(['error' => 'Dates invalides']), 400, ['Content-Type' => 'application/json; charset=utf-8']);
+        }
+
+        // createFromFormat('Y-m-d', ...) conserve l'heure courante du serveur au lieu de minuit,
+        // ce qui fausse les comparaisons avec les dates de fin (minuit) stockées en base.
+        $dateDebut->setTime(0, 0, 0);
+        $dateFin->setTime(0, 0, 0);
+
+        if ($manualJson !== null && $manualJson !== '') {
+            if (empty($this->config('PlanningGeneration-ManualJson'))) {
+                return new Response(json_encode(['error' => 'La génération via un JSON personnalisé est désactivée (Configuration technique > Génération de planning).']), 403, ['Content-Type' => 'application/json; charset=utf-8']);
+            }
+
+            $payload = json_decode($manualJson, true);
+            if (json_last_error() !== JSON_ERROR_NONE || !is_array($payload)) {
+                return new Response(json_encode(['error' => 'Le JSON fourni est invalide.']), 400, ['Content-Type' => 'application/json; charset=utf-8']);
+            }
+        } else {
+            $excluded = json_decode($request->get('excluded_postes', '{}'), true) ?: [];
+            $payloadBuilder = new PlanningGenerationPayloadBuilder($this->entityManager);
+            $payload = $payloadBuilder->build($dateDebut, $dateFin, $site, $excluded);
+        }
+
+        $job = new PlanningGenerationJob();
+        $job->setDateGeneration(new \DateTime());
+        $job->setDateDebut($dateDebut);
+        $job->setDateFin($dateFin);
+        $job->setSite($site);
+        $job->setJsonEnvoye($payload);
+        $job->setStatut(PlanningGenerationJob::STATUT_EN_COURS);
+        $job->setCreatedBy($_SESSION['login_id'] ?? null);
+
+        $this->entityManager->persist($job);
+        $this->entityManager->flush();
+
+        $messageBus->dispatch(new GeneratePlanningMessage($job->getId()));
+
+        return new Response(json_encode(['id' => $job->getId()]), 200, ['Content-Type' => 'application/json; charset=utf-8']);
+    }
+
+    #[Route('/admin/planning-generation/{id<\d+>}', name: 'planning_generation.delete', methods: ['DELETE'])]
+    public function delete(Request $request, int $id): Response
+    {
+        if (!$this->csrf_protection($request)) {
+            return new Response(json_encode(['error' => 'The CSRF token is invalid. Please try to resubmit the form.']));
+        }
+
+        $job = $this->entityManager->getRepository(PlanningGenerationJob::class)->find($id);
+
+        if (!$job) {
+            return new Response(json_encode(['error' => 'Not found']), 404, ['Content-Type' => 'application/json; charset=utf-8']);
+        }
+
+        if ($job->getStatut() === PlanningGenerationJob::STATUT_EN_COURS) {
+            return new Response(json_encode(['error' => 'Impossible de supprimer une génération en cours.']), 409, ['Content-Type' => 'application/json; charset=utf-8']);
+        }
+
+        $this->entityManager->remove($job);
+        $this->entityManager->flush();
+
+        return new Response(json_encode(['ok' => true]), 200, ['Content-Type' => 'application/json; charset=utf-8']);
+    }
+
+    #[Route('/admin/planning-generation/status', name: 'planning_generation.status', methods: ['GET'])]
+    public function status(Request $request): Response
+    {
+        $jobs = $this->entityManager->getRepository(PlanningGenerationJob::class)->findAll();
+
+        $result = [];
+        foreach ($jobs as $job) {
+            $result[$job->getId()] = $job->getStatut();
+        }
+
+        return new Response(json_encode($result), 200, ['Content-Type' => 'application/json; charset=utf-8']);
+    }
+}

--- a/src/Entity/Agent.php
+++ b/src/Entity/Agent.php
@@ -72,6 +72,18 @@ class Agent
     #[ORM\Column]
     private ?float $heures_travail = 0;
 
+    #[ORM\Column(nullable: true)]
+    private ?float $quota_pct = null;
+
+    #[ORM\Column]
+    private ?array $quotas_postes = [];
+
+    #[ORM\Column(nullable: true)]
+    private ?float $max_sp_journee_pct = null;
+
+    #[ORM\Column(nullable: true)]
+    private ?int $pause_inter_listes_min = null;
+
     #[ORM\Column]
     private ?array $sites = [];
 
@@ -419,6 +431,54 @@ class Agent
     public function setWeeklyWorkingHours(?float $weeklyWorkingHours): static
     {
         $this->heures_travail = $weeklyWorkingHours;
+
+        return $this;
+    }
+
+    public function getAlgorithmQuota(): ?float
+    {
+        return $this->quota_pct;
+    }
+
+    public function setAlgorithmQuota(?float $quota): static
+    {
+        $this->quota_pct = $quota;
+
+        return $this;
+    }
+
+    public function getAlgorithmQuotasByPosition(): ?array
+    {
+        return $this->quotas_postes;
+    }
+
+    public function setAlgorithmQuotasByPosition(?array $quotasByPosition): static
+    {
+        $this->quotas_postes = $quotasByPosition;
+
+        return $this;
+    }
+
+    public function getAlgorithmMaxDailyQuota(): ?float
+    {
+        return $this->max_sp_journee_pct;
+    }
+
+    public function setAlgorithmMaxDailyQuota(?float $maxDailyQuota): static
+    {
+        $this->max_sp_journee_pct = $maxDailyQuota;
+
+        return $this;
+    }
+
+    public function getAlgorithmMinBreakBetweenLists(): ?int
+    {
+        return $this->pause_inter_listes_min;
+    }
+
+    public function setAlgorithmMinBreakBetweenLists(?int $minBreak): static
+    {
+        $this->pause_inter_listes_min = $minBreak;
 
         return $this;
     }

--- a/src/Entity/PlanningGenerationJob.php
+++ b/src/Entity/PlanningGenerationJob.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\PlanningGenerationJobRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: PlanningGenerationJobRepository::class)]
+#[ORM\Table(name: 'pl_generation_planning')]
+class PlanningGenerationJob
+{
+    public const STATUT_EN_COURS = 'en_cours';
+    public const STATUT_SUCCES = 'succes';
+    public const STATUT_ECHEC = 'echec';
+    public const STATUT_CONFLIT = 'conflit';
+
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column(type: Types::DATETIME_MUTABLE)]
+    private ?\DateTime $date_generation = null;
+
+    #[ORM\Column(type: Types::DATE_MUTABLE)]
+    private ?\DateTime $date_debut = null;
+
+    #[ORM\Column(type: Types::DATE_MUTABLE)]
+    private ?\DateTime $date_fin = null;
+
+    #[ORM\Column(nullable: true)]
+    private ?int $site = null;
+
+    #[ORM\Column]
+    private ?array $json_envoye = [];
+
+    #[ORM\Column(nullable: true)]
+    private ?array $json_recu = null;
+
+    /**
+     * Affectations reçues de l'algorithme mais non importées car l'agent a déposé une indisponibilité
+     * (absence/congé/récupération) qui chevauche le créneau, entre l'envoi du JSON et la réception de la réponse.
+     */
+    #[ORM\Column(nullable: true)]
+    private ?array $conflicts = null;
+
+    #[ORM\Column(length: 20)]
+    private ?string $statut = self::STATUT_EN_COURS;
+
+    #[ORM\Column(nullable: true)]
+    private ?int $created_by = null;
+
+    #[ORM\Column(type: Types::TEXT, nullable: true)]
+    private ?string $error_message = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getDateGeneration(): ?\DateTime
+    {
+        return $this->date_generation;
+    }
+
+    public function setDateGeneration(?\DateTime $dateGeneration): static
+    {
+        $this->date_generation = $dateGeneration;
+
+        return $this;
+    }
+
+    public function getDateDebut(): ?\DateTime
+    {
+        return $this->date_debut;
+    }
+
+    public function setDateDebut(?\DateTime $dateDebut): static
+    {
+        $this->date_debut = $dateDebut;
+
+        return $this;
+    }
+
+    public function getDateFin(): ?\DateTime
+    {
+        return $this->date_fin;
+    }
+
+    public function setDateFin(?\DateTime $dateFin): static
+    {
+        $this->date_fin = $dateFin;
+
+        return $this;
+    }
+
+    public function getSite(): ?int
+    {
+        return $this->site;
+    }
+
+    public function setSite(?int $site): static
+    {
+        $this->site = $site;
+
+        return $this;
+    }
+
+    public function getJsonEnvoye(): ?array
+    {
+        return $this->json_envoye;
+    }
+
+    public function setJsonEnvoye(?array $jsonEnvoye): static
+    {
+        $this->json_envoye = $jsonEnvoye;
+
+        return $this;
+    }
+
+    public function getJsonRecu(): ?array
+    {
+        return $this->json_recu;
+    }
+
+    public function setJsonRecu(?array $jsonRecu): static
+    {
+        $this->json_recu = $jsonRecu;
+
+        return $this;
+    }
+
+    public function getConflicts(): ?array
+    {
+        return $this->conflicts;
+    }
+
+    public function setConflicts(?array $conflicts): static
+    {
+        $this->conflicts = $conflicts;
+
+        return $this;
+    }
+
+    public function getStatut(): ?string
+    {
+        return $this->statut;
+    }
+
+    public function setStatut(?string $statut): static
+    {
+        $this->statut = $statut;
+
+        return $this;
+    }
+
+    public function getCreatedBy(): ?int
+    {
+        return $this->created_by;
+    }
+
+    public function setCreatedBy(?int $createdBy): static
+    {
+        $this->created_by = $createdBy;
+
+        return $this;
+    }
+
+    public function getErrorMessage(): ?string
+    {
+        return $this->error_message;
+    }
+
+    public function setErrorMessage(?string $errorMessage): static
+    {
+        $this->error_message = $errorMessage;
+
+        return $this;
+    }
+}

--- a/src/Entity/PlanningPositionExpectedStaff.php
+++ b/src/Entity/PlanningPositionExpectedStaff.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'pl_poste_effectif_attendu')]
+class PlanningPositionExpectedStaff
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column]
+    private ?int $numero = null;
+
+    #[ORM\Column]
+    private ?int $tableau = null;
+
+    #[ORM\Column]
+    private ?int $ligne = null;
+
+    #[ORM\Column]
+    private ?int $colonne = null;
+
+    #[ORM\Column]
+    private ?int $nb_attendu = 1;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getNumero(): ?int
+    {
+        return $this->numero;
+    }
+
+    public function setNumero(?int $numero): static
+    {
+        $this->numero = $numero;
+
+        return $this;
+    }
+
+    public function getTableau(): ?int
+    {
+        return $this->tableau;
+    }
+
+    public function setTableau(?int $tableau): static
+    {
+        $this->tableau = $tableau;
+
+        return $this;
+    }
+
+    public function getLigne(): ?int
+    {
+        return $this->ligne;
+    }
+
+    public function setLigne(?int $ligne): static
+    {
+        $this->ligne = $ligne;
+
+        return $this;
+    }
+
+    public function getColonne(): ?int
+    {
+        return $this->colonne;
+    }
+
+    public function setColonne(?int $colonne): static
+    {
+        $this->colonne = $colonne;
+
+        return $this;
+    }
+
+    public function getExpectedStaff(): ?int
+    {
+        return $this->nb_attendu;
+    }
+
+    public function setExpectedStaff(?int $expectedStaff): static
+    {
+        $this->nb_attendu = $expectedStaff;
+
+        return $this;
+    }
+}

--- a/src/Entity/PlanningPositionExpectedStaffDate.php
+++ b/src/Entity/PlanningPositionExpectedStaffDate.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'pl_poste_effectif_attendu_date')]
+class PlanningPositionExpectedStaffDate
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column]
+    private ?int $numero = null;
+
+    #[ORM\Column]
+    private ?int $tableau = null;
+
+    #[ORM\Column]
+    private ?int $ligne = null;
+
+    #[ORM\Column]
+    private ?int $colonne = null;
+
+    #[ORM\Column(type: 'date')]
+    private ?\DateTimeInterface $date = null;
+
+    #[ORM\Column]
+    private ?int $nb_attendu = 1;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getNumero(): ?int
+    {
+        return $this->numero;
+    }
+
+    public function setNumero(?int $numero): static
+    {
+        $this->numero = $numero;
+
+        return $this;
+    }
+
+    public function getTableau(): ?int
+    {
+        return $this->tableau;
+    }
+
+    public function setTableau(?int $tableau): static
+    {
+        $this->tableau = $tableau;
+
+        return $this;
+    }
+
+    public function getLigne(): ?int
+    {
+        return $this->ligne;
+    }
+
+    public function setLigne(?int $ligne): static
+    {
+        $this->ligne = $ligne;
+
+        return $this;
+    }
+
+    public function getColonne(): ?int
+    {
+        return $this->colonne;
+    }
+
+    public function setColonne(?int $colonne): static
+    {
+        $this->colonne = $colonne;
+
+        return $this;
+    }
+
+    public function getDate(): ?\DateTimeInterface
+    {
+        return $this->date;
+    }
+
+    public function setDate(?\DateTimeInterface $date): static
+    {
+        $this->date = $date;
+
+        return $this;
+    }
+
+    public function getExpectedStaff(): ?int
+    {
+        return $this->nb_attendu;
+    }
+
+    public function setExpectedStaff(?int $expectedStaff): static
+    {
+        $this->nb_attendu = $expectedStaff;
+
+        return $this;
+    }
+}

--- a/src/Message/GeneratePlanningMessage.php
+++ b/src/Message/GeneratePlanningMessage.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Message;
+
+class GeneratePlanningMessage
+{
+    public function __construct(private readonly int $jobId)
+    {
+    }
+
+    public function getJobId(): int
+    {
+        return $this->jobId;
+    }
+}

--- a/src/MessageHandler/GeneratePlanningMessageHandler.php
+++ b/src/MessageHandler/GeneratePlanningMessageHandler.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace App\MessageHandler;
+
+use App\Entity\Absence;
+use App\Entity\Agent;
+use App\Entity\Holiday;
+use App\Entity\PlanningGenerationJob;
+use App\Entity\PlanningPosition;
+use App\Entity\Position;
+use App\Message\GeneratePlanningMessage;
+use App\Planno\PlanningGenerationClient;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler]
+class GeneratePlanningMessageHandler
+{
+    use \App\Traits\LoggerTrait;
+
+    public function __construct(private readonly EntityManagerInterface $entityManager)
+    {
+    }
+
+    public function __invoke(GeneratePlanningMessage $message): void
+    {
+        $job = $this->entityManager->getRepository(PlanningGenerationJob::class)->find($message->getJobId());
+
+        if (!$job) {
+            return;
+        }
+
+        $config = $this->entityManager->getRepository(\App\Entity\Config::class)->getAll();
+        $client = new PlanningGenerationClient($config['PlanningGeneration-ApiUrl'] ?? null, $config['PlanningGeneration-ApiKey'] ?? null);
+
+        try {
+            $response = $client->send($job->getJsonEnvoye());
+        } catch (\Exception $e) {
+            $job->setStatut(PlanningGenerationJob::STATUT_ECHEC);
+            $job->setErrorMessage($e->getMessage());
+            $this->entityManager->flush();
+
+            return;
+        }
+
+        $job->setJsonRecu($response);
+
+        if (($response['statut'] ?? null) !== 'succès' && ($response['statut'] ?? null) !== 'succes') {
+            $job->setStatut(PlanningGenerationJob::STATUT_ECHEC);
+            $job->setErrorMessage('L\'API a répondu avec un statut différent de succès.');
+            $this->entityManager->flush();
+
+            return;
+        }
+
+        $conflicts = $this->importPlanning($response, $job->getSite());
+
+        $job->setStatut($conflicts ? PlanningGenerationJob::STATUT_CONFLIT : PlanningGenerationJob::STATUT_SUCCES);
+        $job->setConflicts($conflicts ?: null);
+        $this->entityManager->flush();
+    }
+
+    /**
+     * Importe les affectations reçues, à l'exception de celles pour lesquelles l'agent a déposé une
+     * indisponibilité (absence/congé/récupération) chevauchant le créneau depuis l'envoi du JSON à
+     * l'algorithme (l'algorithme a travaillé sur une version désormais périmée des disponibilités).
+     * Ces affectations en conflit ne sont pas importées ; elles sont retournées pour être signalées.
+     *
+     * @return array<int, array{agent: string, poste: string, date: string, debut: string, fin: string}>
+     */
+    private function importPlanning(array $response, ?int $site): array
+    {
+        $creneaux = $response['optimise']['planning']['creneaux'] ?? [];
+        $conflicts = [];
+
+        foreach ($creneaux as $creneau) {
+            $date = \DateTime::createFromFormat('d/m/Y', $creneau['date']);
+            $debut = \DateTime::createFromFormat('H:i', $creneau['debut']);
+            $fin = \DateTime::createFromFormat('H:i', $creneau['fin']);
+
+            if (!$date || !$debut || !$fin) {
+                continue;
+            }
+
+            foreach ($creneau['postes'] ?? [] as $posteName => $posteData) {
+                foreach ($posteData['agents_postes'] ?? [] as $assignment) {
+                    // Les affectations déjà existantes (bloque=true) ont été envoyées telles quelles, pas besoin de les réécrire.
+                    if (!empty($assignment['bloque'])) {
+                        continue;
+                    }
+
+                    $position = $this->entityManager->getRepository(Position::class)->findOneBy(['nom' => $posteName]);
+                    $agent = ctype_digit((string) $assignment['nom']) ? $this->entityManager->getRepository(Agent::class)->find((int) $assignment['nom']) : null;
+
+                    if (!$position || !$agent) {
+                        $this->log("Import planning généré : poste ou agent introuvable ($posteName / {$assignment['nom']})", 'PlanningGeneration');
+                        continue;
+                    }
+
+                    if ($this->hasUnavailability($agent, $date, $debut, $fin)) {
+                        $conflicts[] = [
+                            'agent' => trim($agent->getFirstname() . ' ' . $agent->getLastname()) ?: $agent->getLogin(),
+                            'poste' => $posteName,
+                            'date' => $creneau['date'],
+                            'debut' => $creneau['debut'],
+                            'fin' => $creneau['fin'],
+                        ];
+                        continue;
+                    }
+
+                    $planningPosition = new PlanningPosition();
+                    $planningPosition->setDate(clone $date);
+                    $planningPosition->setPosition($position->getId());
+                    $planningPosition->setStart(clone $debut);
+                    $planningPosition->setEnd(clone $fin);
+                    $planningPosition->setUser($agent->getId());
+                    $planningPosition->setAbsent(0);
+                    $planningPosition->setDelete(false);
+                    $planningPosition->setGrey(false);
+                    $planningPosition->setSite($site ?? 1);
+
+                    $this->entityManager->persist($planningPosition);
+                }
+            }
+        }
+
+        return $conflicts;
+    }
+
+    /**
+     * Vérifie si l'agent a déposé une absence ou un congé/récupération validé (ou en attente de validation,
+     * cf. PlanningGenerationPayloadBuilder::buildIndisponibilites) qui chevauche le créneau [date debut-fin].
+     */
+    private function hasUnavailability(Agent $agent, \DateTime $date, \DateTime $debut, \DateTime $fin): bool
+    {
+        $creneauDebut = (clone $date)->setTime((int) $debut->format('H'), (int) $debut->format('i'));
+        $creneauFin = (clone $date)->setTime((int) $fin->format('H'), (int) $fin->format('i'));
+
+        $absence = $this->entityManager->createQueryBuilder()
+            ->select('a')->from(Absence::class, 'a')
+            ->andWhere('a.perso_id = :agent')
+            ->andWhere('a.debut < :fin')
+            ->andWhere('a.fin > :debut')
+            ->andWhere('a.valide > 0')
+            ->setParameter('agent', $agent->getId())
+            ->setParameter('debut', $creneauDebut)
+            ->setParameter('fin', $creneauFin)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        if ($absence) {
+            return true;
+        }
+
+        if (empty($GLOBALS['config']['Conges-Enable'])) {
+            return false;
+        }
+
+        $conge = $this->entityManager->createQueryBuilder()
+            ->select('h')->from(Holiday::class, 'h')
+            ->andWhere('h.perso_id = :agent')
+            ->andWhere('h.debut < :fin')
+            ->andWhere('h.fin > :debut')
+            ->andWhere('h.valide >= 0')
+            ->andWhere('h.valide_n1 >= 0')
+            ->andWhere('h.information = 0')
+            ->andWhere('h.supprime = 0')
+            ->setParameter('agent', $agent->getId())
+            ->setParameter('debut', $creneauDebut)
+            ->setParameter('fin', $creneauFin)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $conge !== null;
+    }
+}

--- a/src/Planno/PlanningGenerationClient.php
+++ b/src/Planno/PlanningGenerationClient.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Planno;
+
+use Unirest\Request;
+
+class PlanningGenerationClient
+{
+    private $url;
+    private $apiKey;
+
+    public function __construct(?string $url, ?string $apiKey = null)
+    {
+        $this->url = $url;
+        $this->apiKey = $apiKey;
+    }
+
+    /**
+     * Envoie le payload à l'API de génération de planning et retourne la réponse décodée.
+     * Lève une exception si l'appel échoue ou si la réponse n'est pas un JSON valide.
+     */
+    public function send(array $payload): array
+    {
+        if (empty($this->url)) {
+            throw new \RuntimeException('L\'URL de l\'API de génération de planning n\'est pas configurée (PlanningGeneration-ApiUrl).');
+        }
+
+        $headers = ['Content-Type' => 'application/json'];
+        if (!empty($this->apiKey)) {
+            $headers['X-API-Key'] = $this->apiKey;
+        }
+
+        Request::timeout(120);
+
+        $endpoint = rtrim($this->url, '/') . '/generer-planning';
+
+        try {
+            $response = Request::post($endpoint, $headers, json_encode($payload));
+        } catch (\Exception $e) {
+            throw new \RuntimeException('Erreur lors de l\'appel à l\'API de génération de planning : ' . $e->getMessage());
+        }
+
+        if (!$response or $response->code < 200 or $response->code >= 300) {
+            $code = $response ? $response->code : 'aucune réponse';
+            $body = $response ? (is_string($response->body) ? $response->body : json_encode($response->body)) : '';
+            throw new \RuntimeException("Réponse invalide de l'API de génération de planning (code: $code) : $body");
+        }
+
+        $decoded = is_array($response->body) ? $response->body : json_decode(json_encode($response->body), true);
+
+        if (!is_array($decoded)) {
+            throw new \RuntimeException('La réponse de l\'API de génération de planning n\'est pas un JSON valide.');
+        }
+
+        return $decoded;
+    }
+}

--- a/src/Planno/PlanningGenerationPayloadBuilder.php
+++ b/src/Planno/PlanningGenerationPayloadBuilder.php
@@ -90,8 +90,11 @@ class PlanningGenerationPayloadBuilder
                             }
 
                             // Une cellule grisée signifie que ce poste n'est pas à pourvoir sur ce créneau,
-                            // quel que soit l'effectif attendu configuré par ailleurs.
-                            if (in_array("{$ligne['ligne']}_{$colonne}", $sousTableau['cellules_grises'])) {
+                            // quel que soit l'effectif attendu configuré par ailleurs. Deux mécanismes de
+                            // grisage existent : statique au gabarit (cellules_grises) et ponctuel pour cette
+                            // date précise (pl_poste.grise, ex: import de modèle, "bataille navale").
+                            if (in_array("{$ligne['ligne']}_{$colonne}", $sousTableau['cellules_grises'])
+                                || $this->isCellGreyedForDate($current, (int) $ligne['poste'], $horaire['debut'], $horaire['fin'], $site)) {
                                 $attendu = 0;
                             } else {
                                 $overrideKey = "{$sousTableauId}_{$ligne['ligne']}_{$colonne}";
@@ -150,6 +153,31 @@ class PlanningGenerationPayloadBuilder
         }
 
         return $overrides;
+    }
+
+    /**
+     * Grisage ponctuel d'une cellule poste/créneau pour la date précise (pl_poste.grise), par opposition
+     * au grisage statique du gabarit (pl_poste_cellules) déjà géré via $sousTableau['cellules_grises'].
+     */
+    private function isCellGreyedForDate(\DateTime $date, int $posteId, string $debut, string $fin, ?int $site): bool
+    {
+        $qb = $this->entityManager->createQueryBuilder();
+        $qb->select('p')->from(PlanningPosition::class, 'p')
+            ->andWhere('p.date = :date')
+            ->andWhere('p.poste = :poste')
+            ->andWhere('p.debut = :debut')
+            ->andWhere('p.fin = :fin')
+            ->andWhere('p.grise = 1')
+            ->andWhere('p.supprime = 0 OR p.supprime IS NULL')
+            ->setParameter('date', $date->format('Y-m-d'))
+            ->setParameter('poste', $posteId)
+            ->setParameter('debut', \DateTime::createFromFormat('H:i:s', $debut))
+            ->setParameter('fin', \DateTime::createFromFormat('H:i:s', $fin));
+        if ($site) {
+            $qb->andWhere('p.site = :site')->setParameter('site', $site);
+        }
+
+        return $qb->getQuery()->getOneOrNullResult() !== null;
     }
 
     private function getExistingAssignments(\DateTime $date, int $posteId, string $debut, string $fin, ?int $site): array

--- a/src/Planno/PlanningGenerationPayloadBuilder.php
+++ b/src/Planno/PlanningGenerationPayloadBuilder.php
@@ -1,0 +1,461 @@
+<?php
+
+namespace App\Planno;
+
+use App\Entity\Absence;
+use App\Entity\Agent;
+use App\Entity\Holiday;
+use App\Entity\PlanningPosition;
+use App\Entity\PlanningPositionExpectedStaffDate;
+use App\Entity\PlanningPositionTab;
+use App\Entity\PlanningPositionTabAffectation;
+use App\Entity\Position;
+use App\Entity\WorkingHour;
+use App\Planno\Helper\HourHelper;
+use Doctrine\ORM\EntityManagerInterface;
+
+require_once(__DIR__ . '/../../legacy/Common/function.php');
+
+class PlanningGenerationPayloadBuilder
+{
+    private const JOURS_FR = ['lundi', 'mardi', 'mercredi', 'jeudi', 'vendredi', 'samedi', 'dimanche'];
+
+    // Motifs d'absence considérés comme des congés (le reste est classé "absence").
+    private const MOTIFS_CONGE = ['congés payés', 'maladie', 'congé paternité', 'congé maternité'];
+
+    public function __construct(private readonly EntityManagerInterface $entityManager)
+    {
+    }
+
+    /**
+     * @param array<int, int[]> $excludedPostesByNumero Map cadre (numero) => liste des ids de postes exclus
+     */
+    public function build(\DateTime $dateDebut, \DateTime $dateFin, ?int $site, array $excludedPostesByNumero = []): array
+    {
+        $creneaux = $this->buildCreneaux($dateDebut, $dateFin, $site, $excludedPostesByNumero);
+        $agents = $this->buildAgents($dateDebut, $dateFin, $site);
+
+        return [
+            'creneaux' => $creneaux,
+            'agents' => $agents,
+        ];
+    }
+
+    private function buildCreneaux(\DateTime $dateDebut, \DateTime $dateFin, ?int $site, array $excludedPostesByNumero): array
+    {
+        $creneaux = [];
+        $positionNames = [];
+
+        $current = clone $dateDebut;
+        while ($current <= $dateFin) {
+            $qb = $this->entityManager->createQueryBuilder();
+            $qb->select('a')->from(PlanningPositionTabAffectation::class, 'a')
+                ->andWhere('a.date = :date')
+                ->setParameter('date', $current->format('Y-m-d'));
+            if ($site) {
+                $qb->andWhere('a.site = :site')->setParameter('site', $site);
+            }
+            $affectation = $qb->getQuery()->getOneOrNullResult();
+
+            if ($affectation) {
+                $numero = $affectation->getTable();
+                $excluded = $excludedPostesByNumero[$numero] ?? [];
+                $overrides = $this->getExpectedStaffOverrides($numero, $current);
+
+                $framework = new Framework();
+                $framework->id = $numero;
+                $framework->get();
+
+                $planningTab = $this->entityManager->getRepository(PlanningPositionTab::class)->findOneBy(['tableau' => $numero]);
+
+                foreach ($framework->elements as $sousTableauId => $sousTableau) {
+                    $nomTableau = $sousTableau['titre'] ?: ($planningTab ? $planningTab->getName() : "Tableau $sousTableauId");
+
+                    foreach ($sousTableau['horaires'] as $idx => $horaire) {
+                        $colonne = $idx + 1;
+                        $postesData = [];
+
+                        foreach ($sousTableau['lignes'] as $ligne) {
+                            if ($ligne['type'] !== 'poste' || !$ligne['poste'] || in_array($ligne['poste'], $excluded)) {
+                                continue;
+                            }
+
+                            if (!isset($positionNames[$ligne['poste']])) {
+                                $position = $this->entityManager->getRepository(Position::class)->find($ligne['poste']);
+                                $positionNames[$ligne['poste']] = $position ? $position->getName() : null;
+                            }
+                            $posteName = $positionNames[$ligne['poste']];
+                            if (!$posteName) {
+                                continue;
+                            }
+
+                            // Une cellule grisée signifie que ce poste n'est pas à pourvoir sur ce créneau,
+                            // quel que soit l'effectif attendu configuré par ailleurs.
+                            if (in_array("{$ligne['ligne']}_{$colonne}", $sousTableau['cellules_grises'])) {
+                                $attendu = 0;
+                            } else {
+                                $overrideKey = "{$sousTableauId}_{$ligne['ligne']}_{$colonne}";
+                                $attendu = $overrides[$overrideKey] ?? ($sousTableau['effectifs_attendus']["{$ligne['ligne']}_{$colonne}"] ?? 1);
+                            }
+
+                            $postesData[$posteName] = [
+                                'attendu' => (int) $attendu,
+                                'agents_postes' => $this->getExistingAssignments($current, (int) $ligne['poste'], $horaire['debut'], $horaire['fin'], $site),
+                            ];
+                        }
+
+                        if (empty($postesData)) {
+                            continue;
+                        }
+
+                        $creneaux[] = [
+                            'nom_tableau' => $nomTableau,
+                            'date' => $current->format('d/m/Y'),
+                            'jour' => self::JOURS_FR[(int) $current->format('N') - 1],
+                            'id_creneau' => (string) $colonne,
+                            'debut' => substr($horaire['debut'], 0, 5),
+                            'fin' => substr($horaire['fin'], 0, 5),
+                            'postes' => $postesData,
+                        ];
+                    }
+                }
+            }
+
+            $current->modify('+1 day');
+        }
+
+        return $creneaux;
+    }
+
+    /**
+     * Surcharges ponctuelles (par date) de l'effectif attendu pour le cadre $numero, indexées par
+     * "sousTableau_ligne_colonne". Une entrée présente ici est prioritaire sur le gabarit récurrent
+     * du tableau (voir pl_poste_effectif_attendu_date).
+     *
+     * @return array<string, int>
+     */
+    private function getExpectedStaffOverrides(int $numero, \DateTime $date): array
+    {
+        $qb = $this->entityManager->createQueryBuilder();
+        $qb->select('o')->from(PlanningPositionExpectedStaffDate::class, 'o')
+            ->andWhere('o.numero = :numero')
+            ->andWhere('o.date = :date')
+            ->setParameter('numero', $numero)
+            ->setParameter('date', $date->format('Y-m-d'));
+
+        $overrides = [];
+        foreach ($qb->getQuery()->getResult() as $override) {
+            $key = "{$override->getTableau()}_{$override->getLigne()}_{$override->getColonne()}";
+            $overrides[$key] = $override->getExpectedStaff();
+        }
+
+        return $overrides;
+    }
+
+    private function getExistingAssignments(\DateTime $date, int $posteId, string $debut, string $fin, ?int $site): array
+    {
+        $qb = $this->entityManager->createQueryBuilder();
+        $qb->select('p')->from(PlanningPosition::class, 'p')
+            ->andWhere('p.date = :date')
+            ->andWhere('p.poste = :poste')
+            ->andWhere('p.debut < :fin')
+            ->andWhere('p.fin > :debut')
+            ->andWhere('p.supprime = 0 OR p.supprime IS NULL')
+            ->andWhere('p.perso_id IS NOT NULL')
+            ->andWhere('p.perso_id > 0')
+            ->setParameter('date', $date->format('Y-m-d'))
+            ->setParameter('poste', $posteId)
+            ->setParameter('debut', \DateTime::createFromFormat('H:i:s', $debut))
+            ->setParameter('fin', \DateTime::createFromFormat('H:i:s', $fin));
+        if ($site) {
+            $qb->andWhere('p.site = :site')->setParameter('site', $site);
+        }
+
+        $assignments = [];
+        foreach ($qb->getQuery()->getResult() as $planningPosition) {
+            $agent = $this->entityManager->getRepository(Agent::class)->find($planningPosition->getUser());
+            if ($agent) {
+                // L'id (et non le login) est envoyé à l'algorithme pour anonymiser les agents ;
+                // GeneratePlanningMessageHandler reconvertit cet id en agent à la réception de la réponse.
+                $assignments[] = ['nom' => (string) $agent->getId(), 'bloque' => true];
+            }
+        }
+
+        return $assignments;
+    }
+
+    /**
+     * PHP ne distingue pas tableau vide et objet vide : json_encode([]) produit "[]", pas "{}".
+     * L'API attend un objet (dictionnaire) pour quotas_postes/indisponibilites même quand ils sont vides.
+     */
+    private function asJsonObject(array $value): array|\stdClass
+    {
+        return empty($value) ? new \stdClass() : $value;
+    }
+
+    private function buildAgents(\DateTime $dateDebut, \DateTime $dateFin, ?int $site): array
+    {
+        $qb = $this->entityManager->createQueryBuilder();
+        $qb->select('a')->from(Agent::class, 'a')
+            ->andWhere("a.actif = 'Actif'")
+            ->andWhere('a.depart IS NULL OR a.depart >= :debut')
+            ->andWhere('a.id > 2') // Exclut les comptes techniques "admin" (1) et "Tout le monde" (2)
+            ->setParameter('debut', $dateDebut);
+
+        $agents = $qb->getQuery()->getResult();
+        $positionNames = [];
+
+        $result = [];
+        foreach ($agents as $agent) {
+            $emploiDuTemps = $this->buildEmploiDuTemps($agent, $dateDebut, $dateFin, $site);
+
+            // Un agent sans aucun jour disponible sur la période (aucun jour ne correspond à la
+            // bibliothèque demandée, ou aucun horaire déclaré du tout) n'est pas envoyé à l'algorithme.
+            if (empty($emploiDuTemps)) {
+                continue;
+            }
+
+            $quotasPostes = [];
+            foreach ((array) $agent->getAlgorithmQuotasByPosition() as $posteId => $quota) {
+                if (!isset($positionNames[$posteId])) {
+                    $position = $this->entityManager->getRepository(Position::class)->find($posteId);
+                    $positionNames[$posteId] = $position ? $position->getName() : null;
+                }
+                if ($positionNames[$posteId]) {
+                    $quotasPostes[$positionNames[$posteId]] = (float) $quota;
+                }
+            }
+
+            $result[] = [
+                // L'id (et non le login) est envoyé à l'algorithme pour anonymiser les agents ;
+                // GeneratePlanningMessageHandler reconvertit cet id en agent à la réception de la réponse.
+                'nom_agent' => (string) $agent->getId(),
+                'quota_pct' => $agent->getAlgorithmQuota() ?? 0,
+                'max_sp_journee_pct' => $agent->getAlgorithmMaxDailyQuota() ?? 0,
+                'quotas_postes' => $this->asJsonObject($quotasPostes),
+                'emploi_du_temps' => $emploiDuTemps,
+                'indisponibilites' => $this->asJsonObject($this->buildIndisponibilites($agent, $dateDebut, $dateFin, $site)),
+                'pause_inter_listes_min' => $agent->getAlgorithmMinBreakBetweenLists() ?? 0,
+            ];
+        }
+
+        return $result;
+    }
+
+    /**
+     * Construit l'emploi du temps déclaré par l'agent (menu "Mon compte" > "Mes heures de présence")
+     * sur la période demandée. Si plusieurs emplois du temps se chevauchent sur la période (l'agent a
+     * changé d'horaires, ou a une exception ponctuelle), chaque date est résolue avec l'enregistrement
+     * qui la couvre spécifiquement.
+     *
+     * L'appartenance à une bibliothèque n'est pas déterminée par la fiche agent, mais par le site déclaré
+     * pour chaque jour dans l'emploi du temps : un jour déclaré pour une autre bibliothèque que celle
+     * demandée est simplement absent du résultat pour cette date (l'agent peut rester présent les autres
+     * jours). Seul un jour explicitement déclaré "Tout site" (-1) échappe à ce filtre ; un jour sans site
+     * défini du tout (ni bibliothèque précise, ni "Tout site") est exclu, quelle que soit la bibliothèque
+     * demandée, car son rattachement est indéterminé.
+     */
+    private function buildEmploiDuTemps(Agent $agent, \DateTime $dateDebut, \DateTime $dateFin, ?int $site): array
+    {
+        $emploiDuTemps = [];
+        $current = clone $dateDebut;
+
+        while ($current <= $dateFin) {
+            $periodes = $this->getPeriodsForDate($agent, $current, $site);
+
+            if (!empty($periodes)) {
+                $emploiDuTemps[$current->format('d/m/Y')] = $periodes;
+            }
+
+            $current->modify('+1 day');
+        }
+
+        return $emploiDuTemps;
+    }
+
+    /**
+     * Résout les horaires de travail déclarés par l'agent pour une date précise (voir buildEmploiDuTemps
+     * pour la gestion des chevauchements d'emplois du temps et du filtrage par site). Réutilisé pour
+     * calculer l'emploi du temps affiché et pour recadrer les congés sur les heures réellement travaillées.
+     */
+    private function getPeriodsForDate(Agent $agent, \DateTime $date, ?int $site): array
+    {
+        $records = $this->entityManager->getRepository(WorkingHour::class)
+            ->get($date->format('Y-m-d'), $date->format('Y-m-d'), true, $agent->getId());
+
+        // En cas de chevauchement, une exception (ponctuelle) est prioritaire sur le planning qu'elle remplace.
+        usort($records, fn ($a, $b) => $b->getException() <=> $a->getException());
+
+        foreach ($records as $candidate) {
+            if ($candidate->getStart() > $date || $candidate->getEnd() < $date) {
+                continue;
+            }
+
+            $jourIndex = (new \datePl($date->format('Y-m-d'), $candidate->getNumberOfWeeks()))
+                ->planning_day_index_for($agent->getId());
+
+            $jour = $candidate->getWorkingHours()[$jourIndex] ?? null;
+            $jourSite = $jour[4] ?? null;
+            $jourEstTousSites = $jourSite !== null && $jourSite !== '' && (int) $jourSite === -1;
+            $jourEstSiteNonDefini = $jourSite === null || $jourSite === '';
+            $jourExclu = $site && !$jourEstTousSites && ($jourEstSiteNonDefini || (int) $jourSite !== $site);
+
+            if ($jourExclu) {
+                return [];
+            }
+
+            return $this->extractPeriods($jour, $candidate->getBreaktime()[$jourIndex] ?? null);
+        }
+
+        return [];
+    }
+
+    /**
+     * Reprend la logique d'extraction des créneaux de App\Command\WorkingHourExportCommand, complétée par
+     * la gestion du "temps de pause" (durée) utilisé quand la pause n'est pas déclarée avec une heure de
+     * début et de fin explicites (option "pause libre").
+     */
+    private function extractPeriods(?array $jour, $breaktime = null): array
+    {
+        if (!$jour) {
+            return [];
+        }
+
+        $periodes = [];
+
+        // Pause explicite (heure de début et de fin de pause déclarées) : matinée puis après-midi.
+        if (!empty($jour[0]) and !empty($jour[1])) {
+            $periodes[] = ['debut' => substr($jour[0], 0, 5), 'fin' => substr($jour[1], 0, 5)];
+        }
+        if (!empty($jour[2]) and !empty($jour[3]) and empty($jour[5] ?? null)) {
+            $periodes[] = ['debut' => substr($jour[2], 0, 5), 'fin' => substr($jour[3], 0, 5)];
+        }
+
+        // Deux pauses explicites dans la journée.
+        if (!empty($jour[2]) and !empty($jour[5] ?? null)) {
+            $periodes[] = ['debut' => substr($jour[2], 0, 5), 'fin' => substr($jour[5], 0, 5)];
+            $periodes[] = ['debut' => substr($jour[6], 0, 5), 'fin' => substr($jour[3], 0, 5)];
+        }
+
+        // Journée continue : aucune heure de début/fin de pause déclarée.
+        if (!empty($jour[0]) and empty($jour[2]) and empty($jour[5] ?? null) and !empty($jour[3])) {
+            $periode = ['debut' => substr($jour[0], 0, 5), 'fin' => substr($jour[3], 0, 5)];
+
+            // Si un temps de pause (durée) est déclaré séparément (option "pause libre"), on l'ajoute au créneau.
+            if (!empty($breaktime)) {
+                $periode['temps de pause'] = str_replace('h', ':', HourHelper::decimalToHoursMinutes($breaktime)['as_string']);
+            }
+
+            $periodes[] = $periode;
+        }
+
+        return $periodes;
+    }
+
+    /**
+     * Construit les indisponibilités (absences + congés + récupérations) de l'agent sur la période.
+     *
+     * - "absence" : notée telle quelle (une seule plage par jour couvert), sans recadrage particulier.
+     * - "congé" (motif de congé reconnu, ou entrée du module congés/récupérations) : recadré sur les
+     *   heures réellement travaillées ce jour-là, en évitant la pause de l'agent — un congé qui englobe
+     *   la pause est donc scindé en autant de plages que de périodes de travail qu'il recouvre.
+     */
+    private function buildIndisponibilites(Agent $agent, \DateTime $dateDebut, \DateTime $dateFin, ?int $site): array
+    {
+        $indisponibilites = [];
+
+        $qb = $this->entityManager->createQueryBuilder();
+        $qb->select('a')->from(Absence::class, 'a')
+            ->andWhere('a.perso_id = :agent')
+            ->andWhere('a.debut <= :fin')
+            ->andWhere('a.fin >= :debut')
+            ->andWhere('a.valide > 0')
+            ->setParameter('agent', $agent->getId())
+            ->setParameter('debut', $dateDebut->format('Y-m-d 00:00:00'))
+            ->setParameter('fin', $dateFin->format('Y-m-d 23:59:59'));
+
+        foreach ($qb->getQuery()->getResult() as $absence) {
+            $type = $this->estMotifDeConge($absence->getReason()) ? 'congé' : 'absence';
+            $this->addIndisponibilite($indisponibilites, $agent, $dateDebut, $dateFin, $absence->getStart(), $absence->getEnd(), $type, $site);
+        }
+
+        if (!empty($GLOBALS['config']['Conges-Enable'])) {
+            $qb = $this->entityManager->createQueryBuilder();
+            $qb->select('h')->from(Holiday::class, 'h')
+                ->andWhere('h.perso_id = :agent')
+                ->andWhere('h.debut <= :fin')
+                ->andWhere('h.fin >= :debut')
+                // Inclut les congés/récupérations en attente de validation ; seuls les refusés (valide(_n1) < 0) sont exclus.
+                ->andWhere('h.valide >= 0')
+                ->andWhere('h.valide_n1 >= 0')
+                ->andWhere('h.information = 0')
+                ->andWhere('h.supprime = 0')
+                ->setParameter('agent', $agent->getId())
+                ->setParameter('debut', $dateDebut->format('Y-m-d 00:00:00'))
+                ->setParameter('fin', $dateFin->format('Y-m-d 23:59:59'));
+
+            foreach ($qb->getQuery()->getResult() as $conge) {
+                $this->addIndisponibilite($indisponibilites, $agent, $dateDebut, $dateFin, $conge->getStart(), $conge->getEnd(), 'congé', $site);
+            }
+        }
+
+        return $indisponibilites;
+    }
+
+    private function estMotifDeConge(?string $motif): bool
+    {
+        if (!$motif) {
+            return false;
+        }
+
+        return in_array(mb_strtolower(trim($motif)), self::MOTIFS_CONGE, true);
+    }
+
+    /**
+     * Découpe [debut, fin] jour par jour sur l'intersection avec [dateDebut, dateFin], puis ajoute une ou
+     * plusieurs plages horaires par jour dans $indisponibilites selon le type :
+     * - "absence" : la plage du jour est ajoutée telle quelle.
+     * - "congé" : la plage du jour est recadrée sur les périodes de travail réelles de l'agent (ce qui
+     *   exclut de fait sa pause), et ignorée si elle ne recouvre aucune période travaillée ce jour-là.
+     */
+    private function addIndisponibilite(array &$indisponibilites, Agent $agent, \DateTime $dateDebut, \DateTime $dateFin, \DateTime $debut, \DateTime $fin, string $type, ?int $site): void
+    {
+        $current = max(clone $dateDebut, $debut);
+        $end = min((clone $dateFin)->setTime(23, 59, 59), $fin);
+
+        while ($current <= $end) {
+            $dayStart = $current->format('Y-m-d') === $debut->format('Y-m-d') ? $debut->format('H:i') : '00:00';
+            $dayEnd = $current->format('Y-m-d') === $fin->format('Y-m-d') ? $fin->format('H:i') : '23:59';
+
+            if ($type === 'congé') {
+                foreach ($this->intersectPeriods($dayStart, $dayEnd, $this->getPeriodsForDate($agent, $current, $site)) as $plage) {
+                    $indisponibilites[$current->format('d/m/Y')][] = ['debut' => $plage['debut'], 'fin' => $plage['fin'], 'type' => 'congé'];
+                }
+            } else {
+                $indisponibilites[$current->format('d/m/Y')][] = ['debut' => $dayStart, 'fin' => $dayEnd, 'type' => 'absence'];
+            }
+
+            $current->modify('+1 day');
+        }
+    }
+
+    /**
+     * Intersecte la plage [debut, fin] (format "H:i") avec chacune des périodes travaillées données,
+     * et retourne une plage par intersection non vide.
+     */
+    private function intersectPeriods(string $debut, string $fin, array $periodes): array
+    {
+        $result = [];
+
+        foreach ($periodes as $periode) {
+            $s = max($debut, $periode['debut']);
+            $e = min($fin, $periode['fin']);
+
+            if ($s < $e) {
+                $result[] = ['debut' => $s, 'fin' => $e];
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/Repository/PlanningGenerationJobRepository.php
+++ b/src/Repository/PlanningGenerationJobRepository.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Repository;
+
+use Doctrine\ORM\EntityRepository;
+
+class PlanningGenerationJobRepository extends EntityRepository
+{
+}

--- a/templates/agents/algo_edit.html.twig
+++ b/templates/agents/algo_edit.html.twig
@@ -1,0 +1,50 @@
+{# agents/algo_edit.html.twig #}
+
+<div class="tab-pane fade" id="algo" role="tabpanel" aria-labelledby="algo-tab" tabindex="0">
+  <table style="width:90%;">
+    <tr>
+      <td style="width:400px">Quota de service public total (pour 30% notez : 0,3) :</td>
+      <td>
+        <input type="number" step="0.01" min="0" max="1" name="quota_pct" id="quota_pct"
+               value="{{ agent.algorithmQuota }}" style="width:120px" />
+      </td>
+    </tr>
+
+    <tr>
+      <td style="width:400px">Taux maximum de service public toléré dans la journée (même format que quota) :</td>
+      <td>
+        <input type="number" step="0.01" min="0" max="1" name="max_sp_journee_pct"
+               value="{{ agent.algorithmMaxDailyQuota }}" style="width:120px" />
+      </td>
+    </tr>
+
+    <tr>
+      <td style="width:400px">Pause minimale entre deux shifts (minutes) :</td>
+      <td>
+        <input type="number" step="1" min="0" name="pause_inter_listes_min"
+               value="{{ agent.algorithmMinBreakBetweenLists }}" style="width:120px" />
+      </td>
+    </tr>
+  </table>
+
+  <h3 style="margin:20px 0 5px 0;">Répartition du quota par poste</h3>
+  <p>La somme des quotas ci-dessous doit être égale à 1. exemple : 0.5 signifie que l'agent a une cible de 50% de son quota de service public total sur ce poste. Si aucun quota n'est mentionné pour un poste, l'agent ne sera jamais planifié sur celui ci</p>
+
+  <table style="width:90%;" id="quotas_postes_table">
+    {% for position in positions_algo %}
+      <tr>
+        <td style="width:400px">dont quota {{ position.name }} :</td>
+        <td>
+          <input type="number" step="0.01" min="0" max="1" class="quota-poste-input" data-poste-id="{{ position.id }}"
+                 value="{{ agent.algorithmQuotasByPosition[position.id] ?? '' }}" style="width:120px" oninput="updateQuotasPostesJson()" />
+        </td>
+      </tr>
+    {% endfor %}
+    <tr>
+      <td style="width:400px"><b>Total :</b></td>
+      <td><span id="quotas_postes_total">0</span></td>
+    </tr>
+  </table>
+
+  <input type="hidden" name="quotas_postes" id="quotas_postes" value="{{ agent.algorithmQuotasByPosition | json_encode }}" />
+</div>

--- a/templates/planning-generation/index.html.twig
+++ b/templates/planning-generation/index.html.twig
@@ -1,0 +1,79 @@
+{# planning-generation/index.html.twig #}
+
+{% extends 'base.html.twig' %}
+
+{% block specificjs %}
+  <script type="text/JavaScript" src="{{ asset('js/planning-generation.js') }}"></script>
+{% endblock %}
+
+{% block page %}
+
+  {% include 'planning-generation/wizard.html.twig' %}
+
+  <table style="margin:20px 0;">
+    <tr valign="top">
+      <td style="width:270px">
+        <h3 style="margin-top:0px;">Générer un planning</h3>
+      </td>
+      <td>
+        <input type="button" value="Générer un planning" id="generer-planning-btn" class="btn btn-primary" {% if has_ongoing_job %}disabled title="Une génération est déjà en cours"{% endif %}/>
+      </td>
+    </tr>
+  </table>
+
+  <table id="tableGenerationPlanning" class="CJDataTable" data-sort='[[0, "desc"]]'>
+    <thead>
+      <tr>
+        <th>Date et heure de génération</th>
+        <th>Date de début</th>
+        <th>Date de fin</th>
+        <th>Json envoyé</th>
+        <th>Json reçu</th>
+        <th>Statistique</th>
+        <th>État</th>
+        <th class="dataTableNoSort">&nbsp;</th>
+        <th class="dataTableNoSort">&nbsp;</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for job in jobs %}
+        <tr>
+          <td>{{ job.dateGeneration ? job.dateGeneration | date('d/m/Y H:i') : '' }}</td>
+          <td>{{ job.dateDebut ? job.dateDebut | date('d/m/Y') : '' }}</td>
+          <td>{{ job.dateFin ? job.dateFin | date('d/m/Y') : '' }}</td>
+          <td><a href="{{ path('planning_generation.json', {id: job.id, type: 'sent'}) }}" target="_blank">Voir le JSON envoyé</a></td>
+          <td>
+            {% if job.jsonRecu %}
+              <a href="{{ path('planning_generation.json', {id: job.id, type: 'received'}) }}" target="_blank">Voir le JSON reçu</a>
+            {% endif %}
+          </td>
+          <td>
+            {% if job.jsonRecu or job.errorMessage %}
+              <a href="{{ path('planning_generation.statistics', {id: job.id}) }}" target="_blank">Voir les statistiques</a>
+            {% endif %}
+          </td>
+          <td>
+            {% if job.statut == 'succes' %}
+              Succès
+            {% elseif job.statut == 'echec' %}
+              Échec
+            {% elseif job.statut == 'conflit' %}
+              Conflit
+            {% else %}
+              En cours
+            {% endif %}
+          </td>
+          <td class="text-center">
+            <span class="generation-status-dot generation-status-{{ job.statut }}" title="{{ job.statut }}"></span>
+          </td>
+          <td class="text-center">
+            {% if job.statut != 'en_cours' %}
+              <span class="pl-icon pl-icon-trash generation-delete-btn pointer" data-id="{{ job.id }}" title="Supprimer"></span>
+            {% endif %}
+          </td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+
+{% endblock %}

--- a/templates/planning-generation/statistics.html.twig
+++ b/templates/planning-generation/statistics.html.twig
@@ -1,0 +1,88 @@
+{# planning-generation/statistics.html.twig #}
+
+{% extends 'base.html.twig' %}
+
+{% block page %}
+
+  <table style="margin:20px 0;">
+    <tr valign="top">
+      <td style="width:270px">
+        <h3 style="margin-top:0px;">Statistiques de génération</h3>
+      </td>
+      <td>
+        <a href="{{ path('planning_generation.index') }}" class="btn btn-secondary">&laquo; Retour</a>
+      </td>
+    </tr>
+  </table>
+
+  {% if error_message %}
+    <p class="important">Échec de la génération : {{ error_message }}</p>
+  {% endif %}
+
+  {% if conflict_message %}
+    <p class="generation-conflict-message">{{ conflict_message }}</p>
+  {% endif %}
+
+  {% if not statistiques %}
+
+    <p class="important">Aucune statistique disponible pour cette génération.</p>
+
+  {% else %}
+
+    <table style="margin-bottom:20px;">
+      <tr>
+        <td style="width:250px"><b>Places attendues :</b></td>
+        <td>{{ statistiques.places_attendues }}</td>
+      </tr>
+      <tr>
+        <td><b>Places pourvues :</b></td>
+        <td>{{ statistiques.places_pourvues }}</td>
+      </tr>
+      {% if statistiques.equilibre is defined %}
+        <tr>
+          <td><b>Équilibre :</b></td>
+          <td>{{ statistiques.equilibre.statut }} (écart : {{ statistiques.equilibre.ecart }})</td>
+        </tr>
+      {% endif %}
+    </table>
+
+    {% if statistiques.equilibre.message is defined and statistiques.equilibre.message %}
+      <p class="important">{{ statistiques.equilibre.message }}</p>
+    {% endif %}
+
+    <table id="tableGenerationStatistiques" class="CJDataTable">
+      <thead>
+        <tr>
+          <th>Id agent</th>
+          <th>Agent</th>
+          <th>Temps EDT</th>
+          <th>Congés</th>
+          <th>Temps effectif</th>
+          <th>Quota</th>
+          <th>Quota cible</th>
+          <th>Quota réalisé</th>
+          <th>Reste</th>
+          <th>Statut</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for agent in statistiques.agents %}
+          <tr>
+            <td>{{ agent.agent_id ?? '' }}</td>
+            <td>{{ agent.nom_agent }}</td>
+            <td>{{ agent.temps_travail_edt }}</td>
+            <td>{{ agent.somme_conges }}</td>
+            <td>{{ agent.temps_travail_effectif }}</td>
+            <td>{{ agent.quota_pct }}</td>
+            <td>{{ agent.quota_cible.total ?? '' }}</td>
+            <td>{{ agent.quota_realise.total ?? '' }}</td>
+            <td>{{ agent.reste.valeur ?? '' }}</td>
+            <td>{{ agent.reste.statut ?? '' }}</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+
+  {% endif %}
+
+{% endblock %}

--- a/templates/planning-generation/statistics.html.twig
+++ b/templates/planning-generation/statistics.html.twig
@@ -63,6 +63,7 @@
           <th>Quota réalisé</th>
           <th>Reste</th>
           <th>Statut</th>
+          <th>Reste par poste</th>
         </tr>
       </thead>
       <tbody>
@@ -78,6 +79,11 @@
             <td>{{ agent.quota_realise.total ?? '' }}</td>
             <td>{{ agent.reste.valeur ?? '' }}</td>
             <td>{{ agent.reste.statut ?? '' }}</td>
+            <td>
+              {% for posteName, detail in agent.reste.par_poste ?? [] %}
+                <div title="Cible : {{ detail.cible ?? '' }}">{{ posteName }} : {{ detail.valeur ?? '' }} ({{ detail.statut ?? '' }})</div>
+              {% endfor %}
+            </td>
           </tr>
         {% endfor %}
       </tbody>

--- a/templates/planning-generation/wizard.html.twig
+++ b/templates/planning-generation/wizard.html.twig
@@ -1,0 +1,98 @@
+{# planning-generation/wizard.html.twig #}
+
+<div class="modal" id="generation-wizard-modal" data-bs-backdrop="static" tabindex="-1" aria-labelledby="generation-wizard-title" aria-hidden="true">
+  <div class="modal-dialog modal-lg modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="generation-wizard-title">Générer un planning</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fermer"></button>
+      </div>
+
+      <div class="modal-body">
+        <input type="hidden" name="CSRFToken" value="{{ CSRFSession }}" />
+        <input type="hidden" name="_token" value="{{ csrf_token('') }}" />
+
+        <div id="generation-step-1" class="generation-step">
+          <div class="row mb-3">
+            <label for="generation-date-debut" class="col-4 col-form-label">Date de début :</label>
+            <div class="col-8">
+              <input type="date" id="generation-date-debut" class="form-control" />
+            </div>
+          </div>
+          <div class="row mb-3">
+            <label for="generation-date-fin" class="col-4 col-form-label">Date de fin :</label>
+            <div class="col-8">
+              <input type="date" id="generation-date-fin" class="form-control" />
+            </div>
+          </div>
+          {% if sites | length > 1 %}
+            <div class="row mb-3">
+              <label for="generation-site" class="col-4 col-form-label">Bibliothèque :</label>
+              <div class="col-8">
+                <select id="generation-site" class="form-select">
+                  {% for site in sites %}
+                    <option value="{{ site.id }}">{{ site.nom }}</option>
+                  {% endfor %}
+                </select>
+              </div>
+            </div>
+          {% else %}
+            <input type="hidden" id="generation-site" value="{{ sites | first ? sites | first.id : 1 }}" />
+          {% endif %}
+        </div>
+
+      <div id="generation-step-2" class="generation-step" style="display:none;">
+        <p>La génération du planning peut prendre plusieurs minutes.</p>
+        <p class="important">Assurez-vous :</p>
+        <ul class="important-list">
+          <li>d'avoir activé les tableaux sur l'intervalle <strong id="generation-step-2-range"></strong></li>
+          <li>d'avoir défini les bons quotas d'agents attendus pour chaque poste </li>
+          <li>d'avoir complété tous les attributs des agents dans leur fiche section "informations pour l'algorithme de génération de planning".</li>
+          <li>d'avoir correctement déclaré les sites de tous les agents dans leurs emploi du temps.</li>
+      </ul>
+</div>
+
+        <div id="generation-step-2b" class="generation-step" style="display:none;">
+          <p class="important">Comment souhaitez-vous fournir les données à l'algorithme de génération ?</p>
+          <div class="d-grid gap-2">
+            <button type="button" id="generation-mode-auto" class="btn btn-outline-primary text-start py-2">
+              <strong>Génération automatique</strong><br>
+              <small>Planno construit les données à partir des tableaux, agents et quotas configurés.</small>
+            </button>
+            <button type="button" id="generation-mode-manual" class="btn btn-outline-secondary text-start py-2" {% if not manual_json_enabled %}disabled title="Cette option est désactivée. Active-la dans Configuration technique > Génération de planning pour l'utiliser."{% endif %}>
+              <strong>JSON personnalisé</strong><br>
+              <small>Coller directement le JSON à envoyer à l'algorithme, sans passer par la génération automatique.</small>
+              {% if not manual_json_enabled %}
+                <br><small class="important">Désactivé : à activer dans Configuration technique &gt; Génération de planning.</small>
+              {% endif %}
+            </button>
+          </div>
+        </div>
+
+        <div id="generation-step-3" class="generation-step" style="display:none;">
+          <p>Tableaux actifs sur la période sélectionnée. Décochez les postes à exclure de la génération.</p>
+          <ul class="important-list">
+            <li>Il est fortement conseillé de décocher les postes n'ayant pas vocation à être planifiés (services interne par exemple)</li>
+            <li>Il est également conseillé de les postes "renforts"</li>
+          </ul>
+          <div id="generation-step-3-content"></div>
+        </div>
+
+        <div id="generation-step-manual" class="generation-step" style="display:none;">
+          <div class="mb-3">
+            <label for="generation-manual-json" class="form-label">JSON à envoyer à l'algorithme :</label>
+            <textarea id="generation-manual-json" class="form-control" rows="15" style="font-family: monospace;"></textarea>
+          </div>
+        </div>
+      </div>
+
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuler</button>
+        <button type="button" id="generation-next-1" class="btn btn-primary">Suivant</button>
+        <button type="button" id="generation-next-2" class="btn btn-primary" style="display:none;">Suivant</button>
+        <button type="button" id="generation-launch" class="btn btn-danger" style="display:none;">Lancer la génération</button>
+        <button type="button" id="generation-launch-manual" class="btn btn-danger" style="display:none;">Lancer la génération</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/templates/planning-generation/wizard.html.twig
+++ b/templates/planning-generation/wizard.html.twig
@@ -73,7 +73,7 @@
           <p>Tableaux actifs sur la période sélectionnée. Décochez les postes à exclure de la génération.</p>
           <ul class="important-list">
             <li>Il est fortement conseillé de décocher les postes n'ayant pas vocation à être planifiés (services interne par exemple)</li>
-            <li>Il est également conseillé de les postes "renforts"</li>
+            <li>Il est également conseillé de décocher les postes "renforts"</li>
           </ul>
           <div id="generation-step-3-content"></div>
         </div>


### PR DESCRIPTION
ajout d'une fonctionnalité de génération de planning :

 - administration - configuration technique : ajout d'un champs pour renseigner l'url de l'api de génération de planning ; ajout d'un champs pour la clé api (clé de test)
- fiche agent : ajout d'un onglet pour renseigner des informations sur l'agent utile pour l'algorithme
- vu planning jour : ajout d'une icone "crayon" permettant d'afficher et modifier l'effectif attendu par poste (utile pour l'algorithme)
- administration - générer un planning : ajout d'une page permettant de voir l'historique des plannings générés avec tableau de statistiques ; bouton "générer le planning" permettant de sélectionner l'intervalle de date pour laquelle on veut un planning, sélection de la bibliothèque, la possibilité d'exclure des postes.
- Lors de la validation, créer un json qui sera envoyé à l'api (aucun nom d'agent, seulement leurs identifiants seront envoyés à l'api), recevra ensuite la réponse de l'api et appliquera le planning.

L'algorithme de génération de planning est en cours d'amélioration, elle ne conserve, a ce jour, aucune données.